### PR TITLE
refactor(aio): move generator public adapter (B-09b2)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-22
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `fb85e9eaedb9dabfbcf77740b27bee98c99e679a`
+- Integrated `dev` snapshot commit: `7484dc758fd11de020228129f611f9170634357d`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-09a; B-09b1 implemented in PR #269 | Integrate B-09b1, then continue B-09b2 AiO adapter extraction, compatibility audit, registration/bootstrap, final root shim |
+| B - `nodes.py` extraction | Integrated through B-09b1; B-09b2 implemented in PR #270 | Integrate B-09b2, then continue compatibility audit, registration/bootstrap, final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,16 +42,17 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, the B-09b1 PR-head
-  implementation measures root `nodes.py` at 2,822 lines. This is a PR-head
-  measurement, not a claim that B-09b1 is already integrated into that commit.
-- At that implementation head the mechanical extraction has removed 9,841
-  lines, approximately 77.7% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, the B-09b2 PR-head
+  implementation measures root `nodes.py` at 2,712 lines. This is a PR-head
+  measurement, not a claim that B-09b2 is already integrated into that commit.
+- At that implementation head the mechanical extraction has removed 9,951
+  lines, approximately 78.6% of the Phase A baseline, while preserving the root
   compatibility surface.
-- B-01 through B-08e are integrated. The latest completed implementation slice
-  is the AiO input-adapter Move in PR #268.
-- Root `nodes.py` still owns the public AiO generator adapter and remaining
-  support seams, while its current-order `generate` body is canonical.
+- B-01 through B-09b1 are integrated. The latest completed implementation slice
+  is the AiO legacy orchestration Move in PR #269.
+- At the B-09b2 implementation head the public AiO generator adapter is
+  canonical under `easyuse_anima.nodes.aio_nodes`; root `nodes.py` retains its
+  direct class/helper aliases and remaining support seams.
 - Root `__init__.py` still imports `api.py` for route-registration side effects,
   initializes the wildcard directory during package import, and owns mapping
   composition. B-11 is therefore not complete.
@@ -292,8 +293,8 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 7 | C168-06 normalizer ownership move | COMPLETE on `dev` | Move | #168/#184 | PR #257 / `3ca5500` |
 | 8 | B-08a through B-08e AiO support-helper extraction | COMPLETE on `dev` | Move | #184 | B-08a PR #259; B-08b1 PR #260; B-08b2 PR #261; B-08c PR #262; B-08d1 PR #263; B-08d2 PR #264; B-08e PR #265 |
 | 9 | B-09a AiO input adapter move | COMPLETE in PR #268 | Move | #184 | AiO helpers canonical through B-08e |
-| 10 | B-09b1 AiO legacy orchestration body move | IMPLEMENTED in PR #269 | Move | #184 | B-09a implementation complete |
-| 11 | B-09b2 AiO generator adapter move | READY after B-09b1 | Move | #184 | B-09b1 integrated |
+| 10 | B-09b1 AiO legacy orchestration body move | COMPLETE on `dev` | Move | #184 | PR #269 / `7484dc7` |
+| 11 | B-09b2 AiO generator adapter move | IMPLEMENTED in PR #270 | Move | #184 | B-09b1 integrated |
 | 12 | B-10 compatibility/private-alias audit | BLOCKED by B-09b | Contract/cleanup, split PRs | #184/#188 | All node implementations canonical |
 | 13 | B-11 registration/bootstrap/root shim | BLOCKED by B-10 | Move | #184 | Alias surface frozen |
 | 14 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
@@ -576,6 +577,16 @@ B-09b is split at the existing compatibility boundary:
   ownership after B-09b1 is integrated. It owns class/mapping identity and the
   remaining workflow/browser serialization checkpoint. B-09 is not complete
   until that adapter slice and the stated integration evidence are complete.
+
+B-09b1 is complete in PR #269. B-09b2 is implemented in PR #270: the generator,
+input signature helper, and input validator now live in
+`easyuse_anima.nodes.aio_nodes`; root imports them as direct identity aliases in
+both import modes. The adapter reuses the existing resolver slot so mutable
+special-seed state, normalization, signature, LoRA, change-key, settings-default,
+and legacy-orchestration dependencies remain call-time root compatibility seams.
+No node contract, mapping ID, method signature, or execution order changes in
+this Move. B-09 remains open until PR #270 is integrated and its full
+workflow/runtime checkpoints are recorded.
 
 Before merge, capture a deterministic execution trace fixture for the current
 major phases and prove no order/result/cleanup drift. Run at least:

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -166,10 +166,9 @@ EasyUseAnimaWildcard
 - B-09a public AiO input-adapter transition: `EasyUseAnimaInput` moves to
   `easyuse_anima.nodes.aio_nodes` and remains a direct root alias, so direct
   imports and the package `NODE_CLASS_MAPPINGS` entry retain class identity.
-  The canonical module publicly exports only `EasyUseAnimaInput` through
-  `__all__`; its narrow call-time runtime seam preserves root monkeypatches for
-  resource candidates, normalization, stable change keys, schema/version
-  values, and prompt-data copying. The adapter does not import `nodes.py`.
+  Its narrow call-time runtime seam preserves root monkeypatches for resource
+  candidates, normalization, stable change keys, schema/version values, and
+  prompt-data copying. The adapter does not import `nodes.py`.
 - B-09b1 internal AiO orchestration transition: the current-order
   `EasyUseAnimaAIOGenerator.generate` body moves to
   `easyuse_anima.aio.legacy_generation` while the public class and exact method
@@ -179,6 +178,15 @@ EasyUseAnimaWildcard
   constant, and module at its original call site through one resolver slot.
   These aliases are transitional internal seams for B-10 and are not public
   package `__all__` entries.
+- B-09b2 public AiO generator-adapter transition: `EasyUseAnimaAIOGenerator`,
+  `_easy_use_anima_input_signature`, and `_require_easy_use_anima_input` move to
+  `easyuse_anima.nodes.aio_nodes` and remain direct root identity aliases in both
+  import modes. `EasyUseAnimaInput` and `EasyUseAnimaAIOGenerator` are the only
+  public names in the canonical module `__all__`; the two private aliases remain
+  transitional B-10 seams. The existing resolver slot preserves call-time root
+  lookup for the settings default, mutable special-seed set, normalization,
+  clone/runtime-seed/signature/LoRA/change-key helpers, prompt-data JSON safety,
+  and legacy orchestration. The canonical module does not import `nodes.py`.
 - Removal gate: 0.5.2 node/workflow fixture, mapping identity, direct import,
   Registry archive closure, consumer evidence, separate breaking-change issue,
   and release note. With no external-consumer evidence, retain these exports.

--- a/easyuse_anima/nodes/aio_nodes.py
+++ b/easyuse_anima/nodes/aio_nodes.py
@@ -153,4 +153,145 @@ class EasyUseAnimaInput:
         },)
 
 
-__all__ = ("EasyUseAnimaInput",)
+def _easy_use_anima_input_signature(value) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"type": str(type(value).__name__)}
+    return {
+        "schema": value.get("schema"),
+        "version": value.get("version"),
+        "resource_info": _runtime_helper("_prompt_data_json_safe")(
+            value.get("resource_info", {})
+        ),
+        "input_settings": _runtime_helper("_prompt_data_json_safe")(
+            value.get("input_settings", {})
+        ),
+        "prompt_data": _runtime_helper("_prompt_data_json_safe")(
+            value.get("prompt_data", {})
+        ),
+    }
+
+
+def _require_easy_use_anima_input(value) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise RuntimeError("[EasyUseAnima] easy use anima input is missing or invalid.")
+    missing = [
+        key
+        for key in ("prompt_data", "resource_info", "input_settings")
+        if key not in value
+    ]
+    if missing:
+        raise RuntimeError(
+            "[EasyUseAnima] easy use anima input is missing required value(s): "
+            + ", ".join(missing)
+        )
+    return value
+
+
+class EasyUseAnimaAIOGenerator:
+    """Draft all-in-one generator that consumes one easy use anima input context."""
+
+    DESCRIPTION = (
+        "Consumes the dedicated easy use anima input context and runs the base txt2img "
+        "generation path: prompt-data conditioning, optional Mod Guidance model patch, "
+        "KSampler, VAE decode, and optional image saving. Generation options are stored in "
+        "one versioned JSON field for future-compatible popup settings."
+    )
+    OUTPUT_TOOLTIPS = (
+        "Decoded generated image.",
+        "Sampled latent image.",
+        "JSON metadata summary for debugging or downstream integration.",
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "easy_use_anima_input": (
+                    _runtime_helper("EASY_USE_ANIMA_INPUT_TYPE"),
+                    {
+                        "forceInput": True,
+                        "tooltip": "Context from Easy Use Anima Input.",
+                    },
+                ),
+                "generation_settings": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": _runtime_helper("_aio_generation_settings_json")(),
+                        "hidden": True,
+                        "tooltip": "Hidden versioned JSON storage for popup generation settings. Keep this field serialized.",
+                    },
+                ),
+            },
+            "hidden": {
+                "workflow_prompt": "PROMPT",
+                "extra_pnginfo": "EXTRA_PNGINFO",
+                "unique_id": "UNIQUE_ID",
+            },
+            "optional": {
+                "lora_stack": (
+                    "LORA_STACK",
+                    {
+                        "forceInput": True,
+                        "tooltip": "Optional LoRA stack applied to MODEL and CLIP before conditioning and sampling.",
+                    },
+                ),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE", "LATENT", "STRING")
+    RETURN_NAMES = ("image", "latent", "metadata_json")
+    FUNCTION = "generate"
+    OUTPUT_NODE = True
+    CATEGORY = "EasyUse Anima/AiO"
+
+    @classmethod
+    def IS_CHANGED(
+        cls,
+        easy_use_anima_input=None,
+        lora_stack=None,
+        generation_settings: str | dict | None = None,
+        **kwargs,
+    ):
+        settings = _runtime_helper("_normalize_aio_generation_settings")(
+            generation_settings
+        )
+        if settings.get("sampler", {}).get("seed") in _runtime_helper(
+            "AIO_SPECIAL_SEEDS"
+        ):
+            change_settings = _runtime_helper("_json_clone")(settings)
+            change_settings["sampler"]["seed"] = _runtime_helper(
+                "_resolve_aio_runtime_seed"
+            )(change_settings["sampler"].get("seed"))
+        else:
+            change_settings = settings
+        return _runtime_helper("_stable_change_key")({
+            "mode": "easy_use_anima_generator",
+            "input": _runtime_helper("_easy_use_anima_input_signature")(
+                easy_use_anima_input
+            ),
+            "lora_stack": _runtime_helper("_aio_lora_stack_signature")(lora_stack),
+            "generation_settings": change_settings,
+        })
+
+    def generate(
+        self,
+        easy_use_anima_input,
+        generation_settings: str | dict | None = None,
+        lora_stack=None,
+        workflow_prompt=None,
+        extra_pnginfo=None,
+        unique_id=None,
+    ):
+        return _runtime_helper("_run_aio_legacy_generation")(
+            self,
+            easy_use_anima_input,
+            generation_settings,
+            lora_stack,
+            workflow_prompt,
+            extra_pnginfo,
+            unique_id,
+        )
+
+
+__all__ = ("EasyUseAnimaInput", "EasyUseAnimaAIOGenerator")

--- a/nodes.py
+++ b/nodes.py
@@ -324,8 +324,11 @@ try:
         _bind_prompt_advanced_node_runtime as _bind_prompt_advanced_node_runtime,
     )
     from .easyuse_anima.nodes.aio_nodes import (
+        EasyUseAnimaAIOGenerator as EasyUseAnimaAIOGenerator,
         EasyUseAnimaInput as EasyUseAnimaInput,
         _bind_aio_node_runtime as _bind_aio_node_runtime,
+        _easy_use_anima_input_signature as _easy_use_anima_input_signature,
+        _require_easy_use_anima_input as _require_easy_use_anima_input,
     )
     from .easyuse_anima.image.geometry import (
         _align_down as _align_down,
@@ -834,8 +837,11 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _bind_prompt_advanced_node_runtime as _bind_prompt_advanced_node_runtime,
     )
     from easyuse_anima.nodes.aio_nodes import (
+        EasyUseAnimaAIOGenerator as EasyUseAnimaAIOGenerator,
         EasyUseAnimaInput as EasyUseAnimaInput,
         _bind_aio_node_runtime as _bind_aio_node_runtime,
+        _easy_use_anima_input_signature as _easy_use_anima_input_signature,
+        _require_easy_use_anima_input as _require_easy_use_anima_input,
     )
     from easyuse_anima.image.geometry import (
         _align_down as _align_down,
@@ -2704,119 +2710,3 @@ _bind_lora_node_runtime(
     flexible_optional_input_type=_FlexibleOptionalInputType,
     any_type=_ANY_TYPE,
 )
-
-
-def _easy_use_anima_input_signature(value) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        return {"type": str(type(value).__name__)}
-    return {
-        "schema": value.get("schema"),
-        "version": value.get("version"),
-        "resource_info": _prompt_data_json_safe(value.get("resource_info", {})),
-        "input_settings": _prompt_data_json_safe(value.get("input_settings", {})),
-        "prompt_data": _prompt_data_json_safe(value.get("prompt_data", {})),
-    }
-
-
-def _require_easy_use_anima_input(value) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise RuntimeError("[EasyUseAnima] easy use anima input is missing or invalid.")
-    missing = [key for key in ("prompt_data", "resource_info", "input_settings") if key not in value]
-    if missing:
-        raise RuntimeError(
-            "[EasyUseAnima] easy use anima input is missing required value(s): "
-            + ", ".join(missing)
-        )
-    return value
-
-
-class EasyUseAnimaAIOGenerator:
-    """Draft all-in-one generator that consumes one easy use anima input context."""
-
-    DESCRIPTION = (
-        "Consumes the dedicated easy use anima input context and runs the base txt2img "
-        "generation path: prompt-data conditioning, optional Mod Guidance model patch, "
-        "KSampler, VAE decode, and optional image saving. Generation options are stored in "
-        "one versioned JSON field for future-compatible popup settings."
-    )
-    OUTPUT_TOOLTIPS = (
-        "Decoded generated image.",
-        "Sampled latent image.",
-        "JSON metadata summary for debugging or downstream integration.",
-    )
-
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "easy_use_anima_input": (EASY_USE_ANIMA_INPUT_TYPE, {
-                    "forceInput": True,
-                    "tooltip": "Context from Easy Use Anima Input.",
-                }),
-                "generation_settings": ("STRING", {
-                    "multiline": True,
-                    "default": _aio_generation_settings_json(),
-                    "hidden": True,
-                    "tooltip": "Hidden versioned JSON storage for popup generation settings. Keep this field serialized.",
-                }),
-            },
-            "hidden": {
-                "workflow_prompt": "PROMPT",
-                "extra_pnginfo": "EXTRA_PNGINFO",
-                "unique_id": "UNIQUE_ID",
-            },
-            "optional": {
-                "lora_stack": ("LORA_STACK", {
-                    "forceInput": True,
-                    "tooltip": "Optional LoRA stack applied to MODEL and CLIP before conditioning and sampling.",
-                }),
-            },
-        }
-
-    RETURN_TYPES = ("IMAGE", "LATENT", "STRING")
-    RETURN_NAMES = ("image", "latent", "metadata_json")
-    FUNCTION = "generate"
-    OUTPUT_NODE = True
-    CATEGORY = "EasyUse Anima/AiO"
-
-    @classmethod
-    def IS_CHANGED(
-        cls,
-        easy_use_anima_input=None,
-        lora_stack=None,
-        generation_settings: str | dict | None = None,
-        **kwargs,
-    ):
-        settings = _normalize_aio_generation_settings(generation_settings)
-        if settings.get("sampler", {}).get("seed") in AIO_SPECIAL_SEEDS:
-            change_settings = _json_clone(settings)
-            change_settings["sampler"]["seed"] = _resolve_aio_runtime_seed(
-                change_settings["sampler"].get("seed")
-            )
-        else:
-            change_settings = settings
-        return _stable_change_key({
-            "mode": "easy_use_anima_generator",
-            "input": _easy_use_anima_input_signature(easy_use_anima_input),
-            "lora_stack": _aio_lora_stack_signature(lora_stack),
-            "generation_settings": change_settings,
-        })
-
-    def generate(
-        self,
-        easy_use_anima_input,
-        generation_settings: str | dict | None = None,
-        lora_stack=None,
-        workflow_prompt=None,
-        extra_pnginfo=None,
-        unique_id=None,
-    ):
-        return _run_aio_legacy_generation(
-            self,
-            easy_use_anima_input,
-            generation_settings,
-            lora_stack,
-            workflow_prompt,
-            extra_pnginfo,
-            unique_id,
-        )

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -22086,6 +22086,37 @@
         "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
       },
       {
+        "alias": "EasyUseAnimaAIOGenerator",
+        "bound_name": "EasyUseAnimaAIOGenerator",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaAIOGenerator",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
+        "kind": "static_from",
+        "line": 326,
+        "name": "EasyUseAnimaAIOGenerator",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
         "alias": "EasyUseAnimaInput",
         "bound_name": "EasyUseAnimaInput",
         "branch_context": [
@@ -22148,6 +22179,68 @@
         "target": "easyuse_anima/nodes/aio_nodes.py"
       },
       {
+        "alias": "_easy_use_anima_input_signature",
+        "bound_name": "_easy_use_anima_input_signature",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_easy_use_anima_input_signature",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
+        "kind": "static_from",
+        "line": 326,
+        "name": "_easy_use_anima_input_signature",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "alias": "_require_easy_use_anima_input",
+        "bound_name": "_require_easy_use_anima_input",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_require_easy_use_anima_input",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
+        "kind": "static_from",
+        "line": 326,
+        "name": "_require_easy_use_anima_input",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
         "alias": "_align_down",
         "bound_name": "_align_down",
         "branch_context": [
@@ -22169,7 +22262,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 330,
+        "line": 333,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22200,7 +22293,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 330,
+        "line": 333,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22231,7 +22324,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 330,
+        "line": 333,
         "name": "_align_up",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22262,7 +22355,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 330,
+        "line": 333,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22293,7 +22386,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 330,
+        "line": 333,
         "name": "_alignment_value",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22324,7 +22417,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 337,
+        "line": 340,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": ".easyuse_anima.image.detailer",
@@ -22355,7 +22448,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 340,
+        "line": 343,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22386,7 +22479,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 340,
+        "line": 343,
         "name": "_call_impact_detailer",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22417,7 +22510,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 340,
+        "line": 343,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22448,7 +22541,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 340,
+        "line": 343,
         "name": "_empty_mask_for_image",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22479,7 +22572,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 340,
+        "line": 343,
         "name": "_empty_segs_for_image",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22510,7 +22603,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 340,
+        "line": 343,
         "name": "_find_impact_detailer_class",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22541,7 +22634,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 340,
+        "line": 343,
         "name": "_find_impact_mask_to_segs_class",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22572,7 +22665,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 340,
+        "line": 343,
         "name": "_find_sam3_detect_class",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22603,7 +22696,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 340,
+        "line": 343,
         "name": "_format_sam3_detection_prompt",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22634,7 +22727,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 340,
+        "line": 343,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22665,7 +22758,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 340,
+        "line": 343,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22696,7 +22789,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 353,
+        "line": 356,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22727,7 +22820,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 353,
+        "line": 356,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22758,7 +22851,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 353,
+        "line": 356,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22789,7 +22882,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 353,
+        "line": 356,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22820,7 +22913,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 353,
+        "line": 356,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22851,7 +22944,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 353,
+        "line": 356,
         "name": "_scale_by_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22882,7 +22975,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 361,
+        "line": 364,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22913,7 +23006,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 361,
+        "line": 364,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22944,7 +23037,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 361,
+        "line": 364,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22975,7 +23068,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 361,
+        "line": 364,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -23006,7 +23099,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 361,
+        "line": 364,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -23037,7 +23130,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
-        "line": 361,
+        "line": 364,
         "name": "_impact_core_module",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -23068,7 +23161,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 361,
+        "line": 364,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -23099,7 +23192,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 361,
+        "line": 364,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -23130,7 +23223,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 361,
+        "line": 364,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -23161,7 +23254,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 372,
+        "line": 375,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23192,7 +23285,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 372,
+        "line": 375,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23223,7 +23316,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 372,
+        "line": 375,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23254,7 +23347,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 372,
+        "line": 375,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23285,7 +23378,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 378,
+        "line": 381,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23316,7 +23409,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 378,
+        "line": 381,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23347,7 +23440,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 378,
+        "line": 381,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23378,7 +23471,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 378,
+        "line": 381,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23409,7 +23502,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 378,
+        "line": 381,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23440,7 +23533,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 378,
+        "line": 381,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23471,7 +23564,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 386,
+        "line": 389,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -23502,7 +23595,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 386,
+        "line": 389,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -23533,7 +23626,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 390,
+        "line": 393,
         "name": "_EasyUseAnimaImpactDetailerDelegate",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -23564,7 +23657,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 390,
+        "line": 393,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -23595,7 +23688,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 394,
+        "line": 397,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23626,7 +23719,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 394,
+        "line": 397,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23657,7 +23750,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 394,
+        "line": 397,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23688,7 +23781,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 399,
+        "line": 402,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23719,7 +23812,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 399,
+        "line": 402,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23750,7 +23843,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 399,
+        "line": 402,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23781,7 +23874,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 399,
+        "line": 402,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23812,7 +23905,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 399,
+        "line": 402,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23843,7 +23936,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 406,
+        "line": 409,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23874,7 +23967,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 406,
+        "line": 409,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23905,7 +23998,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 406,
+        "line": 409,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23936,7 +24029,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23967,7 +24060,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23998,7 +24091,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24029,7 +24122,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24060,7 +24153,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24091,7 +24184,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24122,7 +24215,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24153,7 +24246,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "NAI_1MP",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24184,7 +24277,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24215,7 +24308,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24246,7 +24339,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24277,7 +24370,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "_clean_prompt",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24308,7 +24401,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24339,7 +24432,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24370,7 +24463,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24401,7 +24494,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 411,
+        "line": 414,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24432,7 +24525,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24463,7 +24556,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24494,7 +24587,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24525,7 +24618,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24556,7 +24649,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24587,7 +24680,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24618,7 +24711,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24649,7 +24742,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24680,7 +24773,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24711,7 +24804,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24742,7 +24835,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24773,7 +24866,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24804,7 +24897,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24835,7 +24928,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24866,7 +24959,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24897,7 +24990,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24928,7 +25021,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24959,7 +25052,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24990,7 +25083,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25021,7 +25114,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25052,7 +25145,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 429,
+        "line": 432,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25083,7 +25176,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 452,
+        "line": 455,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -25114,7 +25207,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 452,
+        "line": 455,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -25145,7 +25238,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 456,
+        "line": 459,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -25176,7 +25269,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 456,
+        "line": 459,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -25207,7 +25300,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 456,
+        "line": 459,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -25238,7 +25331,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25269,7 +25362,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25300,7 +25393,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25331,7 +25424,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25362,7 +25455,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25393,7 +25486,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25424,7 +25517,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25455,7 +25548,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25486,7 +25579,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25517,7 +25610,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25548,7 +25641,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25579,7 +25672,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25610,7 +25703,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25641,7 +25734,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25672,7 +25765,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 461,
+        "line": 464,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25703,7 +25796,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25734,7 +25827,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25765,7 +25858,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25796,7 +25889,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25827,7 +25920,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25858,7 +25951,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25889,7 +25982,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25920,7 +26013,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25951,7 +26044,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 488,
+        "line": 491,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -25982,7 +26075,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 488,
+        "line": 491,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -26013,7 +26106,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 492,
+        "line": 495,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -26044,7 +26137,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 492,
+        "line": 495,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -26075,7 +26168,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 493,
+        "line": 496,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -26106,7 +26199,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 494,
+        "line": 497,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -26137,7 +26230,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 494,
+        "line": 497,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -26168,7 +26261,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 494,
+        "line": 497,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -26199,7 +26292,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 499,
+        "line": 502,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -26230,7 +26323,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 499,
+        "line": 502,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -26261,7 +26354,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26292,7 +26385,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26323,7 +26416,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26354,7 +26447,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26385,7 +26478,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26416,7 +26509,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26447,7 +26540,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26478,7 +26571,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26509,7 +26602,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26540,7 +26633,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26571,7 +26664,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26602,7 +26695,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26633,7 +26726,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26664,7 +26757,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26695,7 +26788,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26726,7 +26819,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26757,7 +26850,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26788,7 +26881,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26819,7 +26912,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 500,
+        "line": 503,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26838,7 +26931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -26853,7 +26946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26872,7 +26965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -26887,7 +26980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26906,7 +26999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -26921,7 +27014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26940,7 +27033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -26955,7 +27048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26974,7 +27067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -26989,7 +27082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27008,7 +27101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27023,7 +27116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "name": "_clear_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27042,7 +27135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27057,7 +27150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27076,7 +27169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27091,7 +27184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27110,7 +27203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27125,7 +27218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27144,7 +27237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27159,7 +27252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 533,
+        "line": 536,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27178,7 +27271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27193,7 +27286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 533,
+        "line": 536,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27212,7 +27305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27227,7 +27320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 537,
+        "line": 540,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27246,7 +27339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27261,7 +27354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 537,
+        "line": 540,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27280,7 +27373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27295,7 +27388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 537,
+        "line": 540,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27314,7 +27407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27329,7 +27422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 542,
+        "line": 545,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -27348,7 +27441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27363,7 +27456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 545,
+        "line": 548,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27382,7 +27475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27397,7 +27490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 545,
+        "line": 548,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27416,7 +27509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27431,7 +27524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 545,
+        "line": 548,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27450,7 +27543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27465,7 +27558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 545,
+        "line": 548,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27484,7 +27577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27499,7 +27592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27518,7 +27611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27533,7 +27626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27552,7 +27645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27567,7 +27660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27586,7 +27679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27601,7 +27694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27620,7 +27713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27635,7 +27728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27654,7 +27747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27669,7 +27762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27688,7 +27781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27703,7 +27796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27722,7 +27815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27737,7 +27830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27756,7 +27849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27771,7 +27864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27790,7 +27883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27805,7 +27898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27824,7 +27917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27839,7 +27932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27858,7 +27951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27873,7 +27966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27892,7 +27985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27907,7 +28000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27926,7 +28019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27941,7 +28034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27960,7 +28053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -27975,7 +28068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27994,7 +28087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28009,7 +28102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28028,7 +28121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28043,7 +28136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28062,7 +28155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28077,7 +28170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28096,7 +28189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28111,7 +28204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28130,7 +28223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28145,7 +28238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28164,7 +28257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28179,7 +28272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28198,7 +28291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28213,7 +28306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28232,7 +28325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28247,7 +28340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28266,7 +28359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28281,7 +28374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28300,7 +28393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28315,7 +28408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28334,7 +28427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28349,7 +28442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28368,7 +28461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28383,7 +28476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28402,7 +28495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28417,7 +28510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28436,7 +28529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28451,7 +28544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28470,7 +28563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28485,7 +28578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28504,7 +28597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28519,7 +28612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28538,7 +28631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28553,7 +28646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28572,7 +28665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28587,7 +28680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28606,7 +28699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28621,7 +28714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28640,7 +28733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28655,7 +28748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28674,7 +28767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28689,7 +28782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28708,7 +28801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28723,7 +28816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28742,7 +28835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28757,7 +28850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28776,7 +28869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28791,7 +28884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28810,7 +28903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28825,7 +28918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28844,7 +28937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28859,7 +28952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28878,7 +28971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28893,7 +28986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28912,7 +29005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28927,7 +29020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28946,7 +29039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28961,7 +29054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28980,7 +29073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -28995,7 +29088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29014,7 +29107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29029,7 +29122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29048,7 +29141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29063,7 +29156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29082,7 +29175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29097,7 +29190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29116,7 +29209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29131,7 +29224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29150,7 +29243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29165,7 +29258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29184,7 +29277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29199,7 +29292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29218,7 +29311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29233,7 +29326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29252,7 +29345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29267,7 +29360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29286,7 +29379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29301,7 +29394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 614,
+        "line": 617,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29320,7 +29413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29335,7 +29428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 614,
+        "line": 617,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29354,7 +29447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29369,7 +29462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 614,
+        "line": 617,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29388,7 +29481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29403,7 +29496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 619,
+        "line": 622,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29422,7 +29515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29437,7 +29530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 619,
+        "line": 622,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29456,7 +29549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29471,7 +29564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 619,
+        "line": 622,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29490,7 +29583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29505,7 +29598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 619,
+        "line": 622,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29524,7 +29617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29539,7 +29632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 619,
+        "line": 622,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29558,7 +29651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29573,7 +29666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 626,
+        "line": 629,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29592,7 +29685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29607,7 +29700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 626,
+        "line": 629,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29626,7 +29719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29641,7 +29734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 626,
+        "line": 629,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29660,7 +29753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29675,7 +29768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 626,
+        "line": 629,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29694,7 +29787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29709,7 +29802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "name": "DEFAULT_QUALITY_TAGS",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29728,7 +29821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29743,7 +29836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "name": "DEFAULT_TRAILING_QUALITY_TAGS",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29762,7 +29855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29777,7 +29870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29796,7 +29889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29811,7 +29904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29830,7 +29923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29845,7 +29938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29864,7 +29957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29879,7 +29972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29898,7 +29991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29913,7 +30006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29932,7 +30025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29947,7 +30040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29966,7 +30059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -29981,7 +30074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -30000,7 +30093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30015,7 +30108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -30034,7 +30127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30049,7 +30142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -30068,7 +30161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30083,7 +30176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -30102,7 +30195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30117,7 +30210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30136,7 +30229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30151,7 +30244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30170,7 +30263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30185,7 +30278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30204,7 +30297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30219,7 +30312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30238,7 +30331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30253,7 +30346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30272,7 +30365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30287,7 +30380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30306,7 +30399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30321,7 +30414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30340,7 +30433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30355,7 +30448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30374,7 +30467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30389,7 +30482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30408,7 +30501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30423,7 +30516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30442,7 +30535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30457,7 +30550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_prompt_data_input_default",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30476,7 +30569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30491,7 +30584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30510,7 +30603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30525,7 +30618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_prompt_data_nested",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30544,7 +30637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30559,7 +30652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30578,7 +30671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30593,7 +30686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30612,7 +30705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30627,7 +30720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_set_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30646,7 +30739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30661,7 +30754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30680,7 +30773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30695,7 +30788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_LABELS",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "ADVANCED_FIELD_LABELS",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30714,7 +30807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30729,7 +30822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_PANES",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "ADVANCED_FIELD_PANES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30748,7 +30841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30763,7 +30856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_TYPES",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "ADVANCED_FIELD_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30782,7 +30875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30797,7 +30890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:EXTEND_PROMPT_SLOT_SPECS",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "EXTEND_PROMPT_SLOT_SPECS",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30816,7 +30909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30831,7 +30924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30850,7 +30943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30865,7 +30958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30884,7 +30977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30899,7 +30992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30918,7 +31011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30933,7 +31026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30952,7 +31045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -30967,7 +31060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30986,7 +31079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31001,7 +31094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31020,7 +31113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31035,7 +31128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31054,7 +31147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31069,7 +31162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31088,7 +31181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31103,7 +31196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31122,7 +31215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31137,7 +31230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31156,7 +31249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31171,7 +31264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31190,7 +31283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31205,7 +31298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_with_artist_override",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_fields_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31224,7 +31317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31239,7 +31332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31258,7 +31351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31273,7 +31366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_pane_parts",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_pane_parts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31292,7 +31385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31307,7 +31400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_data_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_prompt_data_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31326,7 +31419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31341,7 +31434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31360,7 +31453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31375,7 +31468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31394,7 +31487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31409,7 +31502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31428,7 +31521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31443,7 +31536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31462,7 +31555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31477,7 +31570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31496,7 +31589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31511,7 +31604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31530,7 +31623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31545,7 +31638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31564,7 +31657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31579,7 +31672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31598,7 +31691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31613,7 +31706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31632,7 +31725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31647,7 +31740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31666,7 +31759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31681,7 +31774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31700,7 +31793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31715,7 +31808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31734,7 +31827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31749,7 +31842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31768,7 +31861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31783,7 +31876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31802,7 +31895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31817,7 +31910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "REGIONAL_CONFIG_VERSION",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31836,7 +31929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31851,7 +31944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31870,7 +31963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31885,7 +31978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31904,7 +31997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31919,7 +32012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "REGIONAL_FIELD_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31938,7 +32031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31953,7 +32046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31972,7 +32065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -31987,7 +32080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "REGIONAL_PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32006,7 +32099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32021,7 +32114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "REGIONAL_PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32040,7 +32133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32055,7 +32148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32074,7 +32167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32089,7 +32182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32108,7 +32201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32123,7 +32216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32142,7 +32235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32157,7 +32250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32176,7 +32269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32191,7 +32284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32210,7 +32303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32225,7 +32318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_geometry",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_normalize_mask_geometry",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32244,7 +32337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32259,7 +32352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32278,7 +32371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32293,7 +32386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32312,7 +32405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32327,7 +32420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32346,7 +32439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32361,7 +32454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_mask",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_normalize_regional_mask",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32380,7 +32473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32395,7 +32488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32414,7 +32507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32429,7 +32522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32448,7 +32541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32463,7 +32556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_config",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_regional_default_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32482,7 +32575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32497,7 +32590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_fields",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_regional_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32516,7 +32609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32531,7 +32624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_field_prompt",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_regional_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32550,7 +32643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32565,7 +32658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32584,7 +32677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32599,7 +32692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32618,7 +32711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32633,7 +32726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32652,7 +32745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32667,7 +32760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32686,7 +32779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32701,7 +32794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32720,7 +32813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32735,7 +32828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32754,7 +32847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32769,7 +32862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32788,7 +32881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32803,7 +32896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32822,7 +32915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32837,7 +32930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32856,7 +32949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32871,7 +32964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "ANIMA_MOD_GUIDANCE_PROFILES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32890,7 +32983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32905,7 +32998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32924,7 +33017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32939,7 +33032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32958,7 +33051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -32973,7 +33066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32992,7 +33085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33007,7 +33100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -33026,7 +33119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33041,7 +33134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -33060,7 +33153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33075,7 +33168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -33094,7 +33187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33109,7 +33202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -33128,7 +33221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33143,7 +33236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "name": "_warn_old_spectrum_anima_mod_guidance_once",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -33162,7 +33255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33177,7 +33270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_CONTROL_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33196,7 +33289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33211,7 +33304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33230,7 +33323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33245,7 +33338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33264,7 +33357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33279,7 +33372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33298,7 +33391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33313,7 +33406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33332,7 +33425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33347,7 +33440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33366,7 +33459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33381,7 +33474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33400,7 +33493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33415,7 +33508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33434,7 +33527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33449,7 +33542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33468,7 +33561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33483,7 +33576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_EXACT_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33502,7 +33595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33517,7 +33610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33536,7 +33629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33551,7 +33644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33570,7 +33663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33585,7 +33678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_AVERAGE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33604,7 +33697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33619,7 +33712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33638,7 +33731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33653,7 +33746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_CLUSTERED",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33672,7 +33765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33687,7 +33780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33706,7 +33799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33721,7 +33814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_DELTA_RMS",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33740,7 +33833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33755,7 +33848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33774,7 +33867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33789,7 +33882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33808,7 +33901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33823,7 +33916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33842,7 +33935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33857,7 +33950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_HYBRID",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33876,7 +33969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33891,7 +33984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_LATE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33910,7 +34003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33925,7 +34018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33944,7 +34037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33959,7 +34052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33978,7 +34071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -33993,7 +34086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34012,7 +34105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34027,7 +34120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_SCHEDULE_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34046,7 +34139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34061,7 +34154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_MIX_STUDIO_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34080,7 +34173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34095,7 +34188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_TAG_POSITION_BACK",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34114,7 +34207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34129,7 +34222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_TAG_POSITION_CORRECT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34148,7 +34241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34163,7 +34256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_TAG_POSITION_FRONT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34182,7 +34275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34197,7 +34290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "ARTIST_TAG_POSITION_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34216,7 +34309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34231,7 +34324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_artist_conditioning_feature",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34250,7 +34343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34265,7 +34358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_artist_delta_rms_from_encoded",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34284,7 +34377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34299,7 +34392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_artist_group_token",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34318,7 +34411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34333,7 +34426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34352,7 +34445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34367,7 +34460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34386,7 +34479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34401,7 +34494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_artist_mix_prompt_tags",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34420,7 +34513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34435,7 +34528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34454,7 +34547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34469,7 +34562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34488,7 +34581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34503,7 +34596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_artist_variant_prompt_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34522,7 +34615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34537,7 +34630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34556,7 +34649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34571,7 +34664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34590,7 +34683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34605,7 +34698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34624,7 +34717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34639,7 +34732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34658,7 +34751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34673,7 +34766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_coalesce_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34692,7 +34785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34707,7 +34800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_conditionings_with_range",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34726,7 +34819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34741,7 +34834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_conditionings_with_strength",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34760,7 +34853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34775,7 +34868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_conditionings_with_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34794,7 +34887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34809,7 +34902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_copy_conditioning_metadata",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34828,7 +34921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34843,7 +34936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_encode_artist_average",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34862,7 +34955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34877,7 +34970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_encode_artist_average_late_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34896,7 +34989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34911,7 +35004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34930,7 +35023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34945,7 +35038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_encode_artist_composite_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34964,7 +35057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -34979,7 +35072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34998,7 +35091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35013,7 +35106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_encode_artist_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35032,7 +35125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35047,7 +35140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_encode_artist_hybrid",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35066,7 +35159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35081,7 +35174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_encode_artist_scheduled_average",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35100,7 +35193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35115,7 +35208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35134,7 +35227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35149,7 +35242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_encoded_artist_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35168,7 +35261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35183,7 +35276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_equal_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35202,7 +35295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35217,7 +35310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_fallback_artist_average_or_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35236,7 +35329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35251,7 +35344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_greedy_cluster_encoded_artists",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35270,7 +35363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35285,7 +35378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_interpolate_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35304,7 +35397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35319,7 +35412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35338,7 +35431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35353,7 +35446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_mark_artist_mix_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35372,7 +35465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35387,7 +35480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35406,7 +35499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35421,7 +35514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35440,7 +35533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35455,7 +35548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_normalize_weight_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35474,7 +35567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35489,7 +35582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_normalized_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35508,7 +35601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35523,7 +35616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_pad_conditioning_tensor",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35542,7 +35635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35557,7 +35650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_parse_artist_mix_entries",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35576,7 +35669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35591,7 +35684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_parse_artist_mix_group",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35610,7 +35703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35625,7 +35718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35644,7 +35737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35659,7 +35752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_prompt_data_artist_base_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35678,7 +35771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35693,7 +35786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_prompt_data_artist_mix_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35712,7 +35805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35727,7 +35820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_prompt_data_positive_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35746,7 +35839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35761,7 +35854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_split_artist_mix_blocks",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35780,7 +35873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35795,7 +35888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "name": "_split_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35814,7 +35907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35829,7 +35922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 824,
+        "line": 827,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35848,7 +35941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35863,7 +35956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 824,
+        "line": 827,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35882,7 +35975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35897,7 +35990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 824,
+        "line": 827,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35916,7 +36009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35931,7 +36024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 824,
+        "line": 827,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35950,7 +36043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35965,7 +36058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 830,
+        "line": 833,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -35984,7 +36077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -35999,7 +36092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 830,
+        "line": 833,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -36018,7 +36111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36033,7 +36126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
         "kind": "static_from",
-        "line": 830,
+        "line": 833,
         "name": "EasyUseAnimaPromptStudioExtend",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -36052,7 +36145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36067,7 +36160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 830,
+        "line": 833,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -36075,6 +36168,40 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaAIOGenerator",
+        "bound_name": "EasyUseAnimaAIOGenerator",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 524,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaAIOGenerator",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
+        "kind": "static_from",
+        "line": 839,
+        "name": "EasyUseAnimaAIOGenerator",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
       },
       {
         "alias": "EasyUseAnimaInput",
@@ -36086,7 +36213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36101,7 +36228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 836,
+        "line": 839,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -36120,7 +36247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36135,8 +36262,76 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 836,
+        "line": 839,
         "name": "_bind_aio_node_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "alias": "_easy_use_anima_input_signature",
+        "bound_name": "_easy_use_anima_input_signature",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 524,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_easy_use_anima_input_signature",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
+        "kind": "static_from",
+        "line": 839,
+        "name": "_easy_use_anima_input_signature",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "alias": "_require_easy_use_anima_input",
+        "bound_name": "_require_easy_use_anima_input",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 524,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_require_easy_use_anima_input",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
+        "kind": "static_from",
+        "line": 839,
+        "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
         "role": "compatibility_fallback",
@@ -36154,7 +36349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36169,7 +36364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 840,
+        "line": 846,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36188,7 +36383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36203,7 +36398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 840,
+        "line": 846,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36222,7 +36417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36237,7 +36432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 840,
+        "line": 846,
         "name": "_align_up",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36256,7 +36451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36271,7 +36466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 840,
+        "line": 846,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36290,7 +36485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36305,7 +36500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 840,
+        "line": 846,
         "name": "_alignment_value",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36324,7 +36519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36339,7 +36534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 847,
+        "line": 853,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": "easyuse_anima.image.detailer",
@@ -36358,7 +36553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36373,7 +36568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36392,7 +36587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36407,7 +36602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "name": "_call_impact_detailer",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36426,7 +36621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36441,7 +36636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36460,7 +36655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36475,7 +36670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "name": "_empty_mask_for_image",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36494,7 +36689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36509,7 +36704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "name": "_empty_segs_for_image",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36528,7 +36723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36543,7 +36738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "name": "_find_impact_detailer_class",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36562,7 +36757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36577,7 +36772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "name": "_find_impact_mask_to_segs_class",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36596,7 +36791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36611,7 +36806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "name": "_find_sam3_detect_class",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36630,7 +36825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36645,7 +36840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "name": "_format_sam3_detection_prompt",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36664,7 +36859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36679,7 +36874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36698,7 +36893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36713,7 +36908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36732,7 +36927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36747,7 +36942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 863,
+        "line": 869,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36766,7 +36961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36781,7 +36976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 863,
+        "line": 869,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36800,7 +36995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36815,7 +37010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 863,
+        "line": 869,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36834,7 +37029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36849,7 +37044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 863,
+        "line": 869,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36868,7 +37063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36883,7 +37078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 863,
+        "line": 869,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36902,7 +37097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36917,7 +37112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 863,
+        "line": 869,
         "name": "_scale_by_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36936,7 +37131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36951,7 +37146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36970,7 +37165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -36985,7 +37180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37004,7 +37199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37019,7 +37214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37038,7 +37233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37053,7 +37248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37072,7 +37267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37087,7 +37282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37106,7 +37301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37121,7 +37316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "name": "_impact_core_module",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37140,7 +37335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37155,7 +37350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37174,7 +37369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37189,7 +37384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37208,7 +37403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37223,7 +37418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37242,7 +37437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37257,7 +37452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 882,
+        "line": 888,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -37276,7 +37471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37291,7 +37486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 882,
+        "line": 888,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -37310,7 +37505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37325,7 +37520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 882,
+        "line": 888,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -37344,7 +37539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37359,7 +37554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 882,
+        "line": 888,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -37378,7 +37573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37393,7 +37588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 888,
+        "line": 894,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37412,7 +37607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37427,7 +37622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 888,
+        "line": 894,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37446,7 +37641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37461,7 +37656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 888,
+        "line": 894,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37480,7 +37675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37495,7 +37690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 888,
+        "line": 894,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37514,7 +37709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37529,7 +37724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 888,
+        "line": 894,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37548,7 +37743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37563,7 +37758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 888,
+        "line": 894,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37582,7 +37777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37597,7 +37792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 896,
+        "line": 902,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -37616,7 +37811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37631,7 +37826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 896,
+        "line": 902,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -37650,7 +37845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37665,7 +37860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 900,
+        "line": 906,
         "name": "_EasyUseAnimaImpactDetailerDelegate",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -37684,7 +37879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37699,7 +37894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 900,
+        "line": 906,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -37718,7 +37913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37733,7 +37928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 904,
+        "line": 910,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -37752,7 +37947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37767,7 +37962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 904,
+        "line": 910,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -37786,7 +37981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37801,7 +37996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 904,
+        "line": 910,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -37820,7 +38015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37835,7 +38030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 909,
+        "line": 915,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37854,7 +38049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37869,7 +38064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 909,
+        "line": 915,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37888,7 +38083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37903,7 +38098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 909,
+        "line": 915,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37922,7 +38117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37937,7 +38132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 909,
+        "line": 915,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37956,7 +38151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -37971,7 +38166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 909,
+        "line": 915,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37990,7 +38185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38005,7 +38200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 916,
+        "line": 922,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -38024,7 +38219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38039,7 +38234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 916,
+        "line": 922,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -38058,7 +38253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38073,7 +38268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 916,
+        "line": 922,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -38092,7 +38287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38107,7 +38302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38126,7 +38321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38141,7 +38336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38160,7 +38355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38175,7 +38370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38194,7 +38389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38209,7 +38404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38228,7 +38423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38243,7 +38438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38262,7 +38457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38277,7 +38472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38296,7 +38491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38311,7 +38506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38330,7 +38525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38345,7 +38540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "NAI_1MP",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38364,7 +38559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38379,7 +38574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38398,7 +38593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38413,7 +38608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38432,7 +38627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38447,7 +38642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38466,7 +38661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38481,7 +38676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "_clean_prompt",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38500,7 +38695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38515,7 +38710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38534,7 +38729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38549,7 +38744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38568,7 +38763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38583,7 +38778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38602,7 +38797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38617,7 +38812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38636,7 +38831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38651,7 +38846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38670,7 +38865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38685,7 +38880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38704,7 +38899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38719,7 +38914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38738,7 +38933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38753,7 +38948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38772,7 +38967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38787,7 +38982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38806,7 +39001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38821,7 +39016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38840,7 +39035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38855,7 +39050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38874,7 +39069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38889,7 +39084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38908,7 +39103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38923,7 +39118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38942,7 +39137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38957,7 +39152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38976,7 +39171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -38991,7 +39186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39010,7 +39205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39025,7 +39220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39044,7 +39239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39059,7 +39254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39078,7 +39273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39093,7 +39288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39112,7 +39307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39127,7 +39322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39146,7 +39341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39161,7 +39356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39180,7 +39375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39195,7 +39390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39214,7 +39409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39229,7 +39424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39248,7 +39443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39263,7 +39458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39282,7 +39477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39297,7 +39492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39316,7 +39511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39331,7 +39526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39350,7 +39545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39365,7 +39560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 962,
+        "line": 968,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -39384,7 +39579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39399,7 +39594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 962,
+        "line": 968,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -39418,7 +39613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39433,7 +39628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 966,
+        "line": 972,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39452,7 +39647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39467,7 +39662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 966,
+        "line": 972,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39486,7 +39681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39501,7 +39696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 966,
+        "line": 972,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39520,7 +39715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39535,7 +39730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39554,7 +39749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39569,7 +39764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39588,7 +39783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39603,7 +39798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39622,7 +39817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39637,7 +39832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39656,7 +39851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39671,7 +39866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39690,7 +39885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39705,7 +39900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39724,7 +39919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39739,7 +39934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39758,7 +39953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39773,7 +39968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39792,7 +39987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39807,7 +40002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39826,7 +40021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39841,7 +40036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39860,7 +40055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39875,7 +40070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39894,7 +40089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39909,7 +40104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39928,7 +40123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39943,7 +40138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39962,7 +40157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -39977,7 +40172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39996,7 +40191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40011,7 +40206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40030,7 +40225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40045,7 +40240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40064,7 +40259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40079,7 +40274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40098,7 +40293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40113,7 +40308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40132,7 +40327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40147,7 +40342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40166,7 +40361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40181,7 +40376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40200,7 +40395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40215,7 +40410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40234,7 +40429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40249,7 +40444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40268,7 +40463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40283,7 +40478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40302,7 +40497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40317,7 +40512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 998,
+        "line": 1004,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -40336,7 +40531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40351,7 +40546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 998,
+        "line": 1004,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -40370,7 +40565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40385,7 +40580,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1008,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -40404,7 +40599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40419,7 +40614,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1008,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -40438,7 +40633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40453,7 +40648,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1009,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -40472,7 +40667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40487,7 +40682,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1010,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -40506,7 +40701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40521,7 +40716,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1010,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -40540,7 +40735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40555,7 +40750,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1010,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -40574,7 +40769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40589,7 +40784,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -40608,7 +40803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40623,7 +40818,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -40642,7 +40837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40657,7 +40852,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40676,7 +40871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40691,7 +40886,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40710,7 +40905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40725,7 +40920,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40744,7 +40939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40759,7 +40954,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40778,7 +40973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40793,7 +40988,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40812,7 +41007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40827,7 +41022,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40846,7 +41041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40861,7 +41056,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40880,7 +41075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40895,7 +41090,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40914,7 +41109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40929,7 +41124,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40948,7 +41143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40963,7 +41158,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40982,7 +41177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -40997,7 +41192,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41016,7 +41211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -41031,7 +41226,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41050,7 +41245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -41065,7 +41260,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41084,7 +41279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -41099,7 +41294,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41118,7 +41313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -41133,7 +41328,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41152,7 +41347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -41167,7 +41362,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41186,7 +41381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -41201,7 +41396,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41220,7 +41415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -41235,7 +41430,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41254,7 +41449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -41269,7 +41464,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41287,7 +41482,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1763
+            "line": 1769
           }
         ],
         "classification": "external",
@@ -41295,7 +41490,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1764,
+        "line": 1770,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -41312,7 +41507,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1800
+            "line": 1806
           }
         ],
         "classification": "external",
@@ -41320,7 +41515,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1801,
+        "line": 1807,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -41337,7 +41532,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1808
+            "line": 1814
           }
         ],
         "classification": "external",
@@ -41345,7 +41540,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1809,
+        "line": 1815,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -44529,13 +44724,13 @@
       },
       {
         "is_package": false,
-        "loc": 156,
+        "loc": 297,
         "module": "easyuse_anima.nodes.aio_nodes",
-        "normalized_git_blob_sha1": "8c77faeae9ca6fb124ed184e3a64b32ff570daa9",
+        "normalized_git_blob_sha1": "0f3d1f7d20e88e4686ac9703423aae91e7010d37",
         "path": "easyuse_anima/nodes/aio_nodes.py",
         "top_level": {
-          "class_count": 1,
-          "function_count": 2,
+          "class_count": 2,
+          "function_count": 4,
           "global_count": 3
         }
       },
@@ -44793,13 +44988,13 @@
       },
       {
         "is_package": false,
-        "loc": 2822,
+        "loc": 2712,
         "module": "nodes",
-        "normalized_git_blob_sha1": "688ee31af1383b25856e258d918d3489f5aa4cdc",
+        "normalized_git_blob_sha1": "09f0659ec2f1057b07c4324391aa60d9f2ca62e0",
         "path": "nodes.py",
         "top_level": {
-          "class_count": 3,
-          "function_count": 43,
+          "class_count": 2,
+          "function_count": 41,
           "global_count": 33
         }
       },
@@ -46149,7 +46344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46158,7 +46353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46172,7 +46367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46181,7 +46376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46195,7 +46390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46204,7 +46399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46218,7 +46413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46227,7 +46422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46241,7 +46436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46250,7 +46445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46264,7 +46459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46273,7 +46468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46287,7 +46482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46296,7 +46491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46310,7 +46505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46319,7 +46514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46333,7 +46528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46342,7 +46537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 522,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46356,7 +46551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46365,7 +46560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 533,
+        "line": 536,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46379,7 +46574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46388,7 +46583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 533,
+        "line": 536,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46402,7 +46597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46411,7 +46606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 537,
+        "line": 540,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46425,7 +46620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46434,7 +46629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 537,
+        "line": 540,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46448,7 +46643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46457,7 +46652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 537,
+        "line": 540,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46471,7 +46666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46480,7 +46675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 542,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46494,7 +46689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46503,7 +46698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 545,
+        "line": 548,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46517,7 +46712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46526,7 +46721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 545,
+        "line": 548,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46540,7 +46735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46549,7 +46744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 545,
+        "line": 548,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46563,7 +46758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46572,7 +46767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 545,
+        "line": 548,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46586,7 +46781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46595,7 +46790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46609,7 +46804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46618,7 +46813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46632,7 +46827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46641,7 +46836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46655,7 +46850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46664,7 +46859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46678,7 +46873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46687,7 +46882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46701,7 +46896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46710,7 +46905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46724,7 +46919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46733,7 +46928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46747,7 +46942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46756,7 +46951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46770,7 +46965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46779,7 +46974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46793,7 +46988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46802,7 +46997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46816,7 +47011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46825,7 +47020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46839,7 +47034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46848,7 +47043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 551,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46862,7 +47057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46871,7 +47066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46885,7 +47080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46894,7 +47089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46908,7 +47103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46917,7 +47112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46931,7 +47126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46940,7 +47135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46954,7 +47149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46963,7 +47158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46977,7 +47172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -46986,7 +47181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47000,7 +47195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47009,7 +47204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47023,7 +47218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47032,7 +47227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47046,7 +47241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47055,7 +47250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47069,7 +47264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47078,7 +47273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 565,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47092,7 +47287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47101,7 +47296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47115,7 +47310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47124,7 +47319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47138,7 +47333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47147,7 +47342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47161,7 +47356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47170,7 +47365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47184,7 +47379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47193,7 +47388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47207,7 +47402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47216,7 +47411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47230,7 +47425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47239,7 +47434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47253,7 +47448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47262,7 +47457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47276,7 +47471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47285,7 +47480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47299,7 +47494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47308,7 +47503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 577,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47322,7 +47517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47331,7 +47526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47345,7 +47540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47354,7 +47549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47368,7 +47563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47377,7 +47572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47391,7 +47586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47400,7 +47595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47414,7 +47609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47423,7 +47618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47437,7 +47632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47446,7 +47641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47460,7 +47655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47469,7 +47664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47483,7 +47678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47492,7 +47687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47506,7 +47701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47515,7 +47710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47529,7 +47724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47538,7 +47733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 589,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47552,7 +47747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47561,7 +47756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47575,7 +47770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47584,7 +47779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47598,7 +47793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47607,7 +47802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47621,7 +47816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47630,7 +47825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47644,7 +47839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47653,7 +47848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47667,7 +47862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47676,7 +47871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47690,7 +47885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47699,7 +47894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47713,7 +47908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47722,7 +47917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47736,7 +47931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47745,7 +47940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47759,7 +47954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47768,7 +47963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47782,7 +47977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47791,7 +47986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 601,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47805,7 +48000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47814,7 +48009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 614,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47828,7 +48023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47837,7 +48032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 614,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47851,7 +48046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47860,7 +48055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 614,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47874,7 +48069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47883,7 +48078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 619,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47897,7 +48092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47906,7 +48101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 619,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47920,7 +48115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47929,7 +48124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 619,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47943,7 +48138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47952,7 +48147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 619,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47966,7 +48161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47975,7 +48170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 619,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47989,7 +48184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -47998,7 +48193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 626,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48012,7 +48207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48021,7 +48216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 626,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48035,7 +48230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48044,7 +48239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 626,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48058,7 +48253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48067,7 +48262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 626,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48081,7 +48276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48090,7 +48285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48104,7 +48299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48113,7 +48308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48127,7 +48322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48136,7 +48331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48150,7 +48345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48159,7 +48354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48173,7 +48368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48182,7 +48377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48196,7 +48391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48205,7 +48400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48219,7 +48414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48228,7 +48423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48242,7 +48437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48251,7 +48446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48265,7 +48460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48274,7 +48469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48288,7 +48483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48297,7 +48492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48311,7 +48506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48320,7 +48515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48334,7 +48529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48343,7 +48538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 632,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48357,7 +48552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48366,7 +48561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48380,7 +48575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48389,7 +48584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48403,7 +48598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48412,7 +48607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48426,7 +48621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48435,7 +48630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48449,7 +48644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48458,7 +48653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48472,7 +48667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48481,7 +48676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48495,7 +48690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48504,7 +48699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48518,7 +48713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48527,7 +48722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48541,7 +48736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48550,7 +48745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48564,7 +48759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48573,7 +48768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48587,7 +48782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48596,7 +48791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48610,7 +48805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48619,7 +48814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48633,7 +48828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48642,7 +48837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48656,7 +48851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48665,7 +48860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48679,7 +48874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48688,7 +48883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48702,7 +48897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48711,7 +48906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48725,7 +48920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48734,7 +48929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48748,7 +48943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48757,7 +48952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_LABELS",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48771,7 +48966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48780,7 +48975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_PANES",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48794,7 +48989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48803,7 +48998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_TYPES",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48817,7 +49012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48826,7 +49021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:EXTEND_PROMPT_SLOT_SPECS",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48840,7 +49035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48849,7 +49044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48863,7 +49058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48872,7 +49067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48886,7 +49081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48895,7 +49090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48909,7 +49104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48918,7 +49113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48932,7 +49127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48941,7 +49136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48955,7 +49150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48964,7 +49159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48978,7 +49173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -48987,7 +49182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49001,7 +49196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49010,7 +49205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49024,7 +49219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49033,7 +49228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49047,7 +49242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49056,7 +49251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49070,7 +49265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49079,7 +49274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49093,7 +49288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49102,7 +49297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_with_artist_override",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49116,7 +49311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49125,7 +49320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49139,7 +49334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49148,7 +49343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_pane_parts",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49162,7 +49357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49171,7 +49366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_data_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49185,7 +49380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49194,7 +49389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49208,7 +49403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49217,7 +49412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49231,7 +49426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49240,7 +49435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49254,7 +49449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49263,7 +49458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49277,7 +49472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49286,7 +49481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49300,7 +49495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49309,7 +49504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49323,7 +49518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49332,7 +49527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49346,7 +49541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49355,7 +49550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49369,7 +49564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49378,7 +49573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49392,7 +49587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49401,7 +49596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49415,7 +49610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49424,7 +49619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49438,7 +49633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49447,7 +49642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49461,7 +49656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49470,7 +49665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49484,7 +49679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49493,7 +49688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 664,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49507,7 +49702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49516,7 +49711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49530,7 +49725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49539,7 +49734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49553,7 +49748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49562,7 +49757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49576,7 +49771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49585,7 +49780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49599,7 +49794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49608,7 +49803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49622,7 +49817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49631,7 +49826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49645,7 +49840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49654,7 +49849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49668,7 +49863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49677,7 +49872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49691,7 +49886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49700,7 +49895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49714,7 +49909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49723,7 +49918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49737,7 +49932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49746,7 +49941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49760,7 +49955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49769,7 +49964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49783,7 +49978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49792,7 +49987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_geometry",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49806,7 +50001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49815,7 +50010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49829,7 +50024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49838,7 +50033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49852,7 +50047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49861,7 +50056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49875,7 +50070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49884,7 +50079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_mask",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49898,7 +50093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49907,7 +50102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49921,7 +50116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49930,7 +50125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49944,7 +50139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49953,7 +50148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_config",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49967,7 +50162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49976,7 +50171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_fields",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49990,7 +50185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -49999,7 +50194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_field_prompt",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50013,7 +50208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50022,7 +50217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50036,7 +50231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50045,7 +50240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50059,7 +50254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50068,7 +50263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50082,7 +50277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50091,7 +50286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 700,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50105,7 +50300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50114,7 +50309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50128,7 +50323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50137,7 +50332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50151,7 +50346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50160,7 +50355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50174,7 +50369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50183,7 +50378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50197,7 +50392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50206,7 +50401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50220,7 +50415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50229,7 +50424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50243,7 +50438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50252,7 +50447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50266,7 +50461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50275,7 +50470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50289,7 +50484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50298,7 +50493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50312,7 +50507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50321,7 +50516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50335,7 +50530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50344,7 +50539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50358,7 +50553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50367,7 +50562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50381,7 +50576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50390,7 +50585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50404,7 +50599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50413,7 +50608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 728,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50427,7 +50622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50436,7 +50631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50450,7 +50645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50459,7 +50654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50473,7 +50668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50482,7 +50677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50496,7 +50691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50505,7 +50700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50519,7 +50714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50528,7 +50723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50542,7 +50737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50551,7 +50746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50565,7 +50760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50574,7 +50769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50588,7 +50783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50597,7 +50792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50611,7 +50806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50620,7 +50815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50634,7 +50829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50643,7 +50838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50657,7 +50852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50666,7 +50861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50680,7 +50875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50689,7 +50884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50703,7 +50898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50712,7 +50907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50726,7 +50921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50735,7 +50930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50749,7 +50944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50758,7 +50953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50772,7 +50967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50781,7 +50976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50795,7 +50990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50804,7 +50999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50818,7 +51013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50827,7 +51022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50841,7 +51036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50850,7 +51045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50864,7 +51059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50873,7 +51068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50887,7 +51082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50896,7 +51091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50910,7 +51105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50919,7 +51114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50933,7 +51128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50942,7 +51137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50956,7 +51151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50965,7 +51160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50979,7 +51174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -50988,7 +51183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51002,7 +51197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51011,7 +51206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51025,7 +51220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51034,7 +51229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51048,7 +51243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51057,7 +51252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51071,7 +51266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51080,7 +51275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51094,7 +51289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51103,7 +51298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51117,7 +51312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51126,7 +51321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51140,7 +51335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51149,7 +51344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51163,7 +51358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51172,7 +51367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51186,7 +51381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51195,7 +51390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51209,7 +51404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51218,7 +51413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51232,7 +51427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51241,7 +51436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51255,7 +51450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51264,7 +51459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51278,7 +51473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51287,7 +51482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51301,7 +51496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51310,7 +51505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51324,7 +51519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51333,7 +51528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51347,7 +51542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51356,7 +51551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51370,7 +51565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51379,7 +51574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51393,7 +51588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51402,7 +51597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51416,7 +51611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51425,7 +51620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51439,7 +51634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51448,7 +51643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51462,7 +51657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51471,7 +51666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51485,7 +51680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51494,7 +51689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51508,7 +51703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51517,7 +51712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51531,7 +51726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51540,7 +51735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51554,7 +51749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51563,7 +51758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51577,7 +51772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51586,7 +51781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51600,7 +51795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51609,7 +51804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51623,7 +51818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51632,7 +51827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51646,7 +51841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51655,7 +51850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51669,7 +51864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51678,7 +51873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51692,7 +51887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51701,7 +51896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51715,7 +51910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51724,7 +51919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51738,7 +51933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51747,7 +51942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51761,7 +51956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51770,7 +51965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51784,7 +51979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51793,7 +51988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51807,7 +52002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51816,7 +52011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51830,7 +52025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51839,7 +52034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51853,7 +52048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51862,7 +52057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51876,7 +52071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51885,7 +52080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51899,7 +52094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51908,7 +52103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51922,7 +52117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51931,7 +52126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51945,7 +52140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51954,7 +52149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51968,7 +52163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -51977,7 +52172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51991,7 +52186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52000,7 +52195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52014,7 +52209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52023,7 +52218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52037,7 +52232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52046,7 +52241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52060,7 +52255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52069,7 +52264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52083,7 +52278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52092,7 +52287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52106,7 +52301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52115,7 +52310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52129,7 +52324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52138,7 +52333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52152,7 +52347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52161,7 +52356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52175,7 +52370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52184,7 +52379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52198,7 +52393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52207,7 +52402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 744,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52221,7 +52416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52230,7 +52425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 824,
+        "line": 827,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52244,7 +52439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52253,7 +52448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 824,
+        "line": 827,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52267,7 +52462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52276,7 +52471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 824,
+        "line": 827,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52290,7 +52485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52299,7 +52494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 824,
+        "line": 827,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52313,7 +52508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52322,7 +52517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 830,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52336,7 +52531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52345,7 +52540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 830,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52359,7 +52554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52368,7 +52563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
         "kind": "static_from",
-        "line": 830,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52382,7 +52577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52391,7 +52586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 830,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52405,7 +52600,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
+        "kind": "static_from",
+        "line": 839,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52414,7 +52632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 836,
+        "line": 839,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52428,7 +52646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52437,7 +52655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 836,
+        "line": 839,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52451,7 +52669,53 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
+        "kind": "static_from",
+        "line": 839,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 524,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
+        "kind": "static_from",
+        "line": 839,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52460,7 +52724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 840,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52474,7 +52738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52483,7 +52747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 840,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52497,7 +52761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52506,7 +52770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 840,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52520,7 +52784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52529,7 +52793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 840,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52543,7 +52807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52552,7 +52816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 840,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52566,7 +52830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52575,7 +52839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 847,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52589,7 +52853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52598,7 +52862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52612,7 +52876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52621,7 +52885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52635,7 +52899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52644,7 +52908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52658,7 +52922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52667,7 +52931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52681,7 +52945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52690,7 +52954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52704,7 +52968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52713,7 +52977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52727,7 +52991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52736,7 +53000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52750,7 +53014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52759,7 +53023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52773,7 +53037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52782,7 +53046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52796,7 +53060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52805,7 +53069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52819,7 +53083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52828,7 +53092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 850,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52842,7 +53106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52851,7 +53115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 863,
+        "line": 869,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52865,7 +53129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52874,7 +53138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 863,
+        "line": 869,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52888,7 +53152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52897,7 +53161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 863,
+        "line": 869,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52911,7 +53175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52920,7 +53184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 863,
+        "line": 869,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52934,7 +53198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52943,7 +53207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 863,
+        "line": 869,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52957,7 +53221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52966,7 +53230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 863,
+        "line": 869,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52980,7 +53244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -52989,7 +53253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53003,7 +53267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53012,7 +53276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53026,7 +53290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53035,7 +53299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53049,7 +53313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53058,7 +53322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53072,7 +53336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53081,7 +53345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53095,7 +53359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53104,7 +53368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53118,7 +53382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53127,7 +53391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53141,7 +53405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53150,7 +53414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53164,7 +53428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53173,7 +53437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 871,
+        "line": 877,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53187,7 +53451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53196,7 +53460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 882,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53210,7 +53474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53219,7 +53483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 882,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53233,7 +53497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53242,7 +53506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 882,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53256,7 +53520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53265,7 +53529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 882,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53279,7 +53543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53288,7 +53552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 888,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53302,7 +53566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53311,7 +53575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 888,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53325,7 +53589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53334,7 +53598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 888,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53348,7 +53612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53357,7 +53621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 888,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53371,7 +53635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53380,7 +53644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 888,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53394,7 +53658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53403,7 +53667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 888,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53417,7 +53681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53426,7 +53690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 896,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53440,7 +53704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53449,7 +53713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 896,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53463,7 +53727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53472,7 +53736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 900,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53486,7 +53750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53495,7 +53759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 900,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53509,7 +53773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53518,7 +53782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 904,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53532,7 +53796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53541,7 +53805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 904,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53555,7 +53819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53564,7 +53828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 904,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53578,7 +53842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53587,7 +53851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 909,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53601,7 +53865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53610,7 +53874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 909,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53624,7 +53888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53633,7 +53897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 909,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53647,7 +53911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53656,7 +53920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 909,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53670,7 +53934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53679,7 +53943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 909,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53693,7 +53957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53702,7 +53966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 916,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53716,7 +53980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53725,7 +53989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 916,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53739,7 +54003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53748,7 +54012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 916,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53762,7 +54026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53771,7 +54035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53785,7 +54049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53794,7 +54058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53808,7 +54072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53817,7 +54081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53831,7 +54095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53840,7 +54104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53854,7 +54118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53863,7 +54127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53877,7 +54141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53886,7 +54150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53900,7 +54164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53909,7 +54173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53923,7 +54187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53932,7 +54196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53946,7 +54210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53955,7 +54219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53969,7 +54233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -53978,7 +54242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53992,7 +54256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54001,7 +54265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54015,7 +54279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54024,7 +54288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54038,7 +54302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54047,7 +54311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54061,7 +54325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54070,7 +54334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54084,7 +54348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54093,7 +54357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54107,7 +54371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54116,7 +54380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 921,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54130,7 +54394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54139,7 +54403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54153,7 +54417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54162,7 +54426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54176,7 +54440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54185,7 +54449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54199,7 +54463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54208,7 +54472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54222,7 +54486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54231,7 +54495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54245,7 +54509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54254,7 +54518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54268,7 +54532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54277,7 +54541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54291,7 +54555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54300,7 +54564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54314,7 +54578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54323,7 +54587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54337,7 +54601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54346,7 +54610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54360,7 +54624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54369,7 +54633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54383,7 +54647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54392,7 +54656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54406,7 +54670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54415,7 +54679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54429,7 +54693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54438,7 +54702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54452,7 +54716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54461,7 +54725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54475,7 +54739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54484,7 +54748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54498,7 +54762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54507,7 +54771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54521,7 +54785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54530,7 +54794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54544,7 +54808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54553,7 +54817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54567,7 +54831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54576,7 +54840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54590,7 +54854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54599,7 +54863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 939,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54613,7 +54877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54622,7 +54886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 962,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54636,7 +54900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54645,7 +54909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 962,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54659,7 +54923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54668,7 +54932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 966,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54682,7 +54946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54691,7 +54955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 966,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54705,7 +54969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54714,7 +54978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 966,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54728,7 +54992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54737,7 +55001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54751,7 +55015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54760,7 +55024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54774,7 +55038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54783,7 +55047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54797,7 +55061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54806,7 +55070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54820,7 +55084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54829,7 +55093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54843,7 +55107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54852,7 +55116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54866,7 +55130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54875,7 +55139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54889,7 +55153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54898,7 +55162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54912,7 +55176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54921,7 +55185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54935,7 +55199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54944,7 +55208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54958,7 +55222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54967,7 +55231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54981,7 +55245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -54990,7 +55254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55004,7 +55268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55013,7 +55277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55027,7 +55291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55036,7 +55300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55050,7 +55314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55059,7 +55323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 971,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55073,7 +55337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55082,7 +55346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55096,7 +55360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55105,7 +55369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55119,7 +55383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55128,7 +55392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55142,7 +55406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55151,7 +55415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55165,7 +55429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55174,7 +55438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55188,7 +55452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55197,7 +55461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55211,7 +55475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55220,7 +55484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55234,7 +55498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55243,7 +55507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55257,7 +55521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55266,7 +55530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 998,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55280,7 +55544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55289,7 +55553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 998,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55303,7 +55567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55312,7 +55576,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55326,7 +55590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55335,7 +55599,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55349,7 +55613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55358,7 +55622,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55372,7 +55636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55381,7 +55645,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55395,7 +55659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55404,7 +55668,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55418,7 +55682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55427,7 +55691,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55441,7 +55705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55450,7 +55714,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55464,7 +55728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55473,7 +55737,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55487,7 +55751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55496,7 +55760,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55510,7 +55774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55519,7 +55783,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55533,7 +55797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55542,7 +55806,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55556,7 +55820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55565,7 +55829,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55579,7 +55843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55588,7 +55852,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55602,7 +55866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55611,7 +55875,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55625,7 +55889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55634,7 +55898,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55648,7 +55912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55657,7 +55921,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55671,7 +55935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55680,7 +55944,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55694,7 +55958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55703,7 +55967,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55717,7 +55981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55726,7 +55990,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55740,7 +56004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55749,7 +56013,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55763,7 +56027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55772,7 +56036,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55786,7 +56050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55795,7 +56059,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55809,7 +56073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55818,7 +56082,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55832,7 +56096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55841,7 +56105,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55855,7 +56119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55864,7 +56128,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55878,7 +56142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55887,7 +56151,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55901,7 +56165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 521,
+            "handler_line": 524,
             "kind": "try",
             "line": 11
           }
@@ -55910,7 +56174,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -59594,14 +59858,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1763
+            "line": 1769
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1764,
+        "line": 1770,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -59613,14 +59877,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1800
+            "line": 1806
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1801,
+        "line": 1807,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -59632,14 +59896,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1808
+            "line": 1814
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1809,
+        "line": 1815,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -61014,14 +61278,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1763
+            "line": 1769
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1764,
+        "line": 1770,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -61033,14 +61297,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1800
+            "line": 1806
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1801,
+        "line": 1807,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -61052,14 +61316,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1808
+            "line": 1814
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1809,
+        "line": 1815,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -62661,7 +62925,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1032,
+        "line": 1038,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62670,7 +62934,7 @@
         "column": 12,
         "context": "assign:_ANY_TYPE",
         "kind": "import_time_call",
-        "line": 1548,
+        "line": 1554,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62679,7 +62943,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1714,
+        "line": 1720,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62688,7 +62952,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2608,
+        "line": 2614,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62697,7 +62961,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2611,
+        "line": 2617,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62706,7 +62970,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2614,
+        "line": 2620,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62715,7 +62979,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2617,
+        "line": 2623,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62724,7 +62988,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2620,
+        "line": 2626,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62733,7 +62997,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2623,
+        "line": 2629,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62742,7 +63006,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2626,
+        "line": 2632,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62751,7 +63015,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2629,
+        "line": 2635,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62760,7 +63024,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2632,
+        "line": 2638,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62769,7 +63033,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2635,
+        "line": 2641,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62778,7 +63042,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2638,
+        "line": 2644,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62787,7 +63051,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2641,
+        "line": 2647,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62796,7 +63060,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2644,
+        "line": 2650,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62805,7 +63069,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2647,
+        "line": 2653,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62814,7 +63078,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2651,
+        "line": 2657,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62823,7 +63087,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2654,
+        "line": 2660,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62832,7 +63096,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2658,
+        "line": 2664,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62841,7 +63105,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2661,
+        "line": 2667,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62850,7 +63114,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2665,
+        "line": 2671,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62859,7 +63123,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2668,
+        "line": 2674,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62868,7 +63132,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2671,
+        "line": 2677,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62877,7 +63141,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2674,
+        "line": 2680,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62886,7 +63150,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2677,
+        "line": 2683,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62895,7 +63159,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2680,
+        "line": 2686,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62904,7 +63168,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2687,
+        "line": 2693,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62913,7 +63177,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2693,
+        "line": 2699,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62922,7 +63186,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2698,
+        "line": 2704,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62931,7 +63195,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2702,
+        "line": 2708,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -63421,25 +63685,25 @@
       },
       {
         "kind": "dict",
-        "line": 1102,
+        "line": 1108,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1091,
+        "line": 1097,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1086,
+        "line": 1092,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "set",
-        "line": 1713,
+        "line": 1719,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -11,18 +11,54 @@ from tests.test_node_contracts import _loaded_package_entrypoint
 
 
 class AIONodeContractTests(unittest.TestCase):
-    def test_input_node_is_the_canonical_public_adapter_in_both_import_modes(self):
-        self.assertEqual(aio_nodes.__all__, ("EasyUseAnimaInput",))
+    def test_aio_nodes_are_the_canonical_public_adapters_in_both_import_modes(self):
+        self.assertEqual(
+            aio_nodes.__all__,
+            ("EasyUseAnimaInput", "EasyUseAnimaAIOGenerator"),
+        )
         self.assertIs(nodes.EasyUseAnimaInput, aio_nodes.EasyUseAnimaInput)
+        self.assertIs(
+            nodes.EasyUseAnimaAIOGenerator,
+            aio_nodes.EasyUseAnimaAIOGenerator,
+        )
+        self.assertIs(
+            nodes._easy_use_anima_input_signature,
+            aio_nodes._easy_use_anima_input_signature,
+        )
+        self.assertIs(
+            nodes._require_easy_use_anima_input,
+            aio_nodes._require_easy_use_anima_input,
+        )
 
         with _loaded_package_entrypoint() as (package_entrypoint, package_nodes):
             canonical_module = sys.modules[
                 f"{package_entrypoint.__name__}.easyuse_anima.nodes.aio_nodes"
             ]
-            mapped_class = package_entrypoint.NODE_CLASS_MAPPINGS["EasyUseAnimaInput"]
-
-            self.assertIs(mapped_class, canonical_module.EasyUseAnimaInput)
+            self.assertEqual(
+                canonical_module.__all__,
+                ("EasyUseAnimaInput", "EasyUseAnimaAIOGenerator"),
+            )
+            self.assertIs(
+                package_entrypoint.NODE_CLASS_MAPPINGS["EasyUseAnimaInput"],
+                canonical_module.EasyUseAnimaInput,
+            )
+            self.assertIs(
+                package_entrypoint.NODE_CLASS_MAPPINGS["EasyUseAnimaAIOGenerator"],
+                canonical_module.EasyUseAnimaAIOGenerator,
+            )
             self.assertIs(package_nodes.EasyUseAnimaInput, canonical_module.EasyUseAnimaInput)
+            self.assertIs(
+                package_nodes.EasyUseAnimaAIOGenerator,
+                canonical_module.EasyUseAnimaAIOGenerator,
+            )
+            self.assertIs(
+                package_nodes._easy_use_anima_input_signature,
+                canonical_module._easy_use_anima_input_signature,
+            )
+            self.assertIs(
+                package_nodes._require_easy_use_anima_input,
+                canonical_module._require_easy_use_anima_input,
+            )
 
     def test_input_types_resolve_root_runtime_values_at_call_time(self):
         calls = []
@@ -281,6 +317,185 @@ class AIONodeContractTests(unittest.TestCase):
             nodes.EasyUseAnimaAIOGenerator.RETURN_NAMES,
             ("image", "latent", "metadata_json"),
         )
+
+    def test_generator_input_types_resolve_root_runtime_values_at_call_time(self):
+        calls = []
+
+        def generation_settings_json():
+            calls.append("generation_settings_json")
+            return '{"schema":"generation-test"}'
+
+        with patch.multiple(
+            nodes,
+            EASY_USE_ANIMA_INPUT_TYPE="EASY_USE_ANIMA_INPUT_TEST",
+            _aio_generation_settings_json=generation_settings_json,
+        ):
+            input_types = nodes.EasyUseAnimaAIOGenerator.INPUT_TYPES()
+
+        self.assertEqual(calls, ["generation_settings_json"])
+        self.assertEqual(
+            input_types["required"]["easy_use_anima_input"][0],
+            "EASY_USE_ANIMA_INPUT_TEST",
+        )
+        self.assertEqual(
+            input_types["required"]["generation_settings"][1]["default"],
+            '{"schema":"generation-test"}',
+        )
+        self.assertEqual(
+            list(input_types),
+            ["required", "hidden", "optional"],
+        )
+        self.assertEqual(
+            list(input_types["required"]),
+            ["easy_use_anima_input", "generation_settings"],
+        )
+        self.assertEqual(
+            list(input_types["hidden"]),
+            ["workflow_prompt", "extra_pnginfo", "unique_id"],
+        )
+        self.assertEqual(list(input_types["optional"]), ["lora_stack"])
+
+    def test_generator_change_key_preserves_special_seed_order_and_mutable_set(self):
+        calls = []
+        special_seeds = set()
+        normalized = {"sampler": {"seed": "runtime"}, "future": {"kept": True}}
+
+        def normalize(value):
+            calls.append(("normalize", value))
+            return normalized
+
+        def clone(value):
+            calls.append(("clone", value))
+            return json.loads(json.dumps(value))
+
+        def resolve_seed(value):
+            calls.append(("resolve_seed", value))
+            return 77
+
+        def input_signature(value):
+            calls.append(("input_signature", value))
+            return {"input": value}
+
+        def lora_signature(value):
+            calls.append(("lora_signature", value))
+            return [{"lora": value}]
+
+        def stable_key(value):
+            calls.append(("stable_key", value))
+            return "change-key"
+
+        with patch.multiple(
+            nodes,
+            AIO_SPECIAL_SEEDS=special_seeds,
+            _normalize_aio_generation_settings=normalize,
+            _json_clone=clone,
+            _resolve_aio_runtime_seed=resolve_seed,
+            _easy_use_anima_input_signature=input_signature,
+            _aio_lora_stack_signature=lora_signature,
+            _stable_change_key=stable_key,
+        ):
+            fixed_result = nodes.EasyUseAnimaAIOGenerator.IS_CHANGED(
+                "context",
+                "lora",
+                "settings",
+                ignored="compatibility",
+            )
+            fixed_calls = list(calls)
+            calls.clear()
+            special_seeds.add("runtime")
+            special_result = nodes.EasyUseAnimaAIOGenerator.IS_CHANGED(
+                "context",
+                "lora",
+                "settings",
+            )
+
+        fixed_payload = {
+            "mode": "easy_use_anima_generator",
+            "input": {"input": "context"},
+            "lora_stack": [{"lora": "lora"}],
+            "generation_settings": normalized,
+        }
+        self.assertEqual(fixed_result, "change-key")
+        self.assertEqual(
+            fixed_calls,
+            [
+                ("normalize", "settings"),
+                ("input_signature", "context"),
+                ("lora_signature", "lora"),
+                ("stable_key", fixed_payload),
+            ],
+        )
+        self.assertEqual(special_result, "change-key")
+        self.assertEqual(
+            calls,
+            [
+                ("normalize", "settings"),
+                ("clone", normalized),
+                ("resolve_seed", "runtime"),
+                ("input_signature", "context"),
+                ("lora_signature", "lora"),
+                (
+                    "stable_key",
+                    {
+                        **fixed_payload,
+                        "generation_settings": {
+                            "sampler": {"seed": 77},
+                            "future": {"kept": True},
+                        },
+                    },
+                ),
+            ],
+        )
+        self.assertEqual(normalized["sampler"]["seed"], "runtime")
+
+    def test_input_signature_and_validator_preserve_exact_contract(self):
+        calls = []
+
+        def json_safe(value):
+            calls.append(value)
+            return {"safe": value}
+
+        value = {
+            "schema": "schema",
+            "version": 2,
+            "resource_info": {"resource": 1},
+            "input_settings": {"setting": 2},
+            "prompt_data": {"prompt": 3},
+        }
+        with patch.object(nodes, "_prompt_data_json_safe", side_effect=json_safe):
+            signature = nodes._easy_use_anima_input_signature(value)
+            non_mapping = nodes._easy_use_anima_input_signature("context")
+
+        self.assertEqual(
+            calls,
+            [
+                {"resource": 1},
+                {"setting": 2},
+                {"prompt": 3},
+            ],
+        )
+        self.assertEqual(
+            signature,
+            {
+                "schema": "schema",
+                "version": 2,
+                "resource_info": {"safe": {"resource": 1}},
+                "input_settings": {"safe": {"setting": 2}},
+                "prompt_data": {"safe": {"prompt": 3}},
+            },
+        )
+        self.assertEqual(non_mapping, {"type": "str"})
+        self.assertIs(nodes._require_easy_use_anima_input(value), value)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"^\[EasyUseAnima\] easy use anima input is missing or invalid\.$",
+        ):
+            nodes._require_easy_use_anima_input(None)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"^\[EasyUseAnima\] easy use anima input is missing required value\(s\): resource_info, input_settings$",
+        ):
+            nodes._require_easy_use_anima_input({"prompt_data": {}})
 
     def test_input_context_is_serializable_and_does_not_embed_model_objects(self):
         context = nodes.EasyUseAnimaInput().build(

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,14 +73,14 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "688ee31af1383b25856e258d918d3489f5aa4cdc")
-        # Issue #184 B-09b1 preserves the AiO generator adapter in root while
-        # moving its current-order execution body behind a direct private alias.
-        self.assertEqual(report["top_level"]["function_count"], 43)
-        self.assertEqual(report["top_level"]["class_count"], 3)
-        self.assertEqual(report["line_count"], 2_822)
+        self.assertEqual(report["git_blob_sha1"], "09f0659ec2f1057b07c4324391aa60d9f2ca62e0")
+        # Issue #184 B-09b2 makes the AiO generator adapter canonical while
+        # preserving the class and its two private compatibility aliases at root.
+        self.assertEqual(report["top_level"]["function_count"], 41)
+        self.assertEqual(report["top_level"]["class_count"], 2)
+        self.assertEqual(report["line_count"], 2_712)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
-        self.assertIn("EasyUseAnimaAIOGenerator", class_names)
+        self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)
         self.assertNotIn("EasyUseAnimaPromptStudioAdvanced", class_names)
         self.assertNotIn("EasyUseAnimaPromptStudioAdvancedV2", class_names)

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -136,7 +136,8 @@ print(json.dumps({{
         self.assertEqual(payload["modules"], list(PACKAGE_MODULES))
         expected_all = [[] for _ in PACKAGE_MODULES]
         expected_all[PACKAGE_MODULES.index("easyuse_anima.nodes.aio_nodes")] = [
-            "EasyUseAnimaInput"
+            "EasyUseAnimaInput",
+            "EasyUseAnimaAIOGenerator",
         ]
         self.assertEqual(payload["declared_all"], expected_all)
         self.assertEqual(payload["new_forbidden"], [])

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -189,6 +189,7 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             "easyuse_anima/lora/preset.py",
             "easyuse_anima/naia/client.py",
             "easyuse_anima/naia/resolution.py",
+            "easyuse_anima/nodes/aio_nodes.py",
             "easyuse_anima/nodes/image_nodes.py",
             "easyuse_anima/nodes/impact_detailer_nodes.py",
             "easyuse_anima/nodes/lora_nodes.py",


### PR DESCRIPTION
## 작업 성격

- 로드맵: B-09b2 `EasyUseAnimaAIOGenerator` 공개 어댑터 이동
- 분류: **Move** (Contract/Behavior 변경 없음)
- 기준: `dev` `7484dc758fd11de020228129f611f9170634357d`
- 상태: 구현 및 검증 완료

## 작업 전 inventory

### 이동 심볼

- `nodes.py::_easy_use_anima_input_signature`
- `nodes.py::_require_easy_use_anima_input`
- `nodes.py::EasyUseAnimaAIOGenerator`

세 심볼의 canonical owner를 `easyuse_anima.nodes.aio_nodes`로 옮긴다. 루트 `nodes.py`는 세 심볼을 상대/폴백 import 경로 모두에서 **직접 identity alias**로 유지한다. 공개 `__all__`은 `EasyUseAnimaInput`, `EasyUseAnimaAIOGenerator`만 포함하며 private helper 두 개는 공개하지 않는다.

### 호출자와 호환 별칭

- 패키지 루트 `__init__.py`는 현재처럼 `nodes.EasyUseAnimaAIOGenerator`를 등록한다. 노드 ID, 표시명, 등록 순서와 mapping object identity를 바꾸지 않는다.
- `easyuse_anima.aio.legacy_generation`은 호출 시점에 루트 `_require_easy_use_anima_input`을 찾는다. 루트 direct alias를 유지해 이 seam을 보존한다.
- 기존 테스트와 외부 확장은 `nodes._run_aio_legacy_generation`을 monkeypatch할 수 있다. canonical `generate()`는 이 심볼을 호출 시점에 조회해야 한다.
- 프런트엔드와 저장 워크플로우의 문자열 ID `EasyUseAnimaAIOGenerator`는 변경하지 않는다.

### 호출 시점 전역 상태와 의존성

기존 `aio_nodes._RUNTIME_RESOLVER` 및 binder 하나만 재사용하고 새 전역 상태를 만들지 않는다.

- `INPUT_TYPES`: `EASY_USE_ANIMA_INPUT_TYPE`, `_aio_generation_settings_json`
- `IS_CHANGED`: `_normalize_aio_generation_settings`, `AIO_SPECIAL_SEEDS`, `_json_clone`, `_resolve_aio_runtime_seed`, `_easy_use_anima_input_signature`, `_aio_lora_stack_signature`, `_stable_change_key`
- `generate`: `_run_aio_legacy_generation`
- `_easy_use_anima_input_signature`: `_prompt_data_json_safe`

특히 mutable root set인 `AIO_SPECIAL_SEEDS`를 복사하거나 import 시점에 고정하지 않는다. 모든 항목은 기존 resolver를 통해 호출 시점에 조회한다.

### 보존할 공개 계약

- required 입력 순서: `easy_use_anima_input`, `generation_settings`
- hidden 입력: `workflow_prompt`, `extra_pnginfo`, `unique_id`
- optional 입력: `lora_stack`
- `RETURN_TYPES`, `RETURN_NAMES`, `FUNCTION = "generate"`, `OUTPUT_NODE`, `CATEGORY`, `DESCRIPTION`, tooltip
- `IS_CHANGED`의 고정/특수 시드 payload와 평가 순서
- `_require_easy_use_anima_input`의 오류 문자열 및 동일 객체 반환
- v0.5.2 저장 워크플로우의 Generator node ID 86/type/widget 구조

## allowed-file boundary

- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`
- `easyuse_anima/nodes/aio_nodes.py`
- `nodes.py`
- `tests/fixtures/python_backend_baseline.json`
- `tests/test_aio_nodes.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_package_skeleton.py`
- `tests/test_registry_scanner_safety.py` (canonical adapter를 기존 고위험 패턴 검사 대상에 추가하는 경우에만)

## 금지 범위와 blocker

- `__init__.py`, `easyuse_anima/aio/legacy_generation.py`, 프런트엔드, locale, 예제/0.5.2 workflow fixture, Registry metadata는 변경하지 않는다.
- 시드, 정규화, 캐시, queue, preview, optional stage 동작을 변경하지 않는다.
- 위 compatibility seam이나 Legacy/Node 2.0 저장 계약을 유지하려면 Behavior/Contract 변경이 필요해지는 경우 임의로 범위를 넓히지 않고 blocker를 기록한다.

## 검증 계획

- canonical/root/package mapping class identity 및 private helper alias
- `INPUT_TYPES`, 고정/특수 시드 `IS_CHANGED`, `generate` 호출 시점 lookup
- B-09b1 forwarding/signature/trace 회귀
- node contract fixture 무변경 확인
- package skeleton, backend analyzer/baseline, import boundary, Registry scanner safety
- 집중 검증 및 독립 리뷰 완료 뒤 exact-head `tools/check_project.ps1 -Profile full` 1회
- ComfyUI Codex test instance에서 optional-provider-disabled import, object info, v0.5.2 Legacy/Node 2.0 load-save-reload, 대표 queue

## 롤백

이 PR의 squash commit 하나를 되돌리면 canonical ownership이 다시 루트 `nodes.py`로 복구되며, 노드 ID나 저장 데이터 마이그레이션은 없다.

## 구현 결과

- `EasyUseAnimaAIOGenerator`와 private helper 두 개의 canonical owner를 `easyuse_anima.nodes.aio_nodes`로 이동했다.
- 루트 `nodes.py`는 상대/폴백 import 모두에서 직접 identity alias를 제공한다.
- 기존 `_RUNTIME_RESOLVER`를 통해 runtime symbol과 mutable `AIO_SPECIAL_SEEDS`를 호출 시점에 조회한다.
- `_run_aio_legacy_generation` monkeypatch seam, 입력 순서, 오류 문자열, `IS_CHANGED` payload, node mapping identity를 유지했다.
- 루트 `nodes.py`는 2,712줄, 함수 41개, 클래스 2개로 감소했다.

## 변경 파일

- `easyuse_anima/nodes/aio_nodes.py`, `nodes.py`
- `tests/test_aio_nodes.py`, `tests/test_nodes_module_analyzer.py`, `tests/test_python_package_skeleton.py`, `tests/test_registry_scanner_safety.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 검증

- focused Python: 169 tests passed
- Registry scanner safety: 8 tests passed
- Python compile, package skeleton, 6-group import boundary, canonical-module Ruff, `git diff --check`: passed
- 독립 read-only 리뷰: P0-P2 없음
- exact-head full (`4f538e33e133fa44dcfbfa3de231d106c6556d49`):
  - Python 858 passed
  - frontend 114 JavaScript files passed, TypeScript 6.0.3 passed
  - Pyright baseline 60/60, G03 import boundary 6 groups/0, diff check passed
  - Ruff 105건은 기존 G01 report-only baseline이며 새 canonical module 위반은 없음

## ComfyUI 검증 표면

- ComfyUI 0.27.0 / frontend 1.45.20 Codex test instance
- package import 및 `EasyUseAnimaAIOGenerator` object info 확인
- v0.5.2 배포 workflow를 Legacy와 Node 2.0에서 각각 실제 load-save-reload:
  - nodes 6, links 5 유지
  - Generator ID 86/type/widgets 1, Input ID 69/type/widgets 5 유지
  - settings schema/version, seed 39, Spectrum backend, Highres/Detailer 저장값 유지
- Node 2.0 대표 queue: 512x512, 2 steps, optional stage 및 저장 비활성, output node 86까지 `success`
- B-09b1에서 검증한 Highres optional-stage orchestration은 이 Move에서 변경되지 않아 반복 실행하지 않았다.

## 남은 위험

- `was-ns`의 `numba` 누락과 `comfyui-distilled-resshift` import 실패가 테스트 인스턴스 시작 로그에 있었으나 이 노드팩 및 변경 범위와 무관한 기존 환경 문제다.
- 호환 경계를 넘는 blocker는 발견되지 않았다.
