### PR TITLE
refactor(backend): retire checkpoint root alias (B-10b1)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `57d40b435983f08c91469db6947ef1260b293695`
+- Integrated `dev` snapshot commit: `3c7b857ebe249dcdc23292ad440a2cca9434406e`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-09b2; B-10a audit in review in PR #271 | Integrate B-10a, then perform scoped B-10b cleanup before registration/bootstrap and the final root shim |
+| B - `nodes.py` extraction | Integrated through B-10a; B-10b1 single-alias cleanup in review in PR #272 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -294,8 +294,8 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 9 | B-09a AiO input adapter move | COMPLETE in PR #268 | Move | #184 | AiO helpers canonical through B-08e |
 | 10 | B-09b1 AiO legacy orchestration body move | COMPLETE on `dev` | Move | #184 | PR #269 / `7484dc7` |
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
-| 12 | B-10a machine-readable compatibility audit | IN REVIEW in PR #271 | Contract/gate | #184/#188 | B-09b2 integrated |
-| 13 | B-10b private alias reduction | BLOCKED by B-10a | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
+| 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
+| 13 | B-10b private alias reduction | IN REVIEW: B-10b1 PR #272 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | BLOCKED by B-10b | Move | #184 | Supported alias surface frozen after scoped cleanup |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
@@ -604,7 +604,7 @@ reported as unexecuted, not passed.
 
 ### B-10a — Machine-readable compatibility surface audit
 
-- **Status:** IN REVIEW in PR #271, based on `dev` `57d40b4`.
+- **Status:** COMPLETE on `dev` in PR #271 / `3c7b857`.
 - **Owners:** #184 and #188
 - **Type:** Contract/gate
 - Inventory every root export and alias after B-09.
@@ -621,12 +621,20 @@ reported as unexecuted, not passed.
 
 ### B-10b — Private alias reduction
 
+- **Status:** B-10b1 is in review in PR #272, based on `dev` `3c7b857`.
 - **Type:** small compatibility cleanup PRs, one owner/surface at a time
 - Remove unsupported/test-only aliases after tests use canonical paths.
 - Retain an actual monkeypatch seam only when the consumer and call-time binding
   contract are documented and tested.
 - Do not remove mapped public node-class re-exports in Phase B.
 - Do not combine alias removal with feature behavior changes.
+
+B-10b1 removes only `_comfy_checkpoint_names` from the relative and flat root
+import surfaces. The SAM3 adapter already imports
+`easyuse_anima.infrastructure.comfy.resources` directly; repository tests move
+their deterministic patch to that canonical consumer. No other alias, mapped
+class, optional-dependency behavior, or workflow contract changes in this
+rollback unit.
 
 ### B-11 — Registration, bootstrap, and final `nodes.py` shim
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,13 +3,13 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `57d40b435983f08c91469db6947ef1260b293695`
+  `3c7b857ebe249dcdc23292ad440a2cca9434406e`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-04 through B-09b2 canonical moves are integrated; B-10a is
-  in review in PR #271 and freezes the actual root surface before B-10b cleanup
+- Current state: B-10a is integrated; B-10b1 in PR #272 removes one audited
+  unsupported/test-only root alias before the remaining scoped cleanup
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -74,7 +74,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 401, with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 400 at the
+  B-10b1 PR head, with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -86,6 +87,8 @@ inferring public support from spelling or test imports:
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 256, including
   literal lookups and binder-owned helper-name/default collections;
+- retired private bindings: `_comfy_checkpoint_names`, whose production SAM3
+  consumer already imports the canonical resource owner directly;
 - repository test files with a direct `nodes` import: 22, recorded as migration
   consumers rather than public-support evidence.
 
@@ -101,6 +104,10 @@ The seven preamble imports are implementation dependencies of the remaining
 root body, not compatibility aliases or supported exports. Any addition,
 removal, or retargeting fails the fixture build until it is deliberately
 classified; B-10b must not treat these imports as private-alias cleanup.
+
+The fixture retains retired private-binding metadata separately from the live
+root surface. A retired name cannot silently return to either compatibility
+import branch without failing the audit gate.
 
 The audit follows every import-time `_bind_*_runtime` target and records literal
 root-name lookups made through its runtime resolver. This keeps production seams
@@ -182,6 +189,10 @@ EasyUseAnimaWildcard
   `easyuse_anima.infrastructure.comfy.invocation` behind the existing root
   injection wrapper. These are internal transition surfaces through the B-10
   compatibility audit and are not added to public package `__all__`.
+- B-10b1 checkpoint-name cleanup: `_comfy_checkpoint_names` is no longer a root
+  alias. `easyuse_anima.nodes.sam3_nodes` already imports the canonical
+  `easyuse_anima.infrastructure.comfy.resources` function directly, and tests
+  patch that real consumer rather than retaining a root-only monkeypatch seam.
 - B-08b2 internal AiO model-variant transition: Spectrum correction/forecast
   model patching and ephemeral model cleanup move to
   `easyuse_anima.aio.model_preparation`. Their four root private names remain

--- a/nodes.py
+++ b/nodes.py
@@ -379,7 +379,7 @@ try:
         _node_output_tuple as _node_output_tuple,
     )
     from .easyuse_anima.infrastructure.comfy.resources import (
-        _comfy_checkpoint_names as _comfy_checkpoint_names,
+        # B-10b1 deliberately omits the retired root _comfy_checkpoint_names alias.
         _comfy_clip_loader_types as _adapter_comfy_clip_loader_types,
         _comfy_diffusion_model_names as _adapter_comfy_diffusion_model_names,
         _comfy_text_encoder_names as _adapter_comfy_text_encoder_names,
@@ -892,7 +892,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _node_output_tuple as _node_output_tuple,
     )
     from easyuse_anima.infrastructure.comfy.resources import (
-        _comfy_checkpoint_names as _comfy_checkpoint_names,
+        # B-10b1 deliberately omits the retired root _comfy_checkpoint_names alias.
         _comfy_clip_loader_types as _adapter_comfy_clip_loader_types,
         _comfy_diffusion_model_names as _adapter_comfy_diffusion_model_names,
         _comfy_text_encoder_names as _adapter_comfy_text_encoder_names,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -23357,37 +23357,6 @@
         "target": "easyuse_anima/infrastructure/comfy/invocation.py"
       },
       {
-        "alias": "_comfy_checkpoint_names",
-        "bound_name": "_comfy_checkpoint_names",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_comfy_checkpoint_names",
-          "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
-        "kind": "static_from",
-        "line": 381,
-        "name": "_comfy_checkpoint_names",
-        "optional": false,
-        "requested": ".easyuse_anima.infrastructure.comfy.resources",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/resources.py"
-      },
-      {
         "alias": "_adapter_comfy_clip_loader_types",
         "bound_name": "_adapter_comfy_clip_loader_types",
         "branch_context": [
@@ -37564,40 +37533,6 @@
         "target": "easyuse_anima/infrastructure/comfy/invocation.py"
       },
       {
-        "alias": "_comfy_checkpoint_names",
-        "bound_name": "_comfy_checkpoint_names",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_comfy_checkpoint_names",
-          "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
-        "kind": "static_from",
-        "line": 894,
-        "name": "_comfy_checkpoint_names",
-        "optional": false,
-        "requested": "easyuse_anima.infrastructure.comfy.resources",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/resources.py"
-      },
-      {
         "alias": "_adapter_comfy_clip_loader_types",
         "bound_name": "_adapter_comfy_clip_loader_types",
         "branch_context": [
@@ -44990,7 +44925,7 @@
         "is_package": false,
         "loc": 2712,
         "module": "nodes",
-        "normalized_git_blob_sha1": "09f0659ec2f1057b07c4324391aa60d9f2ca62e0",
+        "normalized_git_blob_sha1": "53d9aa04736dbb22844813b82c3846f09fdef38b",
         "path": "nodes.py",
         "top_level": {
           "class_count": 2,
@@ -53534,29 +53469,6 @@
         "role": "compatibility_fallback",
         "source": "nodes.py",
         "target": "easyuse_anima/infrastructure/comfy/invocation.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
-        "kind": "static_from",
-        "line": 894,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/resources.py"
       },
       {
         "branch_context": [

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,12 +2,13 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "57d40b435983f08c91469db6947ef1260b293695",
+    "base_commit": "3c7b857ebe249dcdc23292ad440a2cca9434406e",
     "first_release": null,
     "owner_tasks": [
       "#184",
       "#188",
-      "B-10a"
+      "B-10a",
+      "B-10b1"
     ]
   },
   "enums": {
@@ -42,7 +43,7 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 401,
+    "nodes_canonical_bindings": 400,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 3,
@@ -1033,6 +1034,13 @@
       "evidence": "docs/version-plans/0.1.6-Detailer.md"
     }
   },
+  "retired_private_bindings": {
+    "_comfy_checkpoint_names": {
+      "canonical_target": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
+      "owner": "#184/#188 B-10b1",
+      "reason": "production SAM3 consumer already imports the canonical owner"
+    }
+  },
   "direct_nodes_import_test_files": [
     "tests/test_aio_conditioning.py",
     "tests/test_aio_first_pass_cache.py",
@@ -1934,35 +1942,6 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.resources:unsupported_test_only",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_comfy_checkpoint_names": "_comfy_checkpoint_names"
-      },
-      "classification": "unsupported_test_only",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.infrastructure.comfy.resources",
-      "target_state": "canonical",
-      "identity_requirement": "not_applicable",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.infrastructure.comfy.resources",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "repository tests may import this root name"
-      ],
-      "evidence": [
-        "AST:no nodes.py runtime load",
-        "test-only consumption is not public support evidence"
-      ],
-      "removal_gates": [
-        "test imports migrate to canonical targets",
-        "no production consumer evidence",
-        "separate B-10b removal review"
-      ],
-      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.lora.metadata:transitional_private_seam",

--- a/tests/test_comfy_adapters.py
+++ b/tests/test_comfy_adapters.py
@@ -15,6 +15,7 @@ if str(ROOT) not in sys.path:
 
 import nodes
 from easyuse_anima.infrastructure.comfy import capabilities, invocation, resources
+from easyuse_anima.nodes import sam3_nodes
 
 
 class ComfyCapabilityAdapterTests(unittest.TestCase):
@@ -324,12 +325,43 @@ class ComfyRootCompatibilityTests(unittest.TestCase):
     def test_domain_neutral_root_names_are_direct_aliases(self):
         self.assertIs(nodes._comfy_sampler_names, capabilities._comfy_sampler_names)
         self.assertIs(nodes._comfy_scheduler_names, capabilities._comfy_scheduler_names)
-        self.assertIs(nodes._comfy_checkpoint_names, resources._comfy_checkpoint_names)
         self.assertIs(nodes._folder_path_names, resources._folder_path_names)
         self.assertIs(nodes._node_output_tuple, invocation._node_output_tuple)
         self.assertIs(nodes._call_with_supported_kwargs, invocation._call_with_supported_kwargs)
         self.assertIs(nodes._impact_core_module, capabilities._impact_core_module)
         self.assertIs(nodes._impact_scheduler_names, capabilities._impact_scheduler_names)
+
+    def test_checkpoint_names_are_owned_by_the_canonical_sam3_consumer(self):
+        self.assertFalse(hasattr(nodes, "_comfy_checkpoint_names"))
+        self.assertIs(
+            sam3_nodes._comfy_checkpoint_names,
+            resources._comfy_checkpoint_names,
+        )
+        checkpoint_names = ["sam3-b.safetensors", "sam3-a.safetensors"]
+        with (
+            patch.object(
+                sam3_nodes,
+                "_comfy_checkpoint_names",
+                return_value=checkpoint_names,
+            ) as names,
+            patch.object(
+                sam3_nodes,
+                "_preferred_checkpoint_default",
+                return_value="sam3-a.safetensors",
+            ) as preferred,
+        ):
+            input_types = sam3_nodes.EasyUseAnimaSAM3Context.INPUT_TYPES()
+
+        self.assertIs(input_types["required"]["ckpt_name"][0], checkpoint_names)
+        self.assertEqual(
+            input_types["required"]["ckpt_name"][1]["default"],
+            "sam3-a.safetensors",
+        )
+        names.assert_called_once_with()
+        preferred.assert_called_once_with(
+            checkpoint_names,
+            "sam3.1_multiplex_fp16.safetensors",
+        )
 
     def test_feature_specific_root_wrappers_inject_existing_constants_and_aliases(self):
         folder_calls = []

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -37,6 +37,7 @@ from easyuse_anima.nodes import (
     prompt_advanced_nodes,
     prompt_data_nodes,
     prompt_nodes,
+    sam3_nodes,
     wildcard_nodes,
 )
 from easyuse_anima.prompt import artist_mix as prompt_artist_mix
@@ -174,7 +175,6 @@ def _deterministic_comfy_inputs():
         "_comfy_max_resolution": lambda: 16384,
         "_comfy_sampler_names": lambda: ["contract_sampler_a", "contract_sampler_b"],
         "_comfy_scheduler_names": lambda: ["contract_scheduler_a", "contract_scheduler_b"],
-        "_comfy_checkpoint_names": lambda: ["contract/checkpoint.safetensors"],
         "_comfy_diffusion_model_names": lambda: ["contract/diffusion_model.safetensors"],
         "_comfy_text_encoder_names": lambda: ["contract/text_encoder.safetensors"],
         "_comfy_vae_names": lambda: ["contract/vae.safetensors"],
@@ -195,7 +195,11 @@ def _deterministic_comfy_inputs():
             "allow_remote_api": False,
         },
     }
-    with patch.multiple(nodes, **replacements):
+    with patch.multiple(nodes, **replacements), patch.object(
+        sam3_nodes,
+        "_comfy_checkpoint_names",
+        return_value=["contract/checkpoint.safetensors"],
+    ):
         yield
 
 
@@ -537,7 +541,7 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
         ),
         (
             comfy_resources,
-            ("_comfy_checkpoint_names", "_folder_path_names"),
+            ("_folder_path_names",),
         ),
         (
             comfy_invocation,
@@ -556,7 +560,40 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
 
     def test_package_nodes_comfy_aliases_are_canonical_objects(self):
         with _loaded_package_entrypoint() as (_, package_nodes):
+            self.assertFalse(hasattr(package_nodes, "_comfy_checkpoint_names"))
             package_name = package_nodes.__package__
+            package_sam3_nodes = sys.modules[
+                f"{package_name}.easyuse_anima.nodes.sam3_nodes"
+            ]
+            package_resources = sys.modules[
+                f"{package_name}.easyuse_anima.infrastructure.comfy.resources"
+            ]
+            self.assertIs(
+                package_sam3_nodes._comfy_checkpoint_names,
+                package_resources._comfy_checkpoint_names,
+            )
+            checkpoint_names = ["package/sam3.safetensors"]
+            with (
+                patch.object(
+                    package_sam3_nodes,
+                    "_comfy_checkpoint_names",
+                    return_value=checkpoint_names,
+                ),
+                patch.object(
+                    package_sam3_nodes,
+                    "_preferred_checkpoint_default",
+                    return_value="package/sam3.safetensors",
+                ),
+            ):
+                input_types = package_sam3_nodes.EasyUseAnimaSAM3Context.INPUT_TYPES()
+            self.assertIs(
+                input_types["required"]["ckpt_name"][0],
+                checkpoint_names,
+            )
+            self.assertEqual(
+                input_types["required"]["ckpt_name"][1]["default"],
+                "package/sam3.safetensors",
+            )
             package_helper_modules = (
                 (
                     sys.modules[

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,9 +73,9 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "09f0659ec2f1057b07c4324391aa60d9f2ca62e0")
-        # Issue #184 B-09b2 makes the AiO generator adapter canonical while
-        # preserving the class and its two private compatibility aliases at root.
+        self.assertEqual(report["git_blob_sha1"], "53d9aa04736dbb22844813b82c3846f09fdef38b")
+        # Issue #184 B-10b1 retires one unsupported/test-only resource alias
+        # after the SAM3 production consumer moved to the canonical path.
         self.assertEqual(report["top_level"]["function_count"], 41)
         self.assertEqual(report["top_level"]["class_count"], 2)
         self.assertEqual(report["line_count"], 2_712)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -15,7 +15,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "57d40b435983f08c91469db6947ef1260b293695"
+BASE_COMMIT = "3c7b857ebe249dcdc23292ad440a2cca9434406e"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -54,6 +54,15 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "random": "random:random",
     "re": "re:re",
     "sqrt": "math:sqrt",
+}
+RETIRED_PRIVATE_BINDINGS = {
+    "_comfy_checkpoint_names": {
+        "canonical_target": (
+            "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names"
+        ),
+        "owner": "#184/#188 B-10b1",
+        "reason": "production SAM3 consumer already imports the canonical owner",
+    },
 }
 
 
@@ -543,6 +552,13 @@ def _build_document() -> dict[str, Any]:
             + ", ".join(sorted(missing_documented_aliases))
         )
 
+    retired_overlap = set(RETIRED_PRIVATE_BINDINGS).intersection(available)
+    if retired_overlap:
+        raise AssertionError(
+            "retired private bindings returned to the root surface: "
+            + ", ".join(sorted(retired_overlap))
+        )
+
     class_like_bindings = {
         name
         for name, target in relative.items()
@@ -612,7 +628,7 @@ def _build_document() -> dict[str, Any]:
             "base_branch": "dev",
             "base_commit": BASE_COMMIT,
             "first_release": None,
-            "owner_tasks": ["#184", "#188", "B-10a"],
+            "owner_tasks": ["#184", "#188", "B-10a", "B-10b1"],
         },
         "enums": {
             "classifications": list(CLASSIFICATIONS),
@@ -624,7 +640,7 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 401,
+            "nodes_canonical_bindings": 400,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 3,
@@ -640,6 +656,7 @@ def _build_document() -> dict[str, Any]:
         "runtime_binders": _runtime_binders(nodes_tree),
         "runtime_resolver_consumers": runtime_resolver_consumers,
         "documented_transitional_aliases": DOCUMENTED_TRANSITIONAL_ALIASES,
+        "retired_private_bindings": RETIRED_PRIVATE_BINDINGS,
         "direct_nodes_import_test_files": _direct_nodes_import_test_files(),
         "groups": sorted(groups, key=lambda group: group["id"]),
     }
@@ -781,6 +798,20 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             for symbol in group["symbols"]
         }
         self.assertTrue(set(excluded).isdisjoint(compatibility_symbols))
+
+    def test_retired_private_bindings_cannot_return_to_the_root_surface(self):
+        retired = self.document["retired_private_bindings"]
+        self.assertEqual(retired, RETIRED_PRIVATE_BINDINGS)
+        compatibility_symbols = {
+            symbol
+            for group in self.document["groups"]
+            for symbol in group["symbols"]
+        }
+        self.assertTrue(set(retired).isdisjoint(compatibility_symbols))
+        for metadata in retired.values():
+            self.assertTrue(metadata["canonical_target"])
+            self.assertTrue(metadata["owner"])
+            self.assertTrue(metadata["reason"])
 
     def test_relative_and_flat_binding_targets_match_the_machine_readable_fixture(self):
         tree = _read_tree(NODES_PATH)


### PR DESCRIPTION
## 작업 성격

- 로드맵: B-10b1 private alias reduction
- 분류: **Contract/cleanup** (Move/Behavior 변경 없음)
- 기준: `dev` `3c7b857ebe249dcdc23292ad440a2cca9434406e`
- 대상: root private alias `_comfy_checkpoint_names` 1개
- 상태: 구현·독립 리뷰·exact-head full 검증 완료
- 검증 head: `dd7d0f3`

## 작업 전 symbol / caller / alias / global-state inventory

### symbol과 canonical owner

- 현재 root alias는 `nodes.py` relative import와 flat fallback에 각각 한 번 존재한다.
- canonical owner는 `easyuse_anima.infrastructure.comfy.resources._comfy_checkpoint_names`다.
- `easyuse_anima.nodes.sam3_nodes`는 이미 canonical 경로를 직접 import하고 `INPUT_TYPES`에서 호출한다.
- root runtime 직접 load와 28개 binder의 문자열 resolver 소비는 모두 없다.

### caller와 compatibility 근거

- production caller: `easyuse_anima.nodes.sam3_nodes`의 canonical direct import 1곳
- repository test consumer:
  - `tests/test_comfy_adapters.py`의 root/canonical identity assertion
  - `tests/test_node_contracts.py`의 deterministic root patch와 root/package identity group
- mapped node, workflow ID, public package entrypoint, canonical `__all__` 소비자는 없다.
- 확인된 외부 Python direct importer는 없다. 다만 외부 소비자 부재를 증명할 수 없으므로 underscore private surface와 repository production/test inventory를 근거로 이 단일 alias만 제거한다.

### mutable/global state와 behavior 경계

- 함수 자체는 상태를 소유하지 않으며 `folder_paths.get_filename_list("checkpoints")`를 조회한다.
- cache, lock, resolver, import-time side effect가 없다.
- SAM3 node의 canonical 호출 대상, 반환값, optional dependency failure, workflow/serialization 계약은 변경하지 않는다.
- 테스트의 deterministic checkpoint 목록은 root monkeypatch가 아니라 실제 canonical consumer 모듈을 patch하도록 이동한다.

## allowed-file boundary

- `nodes.py`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`
- `tests/test_comfy_adapters.py`
- `tests/test_node_contracts.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_backend_analyzer.py` (필요한 경우에만)
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_backend_baseline.json`
- `tests/fixtures/python_compatibility_surface.v1.json`

## 금지 범위와 blocker

- canonical production 모듈, `__init__.py`, mapped class, frontend/locale/workflow/Registry metadata는 변경하지 않는다.
- 다른 unsupported/test-only alias를 함께 제거하지 않는다.
- active dirty `codex/feature-prompt-translation-runtime`도 `nodes.py`를 수정하지만 변경 hunk는 약 1980/2406행이고 이번 alias는 382/895행이다. 해당 워크트리와 파일은 수정하지 않으며 hunk 경계가 겹치면 blocker로 중단한다.
- 외부 지원 surface 또는 call-time monkeypatch 근거가 새로 확인되면 제거하지 않고 B-10a fixture를 정정한다.

## 계약 변경

- canonical binding count: 401 -> 400
- `_comfy_checkpoint_names`를 retired private binding으로 기록하고 root에 재도입되는 drift를 차단
- canonical SAM3 consumer identity와 deterministic node contract는 유지
- analyzer fixture는 두 compatibility import edge 제거와 `nodes.py` hash만 반영

## 검증

- focused compatibility/Comfy adapter/node contract/SAM3/analyzer: 99 tests passed
- exact-head 공식 `tools/check_project.ps1 -Profile full`: passed
  - Python unittest: 871 passed
  - frontend: 114 JavaScript files passed, TypeScript 6.0.3
  - Pyright baseline: 60 files / 60 expected errors / 0 warnings
  - G-03a import boundary: 6 completed groups / 0 violations
  - `git diff --check`: passed
  - Ruff: 기존 baseline 105건 report-only, blocking 아님
- 독립 read-only 리뷰: P0/P1 없음; SAM3 `INPUT_TYPES()`의 일반/synthetic canonical consumer 호출 증거를 보강한 뒤 P2 해결 재검토 완료
- production behavior나 workflow-visible state를 변경하지 않으므로 별도 live queue는 실행하지 않았다.

## 롤백

이 cleanup squash commit 하나를 되돌리면 root private alias와 test-only identity seam, 두 machine-readable fixture가 함께 복원된다. canonical implementation과 사용자 데이터에는 영향이 없다.
