### PR TITLE
refactor(backend): retire Detailer hook root alias (B-10b2)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `3c7b857ebe249dcdc23292ad440a2cca9434406e`
+- Integrated `dev` snapshot commit: `8db89452428dd3816e215857724c97d0aba99dc3`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-10a; B-10b1 single-alias cleanup in review in PR #272 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
+| B - `nodes.py` extraction | Integrated through B-10b1; B-10b2 single-alias cleanup in review in PR #273 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -295,7 +295,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 10 | B-09b1 AiO legacy orchestration body move | COMPLETE on `dev` | Move | #184 | PR #269 / `7484dc7` |
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
-| 13 | B-10b private alias reduction | IN REVIEW: B-10b1 PR #272 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
+| 13 | B-10b private alias reduction | IN REVIEW: B-10b2 PR #273 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | BLOCKED by B-10b | Move | #184 | Supported alias surface frozen after scoped cleanup |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
@@ -621,7 +621,8 @@ reported as unexecuted, not passed.
 
 ### B-10b — Private alias reduction
 
-- **Status:** B-10b1 is in review in PR #272, based on `dev` `3c7b857`.
+- **Status:** B-10b1 is complete on `dev` in PR #272 / `8db8945`; B-10b2 is
+  in review in PR #273 from that integrated base.
 - **Type:** small compatibility cleanup PRs, one owner/surface at a time
 - Remove unsupported/test-only aliases after tests use canonical paths.
 - Retain an actual monkeypatch seam only when the consumer and call-time binding
@@ -635,6 +636,12 @@ import surfaces. The SAM3 adapter already imports
 their deterministic patch to that canonical consumer. No other alias, mapped
 class, optional-dependency behavior, or workflow contract changes in this
 rollback unit.
+
+B-10b2 removes only `_EasyUseAnimaAlignedDetailerHook` from the relative and
+flat root import surfaces. Both canonical production adapters already import
+`easyuse_anima.image.detailer` directly. Focused normal-package and synthetic
+package-entrypoint contracts retain their class identity and construction
+behavior without preserving a root-only private alias.
 
 ### B-11 — Registration, bootstrap, and final `nodes.py` shim
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,13 +3,13 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `3c7b857ebe249dcdc23292ad440a2cca9434406e`
+  `8db89452428dd3816e215857724c97d0aba99dc3`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-10a is integrated; B-10b1 in PR #272 removes one audited
-  unsupported/test-only root alias before the remaining scoped cleanup
+- Current state: B-10b1 is integrated; B-10b2 in PR #273 removes one audited
+  unsupported/test-only Detailer hook root alias
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -74,8 +74,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 400 at the
-  B-10b1 PR head, with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 399 at the
+  B-10b2 PR head, with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -87,8 +87,9 @@ inferring public support from spelling or test imports:
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 256, including
   literal lookups and binder-owned helper-name/default collections;
-- retired private bindings: `_comfy_checkpoint_names`, whose production SAM3
-  consumer already imports the canonical resource owner directly;
+- retired private bindings: `_comfy_checkpoint_names` and
+  `_EasyUseAnimaAlignedDetailerHook`; their production consumers import the
+  corresponding canonical owners directly;
 - repository test files with a direct `nodes` import: 22, recorded as migration
   consumers rather than public-support evidence.
 
@@ -159,7 +160,7 @@ EasyUseAnimaWildcard
   the 0.5.2 public mapping. A separate consumer audit is required before
   deciding that an unmapped symbol is supported.
 - B-04 compatibility exception: `_image_scale_by_multiple_size` and the moved
-  image/Detailer helpers still used by root internals or focused tests remain
+  image/scaling helpers still used by root internals or focused tests remain
   explicit direct aliases to their canonical modules; they are not wrappers.
 - B-07f internal SAM3 transition: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer` remain direct root aliases to
@@ -193,6 +194,11 @@ EasyUseAnimaWildcard
   alias. `easyuse_anima.nodes.sam3_nodes` already imports the canonical
   `easyuse_anima.infrastructure.comfy.resources` function directly, and tests
   patch that real consumer rather than retaining a root-only monkeypatch seam.
+- B-10b2 Detailer-hook cleanup: `_EasyUseAnimaAlignedDetailerHook` is no longer
+  a root alias. The image and Impact Detailer adapters already import the
+  canonical `easyuse_anima.image.detailer` class directly; normal-package and
+  synthetic package-entrypoint tests preserve class identity and hook
+  construction without a root-only private import.
 - B-08b2 internal AiO model-variant transition: Spectrum correction/forecast
   model patching and ephemeral model cleanup move to
   `easyuse_anima.aio.model_preparation`. Their four root private names remain

--- a/nodes.py
+++ b/nodes.py
@@ -337,9 +337,9 @@ try:
         _aligned_size_near_scale as _aligned_size_near_scale,
         _alignment_value as _alignment_value,
     )
-    from .easyuse_anima.image.detailer import (
-        _EasyUseAnimaAlignedDetailerHook as _EasyUseAnimaAlignedDetailerHook,
-    )
+    # B-10b2 deliberately omits the retired root Detailer hook alias.
+    # Canonical image and Impact Detailer adapters import the owner directly.
+    # The root module no longer re-exports this unsupported private helper.
     from .easyuse_anima.image.sam3 import (
         _bind_sam3_runtime as _bind_sam3_runtime,
         _call_impact_detailer as _call_impact_detailer,
@@ -850,9 +850,9 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _aligned_size_near_scale as _aligned_size_near_scale,
         _alignment_value as _alignment_value,
     )
-    from easyuse_anima.image.detailer import (
-        _EasyUseAnimaAlignedDetailerHook as _EasyUseAnimaAlignedDetailerHook,
-    )
+    # B-10b2 deliberately omits the retired root Detailer hook alias.
+    # Canonical image and Impact Detailer adapters import the owner directly.
+    # The root module no longer re-exports this unsupported private helper.
     from easyuse_anima.image.sam3 import (
         _bind_sam3_runtime as _bind_sam3_runtime,
         _call_impact_detailer as _call_impact_detailer,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -22396,37 +22396,6 @@
         "target": "easyuse_anima/image/geometry.py"
       },
       {
-        "alias": "_EasyUseAnimaAlignedDetailerHook",
-        "bound_name": "_EasyUseAnimaAlignedDetailerHook",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_EasyUseAnimaAlignedDetailerHook",
-          "target": "easyuse_anima/image/detailer.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
-        "kind": "static_from",
-        "line": 340,
-        "name": "_EasyUseAnimaAlignedDetailerHook",
-        "optional": false,
-        "requested": ".easyuse_anima.image.detailer",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/image/detailer.py"
-      },
-      {
         "alias": "_bind_sam3_runtime",
         "bound_name": "_bind_sam3_runtime",
         "branch_context": [
@@ -36479,40 +36448,6 @@
         "target": "easyuse_anima/image/geometry.py"
       },
       {
-        "alias": "_EasyUseAnimaAlignedDetailerHook",
-        "bound_name": "_EasyUseAnimaAlignedDetailerHook",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_EasyUseAnimaAlignedDetailerHook",
-          "target": "easyuse_anima/image/detailer.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
-        "kind": "static_from",
-        "line": 853,
-        "name": "_EasyUseAnimaAlignedDetailerHook",
-        "optional": false,
-        "requested": "easyuse_anima.image.detailer",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/image/detailer.py"
-      },
-      {
         "alias": "_bind_sam3_runtime",
         "bound_name": "_bind_sam3_runtime",
         "branch_context": [
@@ -43430,10 +43365,6 @@
       },
       {
         "from": "nodes.py",
-        "to": "easyuse_anima/image/detailer.py"
-      },
-      {
-        "from": "nodes.py",
         "to": "easyuse_anima/image/geometry.py"
       },
       {
@@ -44925,7 +44856,7 @@
         "is_package": false,
         "loc": 2712,
         "module": "nodes",
-        "normalized_git_blob_sha1": "53d9aa04736dbb22844813b82c3846f09fdef38b",
+        "normalized_git_blob_sha1": "b1f49d3caf95ebda2dfeec46a9ded84179cef0c5",
         "path": "nodes.py",
         "top_level": {
           "class_count": 2,
@@ -52756,29 +52687,6 @@
         "role": "compatibility_fallback",
         "source": "nodes.py",
         "target": "easyuse_anima/image/geometry.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
-        "kind": "static_from",
-        "line": 853,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/image/detailer.py"
       },
       {
         "branch_context": [

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,13 +2,14 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "3c7b857ebe249dcdc23292ad440a2cca9434406e",
+    "base_commit": "8db89452428dd3816e215857724c97d0aba99dc3",
     "first_release": null,
     "owner_tasks": [
       "#184",
       "#188",
       "B-10a",
-      "B-10b1"
+      "B-10b1",
+      "B-10b2"
     ]
   },
   "enums": {
@@ -43,7 +44,7 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 400,
+    "nodes_canonical_bindings": 399,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 3,
@@ -1035,6 +1036,11 @@
     }
   },
   "retired_private_bindings": {
+    "_EasyUseAnimaAlignedDetailerHook": {
+      "canonical_target": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
+      "owner": "#184/#188 B-10b2",
+      "reason": "image and Impact Detailer adapters import the canonical owner"
+    },
     "_comfy_checkpoint_names": {
       "canonical_target": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
       "owner": "#184/#188 B-10b1",
@@ -1587,35 +1593,6 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.image.detailer:unsupported_test_only",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_EasyUseAnimaAlignedDetailerHook": "_EasyUseAnimaAlignedDetailerHook"
-      },
-      "classification": "unsupported_test_only",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.image.detailer",
-      "target_state": "canonical",
-      "identity_requirement": "not_applicable",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.image.detailer",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "repository tests may import this root name"
-      ],
-      "evidence": [
-        "AST:no nodes.py runtime load",
-        "test-only consumption is not public support evidence"
-      ],
-      "removal_gates": [
-        "test imports migrate to canonical targets",
-        "no production consumer evidence",
-        "separate B-10b removal review"
-      ],
-      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.image.geometry:transitional_private_seam",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -32,6 +32,7 @@ from easyuse_anima.naia import client as naia_client
 from easyuse_anima.naia import resolution as naia_resolution
 from easyuse_anima.nodes import (
     image_nodes,
+    impact_detailer_nodes,
     lora_nodes,
     naia_nodes,
     prompt_advanced_nodes,
@@ -638,10 +639,25 @@ class ImageNodeMoveContractTests(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertIs(getattr(nodes, name), getattr(image_scaling, name))
 
+        self.assertFalse(hasattr(nodes, "_EasyUseAnimaAlignedDetailerHook"))
         self.assertIs(
-            nodes._EasyUseAnimaAlignedDetailerHook,
+            image_nodes._EasyUseAnimaAlignedDetailerHook,
             image_detailer._EasyUseAnimaAlignedDetailerHook,
         )
+        self.assertIs(
+            impact_detailer_nodes._EasyUseAnimaAlignedDetailerHook,
+            image_detailer._EasyUseAnimaAlignedDetailerHook,
+        )
+        aligned_hook = image_nodes.EasyUseAnimaDetailerAlignHook().build(
+            alignment="32",
+            detailer_hook="existing-hook",
+        )[0]
+        self.assertIsInstance(
+            aligned_hook,
+            image_detailer._EasyUseAnimaAlignedDetailerHook,
+        )
+        self.assertEqual(aligned_hook.base_hook, "existing-hook")
+        self.assertEqual(aligned_hook.alignment, 32)
         self.assertIs(
             nodes.EasyUseAnimaImageScaleByMultiple,
             image_nodes.EasyUseAnimaImageScaleByMultiple,
@@ -654,6 +670,9 @@ class ImageNodeMoveContractTests(unittest.TestCase):
 
     def test_package_loaded_root_nodes_image_objects_are_direct_canonical_aliases(self):
         with _loaded_package_entrypoint() as (_, package_nodes):
+            self.assertFalse(
+                hasattr(package_nodes, "_EasyUseAnimaAlignedDetailerHook")
+            )
             package_name = package_nodes.__package__
             package_scaling = sys.modules[f"{package_name}.easyuse_anima.image.scaling"]
             package_detailer = sys.modules[f"{package_name}.easyuse_anima.image.detailer"]
@@ -663,6 +682,9 @@ class ImageNodeMoveContractTests(unittest.TestCase):
             package_node_adapters = sys.modules[
                 f"{package_name}.easyuse_anima.nodes.image_nodes"
             ]
+            package_impact_adapters = sys.modules[
+                f"{package_name}.easyuse_anima.nodes.impact_detailer_nodes"
+            ]
             for name in self.SCALING_ALIASES:
                 with self.subTest(name=name):
                     self.assertIs(
@@ -671,7 +693,19 @@ class ImageNodeMoveContractTests(unittest.TestCase):
                     )
 
             self.assertIs(
-                package_nodes._EasyUseAnimaAlignedDetailerHook,
+                package_node_adapters._EasyUseAnimaAlignedDetailerHook,
+                package_detailer._EasyUseAnimaAlignedDetailerHook,
+            )
+            self.assertIs(
+                package_impact_adapters._EasyUseAnimaAlignedDetailerHook,
+                package_detailer._EasyUseAnimaAlignedDetailerHook,
+            )
+            aligned_hook = package_node_adapters.EasyUseAnimaDetailerAlignHook().build(
+                alignment="32",
+                detailer_hook=None,
+            )[0]
+            self.assertIs(
+                type(aligned_hook),
                 package_detailer._EasyUseAnimaAlignedDetailerHook,
             )
             for name in (

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,9 +73,9 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "53d9aa04736dbb22844813b82c3846f09fdef38b")
-        # Issue #184 B-10b1 retires one unsupported/test-only resource alias
-        # after the SAM3 production consumer moved to the canonical path.
+        self.assertEqual(report["git_blob_sha1"], "b1f49d3caf95ebda2dfeec46a9ded84179cef0c5")
+        # Issue #184 B-10b2 retires one unsupported/test-only Detailer hook
+        # alias after both production adapters moved to the canonical path.
         self.assertEqual(report["top_level"]["function_count"], 41)
         self.assertEqual(report["top_level"]["class_count"], 2)
         self.assertEqual(report["line_count"], 2_712)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -15,7 +15,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "3c7b857ebe249dcdc23292ad440a2cca9434406e"
+BASE_COMMIT = "8db89452428dd3816e215857724c97d0aba99dc3"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -56,6 +56,13 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "sqrt": "math:sqrt",
 }
 RETIRED_PRIVATE_BINDINGS = {
+    "_EasyUseAnimaAlignedDetailerHook": {
+        "canonical_target": (
+            "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook"
+        ),
+        "owner": "#184/#188 B-10b2",
+        "reason": "image and Impact Detailer adapters import the canonical owner",
+    },
     "_comfy_checkpoint_names": {
         "canonical_target": (
             "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names"
@@ -628,7 +635,7 @@ def _build_document() -> dict[str, Any]:
             "base_branch": "dev",
             "base_commit": BASE_COMMIT,
             "first_release": None,
-            "owner_tasks": ["#184", "#188", "B-10a", "B-10b1"],
+            "owner_tasks": ["#184", "#188", "B-10a", "B-10b1", "B-10b2"],
         },
         "enums": {
             "classifications": list(CLASSIFICATIONS),
@@ -640,7 +647,7 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 400,
+            "nodes_canonical_bindings": 399,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 3,


### PR DESCRIPTION
## 작업 성격

- 로드맵: B-10b2 private alias reduction
- 분류: **Contract/cleanup** (Move/Behavior 변경 없음)
- 기준: `dev` `8db89452428dd3816e215857724c97d0aba99dc3`
- 대상: root private alias `_EasyUseAnimaAlignedDetailerHook` 1개
- 선행 조건: B-10a audit와 B-10b1 retired-binding gate 통합
- 상태: 구현, 독립 리뷰, exact-head 공식 full 완료

## 작업 전 symbol / caller / alias / global-state inventory

### symbol과 canonical owner

- 현재 root alias는 `nodes.py` relative import와 flat fallback에 각각 한 번 존재한다.
- canonical owner는 `easyuse_anima.image.detailer._EasyUseAnimaAlignedDetailerHook`다.
- `easyuse_anima.nodes.image_nodes`와 `easyuse_anima.nodes.impact_detailer_nodes`는 이미 canonical 경로를 직접 import한다.
- root runtime 직접 load와 28개 binder의 문자열 resolver 소비는 모두 없다.

### caller와 compatibility 근거

- production caller:
  - `image_nodes.EasyUseAnimaDetailerAlignHook.build`
  - `impact_detailer_nodes._EasyUseAnimaImpactDetailerDelegate.doit`
- 두 caller 모두 canonical direct import를 사용한다.
- repository root consumer는 `tests/test_node_contracts.py`의 root/package identity assertion뿐이다.
- mapped node, workflow ID, public package entrypoint, canonical `__all__` 소비자는 없다.
- 확인된 외부 Python direct importer는 없다. underscore private class이지만 과거 B-04 문서에서 identity alias로 기록됐으므로, 실제 production/test inventory와 retired-binding gate를 함께 갱신한다.

### mutable/global state와 behavior 경계

- hook instance는 `base_hook`과 `alignment`만 보유하며 module global/cache/lock/resolver를 소유하지 않는다.
- canonical class 구현, construction, Impact delegation, crop-size alignment, class identity between canonical consumers는 변경하지 않는다.
- root/package alias 부재와 두 canonical consumer의 class identity를 테스트한다.

## allowed-file boundary

- `nodes.py`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`
- `tests/test_node_contracts.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_backend_baseline.json`
- `tests/fixtures/python_compatibility_surface.v1.json`

## 금지 범위와 blocker

- canonical production 모듈, `__init__.py`, mapped class, frontend/locale/workflow/Registry metadata는 변경하지 않는다.
- 다른 image/scaling/geometry alias를 함께 제거하지 않는다.
- active dirty `codex/feature-prompt-translation-runtime`의 `nodes.py` hunk는 약 1980/2406행이고 이번 alias는 341/854행이다. 해당 워크트리를 수정하지 않으며 hunk 경계가 겹치면 중단한다.
- 외부 지원 surface 또는 call-time monkeypatch 근거가 새로 확인되면 제거하지 않고 B-10a fixture를 정정한다.

## 예상 계약 변경

- canonical binding count: 400 -> 399
- retired private binding ledger: 1 -> 2
- `_EasyUseAnimaAlignedDetailerHook`의 root 재도입 차단
- analyzer fixture는 두 compatibility import edge 제거와 `nodes.py` hash만 반영

## 검증 계획

- compatibility surface, node contract, image/Impact adapter, nodes/backend analyzer focused unittest
- 독립 read-only diff review
- exact-head 공식 full 1회
- production behavior나 workflow-visible state를 변경하지 않으므로 별도 live queue는 실행하지 않는다.

## 구현 및 현재 검증

- relative-package/flat-fallback root alias 두 경로만 제거했다.
- canonical image/Impact adapters와 Detailer 구현은 변경하지 않았다.
- normal-package와 synthetic package-entrypoint에서 root alias 부재,
  canonical class identity, 실제 hook construction을 검증한다.
- focused unittest: 97 passed
- `git diff --check`: passed
- 독립 read-only review: findings 없음
- exact-head commit: `2ad23fe`
- 공식 full (`tools/check_custom_node.ps1 -Profile full`): passed
  - Python unittest: 871 passed
  - frontend: 114 JavaScript files, TypeScript 6.0.3
  - Pyright baseline ratchet: 60 files / 60 errors / 0 warnings (passed)
  - Python import boundary: 6 groups / 0 violations
  - `git diff --check`: passed
  - Ruff: 기존 G-01 report-only 105건, blocking failure 아님

## 롤백

이 cleanup squash commit 하나를 되돌리면 root private class alias와 test-only identity seam, 두 machine-readable fixture가 함께 복원된다. canonical class와 사용자 데이터에는 영향이 없다.
