### PR TITLE
refactor(backend): retire Impact delegate root alias (B-10b3)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `8db89452428dd3816e215857724c97d0aba99dc3`
+- Integrated `dev` snapshot commit: `743256a6f32a10f2fc8ad155960520e778d24a56`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-10b1; B-10b2 single-alias cleanup in review in PR #273 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
+| B - `nodes.py` extraction | Integrated through B-10b2; B-10b3 single-alias cleanup in review in PR #274 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -295,7 +295,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 10 | B-09b1 AiO legacy orchestration body move | COMPLETE on `dev` | Move | #184 | PR #269 / `7484dc7` |
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
-| 13 | B-10b private alias reduction | IN REVIEW: B-10b2 PR #273 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
+| 13 | B-10b private alias reduction | IN REVIEW: B-10b3 PR #274 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | BLOCKED by B-10b | Move | #184 | Supported alias surface frozen after scoped cleanup |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
@@ -621,8 +621,8 @@ reported as unexecuted, not passed.
 
 ### B-10b — Private alias reduction
 
-- **Status:** B-10b1 is complete on `dev` in PR #272 / `8db8945`; B-10b2 is
-  in review in PR #273 from that integrated base.
+- **Status:** B-10b1 and B-10b2 are complete on `dev` through PR #273 /
+  `743256a`; B-10b3 is in review in PR #274 from that integrated base.
 - **Type:** small compatibility cleanup PRs, one owner/surface at a time
 - Remove unsupported/test-only aliases after tests use canonical paths.
 - Retain an actual monkeypatch seam only when the consumer and call-time binding
@@ -642,6 +642,12 @@ flat root import surfaces. Both canonical production adapters already import
 `easyuse_anima.image.detailer` directly. Focused normal-package and synthetic
 package-entrypoint contracts retain their class identity and construction
 behavior without preserving a root-only private alias.
+
+B-10b3 removes only `_EasyUseAnimaImpactDetailerDelegate` from the relative and
+flat root import surfaces. The canonical SAM3 adapter already imports the
+delegate class directly from `easyuse_anima.nodes.impact_detailer_nodes`.
+Normal-package and synthetic package-entrypoint contracts retain class identity,
+`INPUT_TYPES`, and the existing canonical delegation path.
 
 ### B-11 — Registration, bootstrap, and final `nodes.py` shim
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,13 +3,13 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `8db89452428dd3816e215857724c97d0aba99dc3`
+  `743256a6f32a10f2fc8ad155960520e778d24a56`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-10b1 is integrated; B-10b2 in PR #273 removes one audited
-  unsupported/test-only Detailer hook root alias
+- Current state: B-10b2 is integrated; B-10b3 in PR #274 removes one audited
+  unsupported/test-only Impact delegate root alias
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -74,8 +74,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 399 at the
-  B-10b2 PR head, with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 398 at the
+  B-10b3 PR head, with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -87,8 +87,9 @@ inferring public support from spelling or test imports:
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 256, including
   literal lookups and binder-owned helper-name/default collections;
-- retired private bindings: `_comfy_checkpoint_names` and
-  `_EasyUseAnimaAlignedDetailerHook`; their production consumers import the
+- retired private bindings: `_comfy_checkpoint_names`,
+  `_EasyUseAnimaAlignedDetailerHook`, and
+  `_EasyUseAnimaImpactDetailerDelegate`; their production consumers import the
   corresponding canonical owners directly;
 - repository test files with a direct `nodes` import: 22, recorded as migration
   consumers rather than public-support evidence.
@@ -164,9 +165,8 @@ EasyUseAnimaWildcard
   explicit direct aliases to their canonical modules; they are not wrappers.
 - B-07f internal SAM3 transition: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer` remain direct root aliases to
-  `easyuse_anima.nodes.sam3_nodes`; `_EasyUseAnimaImpactDetailerDelegate`
-  remains a direct alias to `easyuse_anima.nodes.impact_detailer_nodes`. SAM3
-  resolver, formatting, context, mask/SEGS, and Impact-call helpers moved to
+  `easyuse_anima.nodes.sam3_nodes`. SAM3 resolver, formatting, context,
+  mask/SEGS, and Impact-call helpers moved to
   `easyuse_anima.image.sam3` and remain direct root aliases through the B-10
   compatibility audit. These names are internal transition surfaces for the
   root AiO caller, historical convenience-node compatibility, and focused
@@ -199,6 +199,11 @@ EasyUseAnimaWildcard
   canonical `easyuse_anima.image.detailer` class directly; normal-package and
   synthetic package-entrypoint tests preserve class identity and hook
   construction without a root-only private import.
+- B-10b3 Impact-delegate cleanup: `_EasyUseAnimaImpactDetailerDelegate` is no
+  longer a root alias. The SAM3 adapter already imports the canonical
+  `easyuse_anima.nodes.impact_detailer_nodes` class directly; normal-package
+  and synthetic package-entrypoint tests preserve class identity,
+  `INPUT_TYPES`, and the existing canonical delegation path.
 - B-08b2 internal AiO model-variant transition: Spectrum correction/forecast
   model patching and ephemeral model cleanup move to
   `easyuse_anima.aio.model_preparation`. Their four root private names remain

--- a/nodes.py
+++ b/nodes.py
@@ -391,7 +391,7 @@ try:
         EasyUseAnimaImageScaleByMultiple as EasyUseAnimaImageScaleByMultiple,
     )
     from .easyuse_anima.nodes.impact_detailer_nodes import (
-        _EasyUseAnimaImpactDetailerDelegate as _EasyUseAnimaImpactDetailerDelegate,
+        # B-10b3 deliberately omits the retired root Impact delegate alias.
         _bind_impact_detailer_node_runtime as _bind_impact_detailer_node_runtime,
     )
     from .easyuse_anima.nodes.sam3_nodes import (
@@ -904,7 +904,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         EasyUseAnimaImageScaleByMultiple as EasyUseAnimaImageScaleByMultiple,
     )
     from easyuse_anima.nodes.impact_detailer_nodes import (
-        _EasyUseAnimaImpactDetailerDelegate as _EasyUseAnimaImpactDetailerDelegate,
+        # B-10b3 deliberately omits the retired root Impact delegate alias.
         _bind_impact_detailer_node_runtime as _bind_impact_detailer_node_runtime,
     )
     from easyuse_anima.nodes.sam3_nodes import (

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -23543,37 +23543,6 @@
         "target": "easyuse_anima/nodes/image_nodes.py"
       },
       {
-        "alias": "_EasyUseAnimaImpactDetailerDelegate",
-        "bound_name": "_EasyUseAnimaImpactDetailerDelegate",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_EasyUseAnimaImpactDetailerDelegate",
-          "target": "easyuse_anima/nodes/impact_detailer_nodes.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
-        "kind": "static_from",
-        "line": 393,
-        "name": "_EasyUseAnimaImpactDetailerDelegate",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/impact_detailer_nodes.py"
-      },
-      {
         "alias": "_bind_impact_detailer_node_runtime",
         "bound_name": "_bind_impact_detailer_node_runtime",
         "branch_context": [
@@ -37706,40 +37675,6 @@
         "target": "easyuse_anima/nodes/image_nodes.py"
       },
       {
-        "alias": "_EasyUseAnimaImpactDetailerDelegate",
-        "bound_name": "_EasyUseAnimaImpactDetailerDelegate",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_EasyUseAnimaImpactDetailerDelegate",
-          "target": "easyuse_anima/nodes/impact_detailer_nodes.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
-        "kind": "static_from",
-        "line": 906,
-        "name": "_EasyUseAnimaImpactDetailerDelegate",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.impact_detailer_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/impact_detailer_nodes.py"
-      },
-      {
         "alias": "_bind_impact_detailer_node_runtime",
         "bound_name": "_bind_impact_detailer_node_runtime",
         "branch_context": [
@@ -44856,7 +44791,7 @@
         "is_package": false,
         "loc": 2712,
         "module": "nodes",
-        "normalized_git_blob_sha1": "b1f49d3caf95ebda2dfeec46a9ded84179cef0c5",
+        "normalized_git_blob_sha1": "33164f1faec2e4c7c40b7970cca51a6aea17581a",
         "path": "nodes.py",
         "top_level": {
           "class_count": 2,
@@ -53538,29 +53473,6 @@
         "role": "compatibility_fallback",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/image_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
-        "kind": "static_from",
-        "line": 906,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/impact_detailer_nodes.py"
       },
       {
         "branch_context": [

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,14 +2,15 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "8db89452428dd3816e215857724c97d0aba99dc3",
+    "base_commit": "743256a6f32a10f2fc8ad155960520e778d24a56",
     "first_release": null,
     "owner_tasks": [
       "#184",
       "#188",
       "B-10a",
       "B-10b1",
-      "B-10b2"
+      "B-10b2",
+      "B-10b3"
     ]
   },
   "enums": {
@@ -44,7 +45,7 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 399,
+    "nodes_canonical_bindings": 398,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 3,
@@ -1036,6 +1037,11 @@
     }
   },
   "retired_private_bindings": {
+    "_EasyUseAnimaImpactDetailerDelegate": {
+      "canonical_target": "easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
+      "owner": "#184/#188 B-10b3",
+      "reason": "SAM3 production adapter imports the canonical owner directly"
+    },
     "_EasyUseAnimaAlignedDetailerHook": {
       "canonical_target": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
       "owner": "#184/#188 B-10b2",
@@ -2287,35 +2293,6 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.impact_detailer_nodes:unsupported_test_only",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_EasyUseAnimaImpactDetailerDelegate": "_EasyUseAnimaImpactDetailerDelegate"
-      },
-      "classification": "unsupported_test_only",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.nodes.impact_detailer_nodes",
-      "target_state": "canonical",
-      "identity_requirement": "not_applicable",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.nodes.impact_detailer_nodes",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "repository tests may import this root name"
-      ],
-      "evidence": [
-        "AST:no nodes.py runtime load",
-        "test-only consumption is not public support evidence"
-      ],
-      "removal_gates": [
-        "test imports migrate to canonical targets",
-        "no production consumer evidence",
-        "separate B-10b removal review"
-      ],
-      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.lora_nodes:supported_public_reexport",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -562,9 +562,15 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
     def test_package_nodes_comfy_aliases_are_canonical_objects(self):
         with _loaded_package_entrypoint() as (_, package_nodes):
             self.assertFalse(hasattr(package_nodes, "_comfy_checkpoint_names"))
+            self.assertFalse(
+                hasattr(package_nodes, "_EasyUseAnimaImpactDetailerDelegate")
+            )
             package_name = package_nodes.__package__
             package_sam3_nodes = sys.modules[
                 f"{package_name}.easyuse_anima.nodes.sam3_nodes"
+            ]
+            package_impact_nodes = sys.modules[
+                f"{package_name}.easyuse_anima.nodes.impact_detailer_nodes"
             ]
             package_resources = sys.modules[
                 f"{package_name}.easyuse_anima.infrastructure.comfy.resources"
@@ -594,6 +600,42 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
             self.assertEqual(
                 input_types["required"]["ckpt_name"][1]["default"],
                 "package/sam3.safetensors",
+            )
+            self.assertIs(
+                package_sam3_nodes._EasyUseAnimaImpactDetailerDelegate,
+                package_impact_nodes._EasyUseAnimaImpactDetailerDelegate,
+            )
+            with (
+                patch.object(
+                    package_impact_nodes,
+                    "_comfy_max_resolution",
+                    return_value=8192,
+                ),
+                patch.object(
+                    package_impact_nodes,
+                    "_comfy_sampler_names",
+                    return_value=["package-sampler"],
+                ),
+                patch.object(
+                    package_impact_nodes,
+                    "_impact_scheduler_names",
+                    return_value=["package-scheduler"],
+                ),
+            ):
+                detailer_inputs = (
+                    package_sam3_nodes._EasyUseAnimaImpactDetailerDelegate.INPUT_TYPES()
+                )
+            self.assertEqual(
+                detailer_inputs["required"]["guide_size"][1]["max"],
+                8192,
+            )
+            self.assertEqual(
+                detailer_inputs["required"]["sampler_name"][0],
+                ["package-sampler"],
+            )
+            self.assertEqual(
+                detailer_inputs["required"]["scheduler"][0],
+                ["package-scheduler"],
             )
             package_helper_modules = (
                 (

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,9 +73,9 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "b1f49d3caf95ebda2dfeec46a9ded84179cef0c5")
-        # Issue #184 B-10b2 retires one unsupported/test-only Detailer hook
-        # alias after both production adapters moved to the canonical path.
+        self.assertEqual(report["git_blob_sha1"], "33164f1faec2e4c7c40b7970cca51a6aea17581a")
+        # Issue #184 B-10b3 retires one unsupported/test-only Impact delegate
+        # alias after the SAM3 adapter moved to the canonical class path.
         self.assertEqual(report["top_level"]["function_count"], 41)
         self.assertEqual(report["top_level"]["class_count"], 2)
         self.assertEqual(report["line_count"], 2_712)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -15,7 +15,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "8db89452428dd3816e215857724c97d0aba99dc3"
+BASE_COMMIT = "743256a6f32a10f2fc8ad155960520e778d24a56"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -56,6 +56,14 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "sqrt": "math:sqrt",
 }
 RETIRED_PRIVATE_BINDINGS = {
+    "_EasyUseAnimaImpactDetailerDelegate": {
+        "canonical_target": (
+            "easyuse_anima.nodes.impact_detailer_nodes:"
+            "_EasyUseAnimaImpactDetailerDelegate"
+        ),
+        "owner": "#184/#188 B-10b3",
+        "reason": "SAM3 production adapter imports the canonical owner directly",
+    },
     "_EasyUseAnimaAlignedDetailerHook": {
         "canonical_target": (
             "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook"
@@ -635,7 +643,14 @@ def _build_document() -> dict[str, Any]:
             "base_branch": "dev",
             "base_commit": BASE_COMMIT,
             "first_release": None,
-            "owner_tasks": ["#184", "#188", "B-10a", "B-10b1", "B-10b2"],
+            "owner_tasks": [
+                "#184",
+                "#188",
+                "B-10a",
+                "B-10b1",
+                "B-10b2",
+                "B-10b3",
+            ],
         },
         "enums": {
             "classifications": list(CLASSIFICATIONS),
@@ -647,7 +662,7 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 399,
+            "nodes_canonical_bindings": 398,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 3,

--- a/tests/test_sam3_nodes.py
+++ b/tests/test_sam3_nodes.py
@@ -72,10 +72,32 @@ class SAM3MoveTests(unittest.TestCase):
         for name in node_names:
             with self.subTest(name=name):
                 self.assertIs(getattr(nodes, name), getattr(sam3_nodes, name))
+        self.assertFalse(hasattr(nodes, "_EasyUseAnimaImpactDetailerDelegate"))
         self.assertIs(
-            nodes._EasyUseAnimaImpactDetailerDelegate,
+            sam3_nodes._EasyUseAnimaImpactDetailerDelegate,
             impact_detailer_nodes._EasyUseAnimaImpactDetailerDelegate,
         )
+        with (
+            patch.object(
+                impact_detailer_nodes,
+                "_comfy_max_resolution",
+                return_value=4096,
+            ),
+            patch.object(
+                impact_detailer_nodes,
+                "_comfy_sampler_names",
+                return_value=["sampler"],
+            ),
+            patch.object(
+                impact_detailer_nodes,
+                "_impact_scheduler_names",
+                return_value=["scheduler"],
+            ),
+        ):
+            input_types = sam3_nodes._EasyUseAnimaImpactDetailerDelegate.INPUT_TYPES()
+        self.assertEqual(input_types["required"]["guide_size"][1]["max"], 4096)
+        self.assertEqual(input_types["required"]["sampler_name"][0], ["sampler"])
+        self.assertEqual(input_types["required"]["scheduler"][0], ["scheduler"])
 
     def test_detection_prompt_formatting_is_preserved(self):
         self.assertEqual(


### PR DESCRIPTION
## 작업 성격

- 로드맵: B-10b3 private alias reduction
- 분류: **Contract/cleanup** (Move/Behavior 변경 없음)
- 기준: `dev` `743256a6f32a10f2fc8ad155960520e778d24a56`
- 대상: root private alias `_EasyUseAnimaImpactDetailerDelegate` 1개
- 선행 조건: B-10a audit와 B-10b1/B-10b2 retired-binding gate 통합
- 상태: 구현, 독립 리뷰, exact-head 공식 full 완료

## 작업 전 symbol / caller / alias / global-state inventory

### symbol과 canonical owner

- root alias는 `nodes.py` relative import와 flat fallback에 각각 한 번 존재한다.
- canonical owner는 `easyuse_anima.nodes.impact_detailer_nodes._EasyUseAnimaImpactDetailerDelegate`다.
- `easyuse_anima.nodes.sam3_nodes`는 canonical owner에서 class를 직접 import하고 `INPUT_TYPES` 및 `doit` 경로에서 사용한다.
- owner module의 `_bind_impact_detailer_node_runtime`은 `_comfy_max_resolution`과 `_impact_scheduler_names` dependency slot만 바인딩하며 delegate class를 조회하지 않는다.
- delegate 자체는 root runtime 직접 load, binder 문자열 resolver, helper-name/default collection 소비가 없다.

### caller와 compatibility 근거

- production caller는 canonical `sam3_nodes`의 `INPUT_TYPES`와 실제 detailer delegate 실행 경로다.
- repository root consumer는 `tests/test_sam3_nodes.py`의 identity assertion뿐이다.
- canonical behavior tests는 이미 `sam3_nodes._EasyUseAnimaImpactDetailerDelegate`를 직접 patch하여 입력 계약과 detailer 실행을 검증한다.
- mapped node, workflow ID, public package entrypoint, canonical `__all__` 소비자는 없다.
- 확인된 외부 Python direct importer는 없다. 외부 소비자 부재를 증명할 수 없으므로 underscore private surface와 실제 production/test inventory를 근거로 이 단일 alias만 제거한다.

### mutable/global state와 behavior 경계

- class 자체는 module cache, lock, resolver 또는 별도 mutable global state를 소유하지 않는다.
- canonical class 구현, `INPUT_TYPES`, Impact Pack lookup/delegation, 오류 시점과 결과 shape는 변경하지 않는다.
- root alias 부재와 canonical SAM3 consumer의 class identity/실제 delegate 호출을 normal-package 및 synthetic package-entrypoint 계약으로 고정한다.

## allowed-file boundary

- `nodes.py`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`
- `tests/test_sam3_nodes.py`
- `tests/test_node_contracts.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_backend_baseline.json`
- `tests/fixtures/python_compatibility_surface.v1.json`

## 금지 범위와 blocker

- canonical production module, `__init__.py`, mapped class, frontend/locale/workflow/Registry metadata는 변경하지 않는다.
- `_bind_impact_detailer_node_runtime`, `_impact_scheduler_names` 또는 다른 SAM3/Impact alias를 함께 제거하지 않는다.
- active dirty `codex/feature-prompt-translation-runtime`의 `nodes.py` 변경은 약 1983행 이후이며 이번 alias는 394/907행이다. 해당 워크트리를 수정하지 않고 hunk 경계가 겹치면 중단한다.
- 외부 지원 surface 또는 call-time monkeypatch 근거가 새로 확인되면 제거하지 않고 B-10a fixture를 정정한다.

## 예상 계약 변경

- canonical binding count: 399 -> 398
- retired private binding ledger: 2 -> 3
- `_EasyUseAnimaImpactDetailerDelegate`의 root 재도입 차단
- analyzer fixture는 두 compatibility import record 제거와 `nodes.py` hash만 반영하며 canonical Impact adapter dependency edge는 유지

## 검증 계획

- compatibility surface, SAM3/Impact adapter, package node contract, nodes/backend analyzer focused unittest
- 독립 read-only diff review
- exact-head 공식 full 1회
- production behavior나 workflow-visible state를 변경하지 않으므로 별도 live queue는 실행하지 않는다.

## 구현 및 현재 검증

- relative-package/flat-fallback root alias 두 경로만 제거했다.
- canonical SAM3/Impact adapter와 delegate 구현은 변경하지 않았다.
- normal-package와 synthetic package-entrypoint에서 root alias 부재,
  canonical class identity, 실제 `INPUT_TYPES` dependency resolution을 검증한다.
- focused unittest: 86 passed
- `git diff --check`: passed
- 독립 read-only review (`6973c40`): findings 없음. allowed-file 9개와 단일 alias 제거 경계를 확인했다.
- exact-head 공식 full (`6973c40`): passed
  - Python `unittest`: 871 passed
  - frontend: 114 JS files, TypeScript 6.0.3 passed
  - Pyright baseline: 60 files / 60 errors / 0 warnings / 0 info passed
  - import boundary: 6 groups / 0 violations
  - `git diff --check`: passed
  - Ruff: 기존 G01 105건 report-only, nonblocking

## 롤백

이 cleanup squash commit 하나를 되돌리면 root private class alias와 test-only identity seam, 두 machine-readable fixture가 함께 복원된다. canonical class와 사용자 데이터에는 영향이 없다.
