### PR TITLE
refactor(backend): retire Impact core root alias (B-10b4)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `743256a6f32a10f2fc8ad155960520e778d24a56`
+- Integrated `dev` snapshot commit: `5080210f1d156ade7b6b12cf989b3f958df150cb`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-10b2; B-10b3 single-alias cleanup in review in PR #274 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
+| B - `nodes.py` extraction | Integrated through B-10b3; B-10b4 single-alias cleanup in review in PR #275 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -295,7 +295,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 10 | B-09b1 AiO legacy orchestration body move | COMPLETE on `dev` | Move | #184 | PR #269 / `7484dc7` |
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
-| 13 | B-10b private alias reduction | IN REVIEW: B-10b3 PR #274 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
+| 13 | B-10b private alias reduction | IN REVIEW: B-10b4 PR #275 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | BLOCKED by B-10b | Move | #184 | Supported alias surface frozen after scoped cleanup |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
@@ -621,8 +621,8 @@ reported as unexecuted, not passed.
 
 ### B-10b — Private alias reduction
 
-- **Status:** B-10b1 and B-10b2 are complete on `dev` through PR #273 /
-  `743256a`; B-10b3 is in review in PR #274 from that integrated base.
+- **Status:** B-10b1 through B-10b3 are complete on `dev` through PR #274 /
+  `5080210`; B-10b4 is in review in PR #275 from that integrated base.
 - **Type:** small compatibility cleanup PRs, one owner/surface at a time
 - Remove unsupported/test-only aliases after tests use canonical paths.
 - Retain an actual monkeypatch seam only when the consumer and call-time binding
@@ -648,6 +648,13 @@ flat root import surfaces. The canonical SAM3 adapter already imports the
 delegate class directly from `easyuse_anima.nodes.impact_detailer_nodes`.
 Normal-package and synthetic package-entrypoint contracts retain class identity,
 `INPUT_TYPES`, and the existing canonical delegation path.
+
+B-10b4 removes only `_impact_core_module` from the relative and flat root
+import surfaces. The canonical `_impact_scheduler_names` implementation calls
+the helper in its own `easyuse_anima.infrastructure.comfy.capabilities` module;
+the root alias is test-only and is not a working call-time monkeypatch seam.
+Normal-package and synthetic package-entrypoint contracts retain canonical
+Impact discovery, scheduler lookup, and optional-dependency fallback behavior.
 
 ### B-11 — Registration, bootstrap, and final `nodes.py` shim
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,13 +3,13 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `743256a6f32a10f2fc8ad155960520e778d24a56`
+  `5080210f1d156ade7b6b12cf989b3f958df150cb`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-10b2 is integrated; B-10b3 in PR #274 removes one audited
-  unsupported/test-only Impact delegate root alias
+- Current state: B-10b3 is integrated; B-10b4 in PR #275 removes one audited
+  unsupported/test-only Impact core root alias
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -74,8 +74,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 398 at the
-  B-10b3 PR head, with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 397 at the
+  B-10b4 PR head, with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -89,8 +89,9 @@ inferring public support from spelling or test imports:
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
-  `_EasyUseAnimaImpactDetailerDelegate`; their production consumers import the
-  corresponding canonical owners directly;
+  `_EasyUseAnimaImpactDetailerDelegate`, plus `_impact_core_module`; their
+  production consumers import or call the corresponding canonical owners
+  directly;
 - repository test files with a direct `nodes` import: 22, recorded as migration
   consumers rather than public-support evidence.
 
@@ -175,12 +176,13 @@ EasyUseAnimaWildcard
 - B-08a internal AiO resource transition: resource default selection, ComfyUI
   model/CLIP/VAE/upscale loading, SAM3 context loading, and AiO resource bundle
   helpers move to `easyuse_anima.aio.resources`; Impact core/scheduler lookup
-  moves to `easyuse_anima.infrastructure.comfy.capabilities`. The twelve root
+  moves to `easyuse_anima.infrastructure.comfy.capabilities`. Eleven root
   private names remain direct identity aliases because the current root AiO,
   SAM3, Impact detailer, and normalization callers and their focused
-  monkeypatch seams still consume them. They remain internal transition
-  surfaces through the B-10 compatibility audit and are not added to public
-  package `__all__`.
+  monkeypatch seams still consume them. `_impact_core_module` is excluded after
+  B-10b4 because the canonical scheduler helper calls it within the same module
+  and the root alias was only a test identity seam. The remaining names stay
+  internal transition surfaces and are not added to public package `__all__`.
 - B-08b1 internal AiO model-preparation transition: LoRA normalization and
   application, AuraFlow/DAVE/Safe PAG/KJ base-model patching, and USDU
   conditioning preparation move to `easyuse_anima.aio.model_preparation` and
@@ -204,6 +206,11 @@ EasyUseAnimaWildcard
   `easyuse_anima.nodes.impact_detailer_nodes` class directly; normal-package
   and synthetic package-entrypoint tests preserve class identity,
   `INPUT_TYPES`, and the existing canonical delegation path.
+- B-10b4 Impact-core cleanup: `_impact_core_module` is no longer a root alias.
+  The canonical `_impact_scheduler_names` implementation calls the helper in
+  `easyuse_anima.infrastructure.comfy.capabilities` directly; normal-package
+  and synthetic package-entrypoint tests preserve Impact discovery, scheduler
+  lookup, and optional-dependency fallback behavior.
 - B-08b2 internal AiO model-variant transition: Spectrum correction/forecast
   model patching and ephemeral model cleanup move to
   `easyuse_anima.aio.model_preparation`. Their four root private names remain

--- a/nodes.py
+++ b/nodes.py
@@ -367,7 +367,7 @@ try:
         _comfy_scheduler_names as _comfy_scheduler_names,
         _find_comfy_node_class as _adapter_find_comfy_node_class,
         _find_loaded_node_class as _adapter_find_loaded_node_class,
-        _impact_core_module as _impact_core_module,
+        # B-10b4 omits the retired root _impact_core_module alias.
         _impact_scheduler_names as _impact_scheduler_names,
         _require_any_custom_node_class as _adapter_require_any_custom_node_class,
         _require_custom_node_class as _adapter_require_custom_node_class,
@@ -880,7 +880,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _comfy_scheduler_names as _comfy_scheduler_names,
         _find_comfy_node_class as _adapter_find_comfy_node_class,
         _find_loaded_node_class as _adapter_find_loaded_node_class,
-        _impact_core_module as _impact_core_module,
+        # B-10b4 omits the retired root _impact_core_module alias.
         _impact_scheduler_names as _impact_scheduler_names,
         _require_any_custom_node_class as _adapter_require_any_custom_node_class,
         _require_custom_node_class as _adapter_require_custom_node_class,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -23078,37 +23078,6 @@
         "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
       },
       {
-        "alias": "_impact_core_module",
-        "bound_name": "_impact_core_module",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_impact_core_module",
-          "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
-        "kind": "static_from",
-        "line": 364,
-        "name": "_impact_core_module",
-        "optional": false,
-        "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
         "alias": "_impact_scheduler_names",
         "bound_name": "_impact_scheduler_names",
         "branch_context": [
@@ -37165,40 +37134,6 @@
         "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
       },
       {
-        "alias": "_impact_core_module",
-        "bound_name": "_impact_core_module",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_impact_core_module",
-          "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
-        "kind": "static_from",
-        "line": 877,
-        "name": "_impact_core_module",
-        "optional": false,
-        "requested": "easyuse_anima.infrastructure.comfy.capabilities",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
         "alias": "_impact_scheduler_names",
         "bound_name": "_impact_scheduler_names",
         "branch_context": [
@@ -44791,7 +44726,7 @@
         "is_package": false,
         "loc": 2712,
         "module": "nodes",
-        "normalized_git_blob_sha1": "33164f1faec2e4c7c40b7970cca51a6aea17581a",
+        "normalized_git_blob_sha1": "b959d011728431cf26338f9a88e867ea39de18fb",
         "path": "nodes.py",
         "top_level": {
           "class_count": 2,
@@ -53122,29 +53057,6 @@
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
-        "kind": "static_from",
-        "line": 877,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
         "line": 877,
         "optional": false,

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "743256a6f32a10f2fc8ad155960520e778d24a56",
+    "base_commit": "5080210f1d156ade7b6b12cf989b3f958df150cb",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -10,7 +10,8 @@
       "B-10a",
       "B-10b1",
       "B-10b2",
-      "B-10b3"
+      "B-10b3",
+      "B-10b4"
     ]
   },
   "enums": {
@@ -45,7 +46,7 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 398,
+    "nodes_canonical_bindings": 397,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 3,
@@ -1037,6 +1038,11 @@
     }
   },
   "retired_private_bindings": {
+    "_impact_core_module": {
+      "canonical_target": "easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
+      "owner": "#184/#188 B-10b4",
+      "reason": "scheduler lookup calls the canonical owner directly"
+    },
     "_EasyUseAnimaImpactDetailerDelegate": {
       "canonical_target": "easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
       "owner": "#184/#188 B-10b3",
@@ -1827,35 +1833,6 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.capabilities:unsupported_test_only",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_impact_core_module": "_impact_core_module"
-      },
-      "classification": "unsupported_test_only",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.infrastructure.comfy.capabilities",
-      "target_state": "canonical",
-      "identity_requirement": "not_applicable",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.infrastructure.comfy.capabilities",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "repository tests may import this root name"
-      ],
-      "evidence": [
-        "AST:no nodes.py runtime load",
-        "test-only consumption is not public support evidence"
-      ],
-      "removal_gates": [
-        "test imports migrate to canonical targets",
-        "no production consumer evidence",
-        "separate B-10b removal review"
-      ],
-      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.invocation:transitional_private_seam",

--- a/tests/test_aio_resources.py
+++ b/tests/test_aio_resources.py
@@ -26,9 +26,8 @@ class AIOResourceMoveTests(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertIs(getattr(nodes, name), getattr(aio_resources, name))
 
-        for name in ("_impact_core_module", "_impact_scheduler_names"):
-            with self.subTest(name=name):
-                self.assertIs(getattr(nodes, name), getattr(capabilities, name))
+        self.assertFalse(hasattr(nodes, "_impact_core_module"))
+        self.assertIs(nodes._impact_scheduler_names, capabilities._impact_scheduler_names)
 
     def test_preferred_resource_defaults_preserve_exact_and_basename_order(self):
         names = ["models\\anima.safetensors", "fallback.safetensors"]

--- a/tests/test_comfy_adapters.py
+++ b/tests/test_comfy_adapters.py
@@ -328,7 +328,7 @@ class ComfyRootCompatibilityTests(unittest.TestCase):
         self.assertIs(nodes._folder_path_names, resources._folder_path_names)
         self.assertIs(nodes._node_output_tuple, invocation._node_output_tuple)
         self.assertIs(nodes._call_with_supported_kwargs, invocation._call_with_supported_kwargs)
-        self.assertIs(nodes._impact_core_module, capabilities._impact_core_module)
+        self.assertFalse(hasattr(nodes, "_impact_core_module"))
         self.assertIs(nodes._impact_scheduler_names, capabilities._impact_scheduler_names)
 
     def test_checkpoint_names_are_owned_by_the_canonical_sam3_consumer(self):

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -562,10 +562,14 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
     def test_package_nodes_comfy_aliases_are_canonical_objects(self):
         with _loaded_package_entrypoint() as (_, package_nodes):
             self.assertFalse(hasattr(package_nodes, "_comfy_checkpoint_names"))
+            self.assertFalse(hasattr(package_nodes, "_impact_core_module"))
             self.assertFalse(
                 hasattr(package_nodes, "_EasyUseAnimaImpactDetailerDelegate")
             )
             package_name = package_nodes.__package__
+            package_capabilities = sys.modules[
+                f"{package_name}.easyuse_anima.infrastructure.comfy.capabilities"
+            ]
             package_sam3_nodes = sys.modules[
                 f"{package_name}.easyuse_anima.nodes.sam3_nodes"
             ]
@@ -637,11 +641,21 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
                 detailer_inputs["required"]["scheduler"][0],
                 ["package-scheduler"],
             )
+            with patch.object(
+                package_capabilities,
+                "_impact_core_module",
+                return_value=types.SimpleNamespace(
+                    get_schedulers=lambda: ("package-impact",)
+                ),
+            ) as impact_core:
+                self.assertEqual(
+                    package_capabilities._impact_scheduler_names(),
+                    ["package-impact"],
+                )
+            impact_core.assert_called_once_with()
             package_helper_modules = (
                 (
-                    sys.modules[
-                        f"{package_name}.easyuse_anima.infrastructure.comfy.capabilities"
-                    ],
+                    package_capabilities,
                     self.DIRECT_HELPER_MODULES[0][1],
                 ),
                 (

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,9 +73,9 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "33164f1faec2e4c7c40b7970cca51a6aea17581a")
-        # Issue #184 B-10b3 retires one unsupported/test-only Impact delegate
-        # alias after the SAM3 adapter moved to the canonical class path.
+        self.assertEqual(report["git_blob_sha1"], "b959d011728431cf26338f9a88e867ea39de18fb")
+        # Issue #184 B-10b4 retires one unsupported/test-only Impact core alias
+        # after scheduler lookup was confirmed to call its canonical owner.
         self.assertEqual(report["top_level"]["function_count"], 41)
         self.assertEqual(report["top_level"]["class_count"], 2)
         self.assertEqual(report["line_count"], 2_712)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -15,7 +15,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "743256a6f32a10f2fc8ad155960520e778d24a56"
+BASE_COMMIT = "5080210f1d156ade7b6b12cf989b3f958df150cb"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -56,6 +56,13 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "sqrt": "math:sqrt",
 }
 RETIRED_PRIVATE_BINDINGS = {
+    "_impact_core_module": {
+        "canonical_target": (
+            "easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module"
+        ),
+        "owner": "#184/#188 B-10b4",
+        "reason": "scheduler lookup calls the canonical owner directly",
+    },
     "_EasyUseAnimaImpactDetailerDelegate": {
         "canonical_target": (
             "easyuse_anima.nodes.impact_detailer_nodes:"
@@ -650,6 +657,7 @@ def _build_document() -> dict[str, Any]:
                 "B-10b1",
                 "B-10b2",
                 "B-10b3",
+                "B-10b4",
             ],
         },
         "enums": {
@@ -662,7 +670,7 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 398,
+            "nodes_canonical_bindings": 397,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 3,


### PR DESCRIPTION
## 작업 성격

- 로드맵: B-10b4 private alias reduction
- 분류: **Contract/cleanup** (Move/Behavior 변경 없음)
- 기준: `dev` `5080210f1d156ade7b6b12cf989b3f958df150cb`
- 대상: root private alias `_impact_core_module` 1개
- 선행 조건: B-10a compatibility fixture와 B-10b1~B-10b3 retired-binding gate 통합
- 상태: 구현, 독립 리뷰, exact-head 공식 full 완료

## 작업 전 symbol / caller / alias / global-state inventory

### symbol과 canonical owner

- root alias는 `nodes.py` relative import와 flat fallback에 각각 한 번 존재한다.
- canonical owner는 `easyuse_anima.infrastructure.comfy.capabilities._impact_core_module`이다.
- 같은 canonical module의 `_impact_scheduler_names`가 `_impact_core_module()`을 직접 호출한다. root를 경유하지 않는다.
- compatibility fixture는 이 이름을 이미 `unsupported_test_only`로 분류하고, `nodes.py` runtime load가 없음을 기록한다.
- root runtime direct load, binder, string resolver, helper-name/default collection, call-time root monkeypatch 소비는 확인되지 않았다.

### caller와 compatibility 근거

- production caller는 canonical `capabilities._impact_scheduler_names`뿐이다.
- repository root consumers는 `tests/test_comfy_adapters.py`와 `tests/test_aio_resources.py`의 identity assertion뿐이다.
- root alias를 monkeypatch해도 canonical `_impact_scheduler_names`의 function globals에는 닿지 않으므로 실제 call-time compatibility seam이 아니다.
- canonical behavior tests는 `sys.modules["impact.core"]`, import fallback, missing-module 경로를 canonical owner에 직접 검증한다.
- mapped node, workflow ID, package entrypoint, canonical `__all__`, frontend/locale 소비자는 없다.
- 확인된 외부 Python direct importer는 없다. 외부 소비자 부재를 증명할 수 없으므로 underscore-private surface와 B-10a fixture/removal gate를 근거로 이 단일 alias만 제거한다.

### mutable/global state와 behavior 경계

- 함수는 `sys.modules`를 읽고 optional Impact Pack import fallback을 수행하지만 별도 cache, lock 또는 mutable state를 소유하지 않는다.
- canonical 구현, import 우선순위, optional dependency 실패 처리, scheduler fallback과 결과 shape는 변경하지 않는다.
- root alias 부재와 canonical scheduler consumer의 call-time lookup을 normal-package 및 synthetic package-entrypoint 계약으로 고정한다.

## allowed-file boundary

- `nodes.py`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`
- `tests/test_comfy_adapters.py`
- `tests/test_aio_resources.py`
- `tests/test_node_contracts.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_backend_baseline.json`
- `tests/fixtures/python_compatibility_surface.v1.json`

## 금지 범위와 blocker

- canonical capabilities module, `_impact_scheduler_names`, AiO/resource implementation, mapped class, `__init__.py`, frontend/locale/workflow/Registry metadata는 변경하지 않는다.
- image geometry/scaling aliases나 다른 Impact/AiO alias를 함께 제거하지 않는다.
- active dirty `codex/feature-prompt-translation-runtime` 워크트리를 수정하지 않는다. `nodes.py` hunk 경계가 겹치면 중단한다.
- production root consumer, external support surface 또는 call-time monkeypatch 근거가 새로 확인되면 제거하지 않고 B-10a fixture를 정정한다.

## 예상 계약 변경

- canonical binding count: 398 → 397
- retired private binding ledger: 3 → 4
- `_impact_core_module`의 root 재도입 차단
- analyzer fixture는 relative/flat compatibility import record 제거와 `nodes.py` hash만 반영한다. canonical `_impact_scheduler_names` → `_impact_core_module` dependency는 유지한다.
- B-08a 문서의 일괄 유지 설명은 core alias 제거와 scheduler alias 유지가 구분되도록 정정한다.

## 검증 계획

- canonical Comfy adapter, AiO resource, synthetic package-entrypoint, compatibility surface, nodes/backend analyzer focused `unittest`
- 독립 read-only diff review
- exact-head 공식 full 1회
- production behavior나 workflow-visible state를 변경하지 않으므로 별도 live queue는 실행하지 않는다.

## 구현 및 현재 검증

- relative-package/flat-fallback root alias 두 경로만 제거했다.
- canonical capabilities 구현과 `_impact_scheduler_names`는 변경하지 않았다.
- normal-package와 synthetic package-entrypoint에서 root alias 부재와 canonical scheduler lookup을 검증한다.
- focused `unittest`: 98 passed
- `git diff --check`: passed
- exact implementation head: `da0dc75`
- 독립 read-only review (`da0dc75`): findings 없음. allowed-file 10개와 단일 alias 제거 경계를 확인했다.
- exact-head 공식 full (`da0dc75`): passed
  - Python `unittest`: 871 passed
  - frontend: 114 JS files, TypeScript 6.0.3 passed
  - Pyright baseline: 60 files / 60 errors / 0 warnings / 0 info passed
  - import boundary: 6 groups / 0 violations
  - `git diff --check`: passed
  - Ruff: 기존 G01 105건 report-only, nonblocking

## 롤백

이 cleanup squash commit 하나를 되돌리면 root private function alias와 test-only identity seam, 두 machine-readable fixture가 함께 복원된다. canonical function과 사용자 데이터에는 영향이 없다.
