### PR TITLE
refactor(backend): retire AiO cache-clear root alias (B-10b7)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `44d338bbc4ea6322edc83ab03928e8d14b5d8775`
+- Integrated `dev` snapshot commit: `d36caf8af5b528a9f8ac6a80d5fc93f925784bf3`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-10b5; B-10b6 image-scaling cleanup in review in PR #277 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
+| B - `nodes.py` extraction | Integrated through B-10b6; B-10b7 AiO cache-clear alias cleanup in review in PR #278 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -295,7 +295,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 10 | B-09b1 AiO legacy orchestration body move | COMPLETE on `dev` | Move | #184 | PR #269 / `7484dc7` |
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
-| 13 | B-10b private alias reduction | IN REVIEW: B-10b6 PR #277 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
+| 13 | B-10b private alias reduction | IN REVIEW: B-10b7 PR #278 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | BLOCKED by B-10b | Move | #184 | Supported alias surface frozen after scoped cleanup |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
@@ -621,8 +621,8 @@ reported as unexecuted, not passed.
 
 ### B-10b — Private alias reduction
 
-- **Status:** B-10b1 through B-10b5 are complete on `dev` through PR #276 /
-  `44d338b`; B-10b6 is in review in PR #277 from that integrated base.
+- **Status:** B-10b1 through B-10b6 are complete on `dev` through PR #277 /
+  `d36caf8`; B-10b7 is in review in PR #278 from that integrated base.
 - **Type:** small compatibility cleanup PRs, one owner/surface at a time
 - Remove unsupported/test-only aliases after tests use canonical paths.
 - Retain an actual monkeypatch seam only when the consumer and call-time binding
@@ -669,6 +669,12 @@ flat root import surfaces. The canonical image adapter and scaling policy
 already call `easyuse_anima.image.scaling` directly. The two scaling constants
 remain root runtime-resolver seams, and the mapped image-scale node class stays
 a supported root re-export.
+
+B-10b7 removes only `_clear_aio_first_pass_cache` from the relative and flat
+root import surfaces. Repository tests call the canonical
+`easyuse_anima.aio.first_pass_cache` owner directly; no production caller,
+runtime resolver, or monkeypatch seam consumes the root function alias. Mutable
+cache state, binding, key, clone, get/put, LRU, and clear behavior stay unchanged.
 
 ### B-11 — Registration, bootstrap, and final `nodes.py` shim
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,13 +3,13 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `44d338bbc4ea6322edc83ab03928e8d14b5d8775`
+  `d36caf8af5b528a9f8ac6a80d5fc93f925784bf3`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-10b5 is integrated; B-10b6 in PR #277 removes one audited
-  unsupported/test-only image scaling root-alias group
+- Current state: B-10b6 is integrated; B-10b7 in PR #278 removes one audited
+  unsupported/test-only AiO cache-clear root alias
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -74,8 +74,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 390 at the
-  B-10b6 PR head, with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 389 at the
+  B-10b7 PR head, with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -92,7 +92,8 @@ inferring public support from spelling or test imports:
   `_EasyUseAnimaImpactDetailerDelegate`, plus `_impact_core_module`,
   `_align_up`, `_aligned_size_near_scale`, `_alignment_value`,
   `_image_scale_by_multiple_size`, `_max_long_edge_value`,
-  `_normalize_image_scale_options`, and `_scale_by_value`; their production
+  `_normalize_image_scale_options`, `_scale_by_value`, and
+  `_clear_aio_first_pass_cache`; their production
   consumers import or call the corresponding canonical owners directly;
 - repository test files with a direct `nodes` import: 21, recorded as migration
   consumers rather than public-support evidence.
@@ -227,6 +228,11 @@ EasyUseAnimaWildcard
   normal-package and synthetic package-entrypoint tests preserve size,
   max-edge, and legacy shifted-widget normalization behavior. The two scaling
   constants and mapped image-scale node class remain root compatibility seams.
+- B-10b7 AiO cache-clear cleanup: `_clear_aio_first_pass_cache` is no longer a
+  root alias. Repository tests call the canonical
+  `easyuse_anima.aio.first_pass_cache` owner directly; normal-package and
+  synthetic package-entrypoint tests reject the retired root name. Mutable
+  cache state and the remaining binder/resolver seams stay unchanged.
 - B-08b2 internal AiO model-variant transition: Spectrum correction/forecast
   model patching and ephemeral model cleanup move to
   `easyuse_anima.aio.model_preparation`. Their four root private names remain

--- a/nodes.py
+++ b/nodes.py
@@ -15,7 +15,7 @@ try:
         _AIO_FIRST_PASS_CACHE_ORDER as _AIO_FIRST_PASS_CACHE_ORDER,
         _aio_first_pass_cache_key as _aio_first_pass_cache_key,
         _bind_aio_first_pass_cache_runtime as _bind_aio_first_pass_cache_runtime,
-        _clear_aio_first_pass_cache as _clear_aio_first_pass_cache,
+        # B-10b7 retires the test-only root cache-clear function alias.
         _clone_aio_cache_value as _clone_aio_cache_value,
         _get_aio_first_pass_cache as _get_aio_first_pass_cache,
         _put_aio_first_pass_cache as _put_aio_first_pass_cache,
@@ -528,7 +528,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _AIO_FIRST_PASS_CACHE_ORDER as _AIO_FIRST_PASS_CACHE_ORDER,
         _aio_first_pass_cache_key as _aio_first_pass_cache_key,
         _bind_aio_first_pass_cache_runtime as _bind_aio_first_pass_cache_runtime,
-        _clear_aio_first_pass_cache as _clear_aio_first_pass_cache,
+        # B-10b7 retires the test-only root cache-clear function alias.
         _clone_aio_cache_value as _clone_aio_cache_value,
         _get_aio_first_pass_cache as _get_aio_first_pass_cache,
         _put_aio_first_pass_cache as _put_aio_first_pass_cache,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -13809,37 +13809,6 @@
         "target": "easyuse_anima/aio/first_pass_cache.py"
       },
       {
-        "alias": "_clear_aio_first_pass_cache",
-        "bound_name": "_clear_aio_first_pass_cache",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_clear_aio_first_pass_cache",
-          "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache",
-        "kind": "static_from",
-        "line": 12,
-        "name": "_clear_aio_first_pass_cache",
-        "optional": false,
-        "requested": ".easyuse_anima.aio.first_pass_cache",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/first_pass_cache.py"
-      },
-      {
         "alias": "_clone_aio_cache_value",
         "bound_name": "_clone_aio_cache_value",
         "branch_context": [
@@ -26743,40 +26712,6 @@
         "kind": "static_from",
         "line": 525,
         "name": "_bind_aio_first_pass_cache_runtime",
-        "optional": false,
-        "requested": "easyuse_anima.aio.first_pass_cache",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/first_pass_cache.py"
-      },
-      {
-        "alias": "_clear_aio_first_pass_cache",
-        "bound_name": "_clear_aio_first_pass_cache",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_clear_aio_first_pass_cache",
-          "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache",
-        "kind": "static_from",
-        "line": 525,
-        "name": "_clear_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
         "role": "compatibility_fallback",
@@ -44271,7 +44206,7 @@
         "is_package": false,
         "loc": 2712,
         "module": "nodes",
-        "normalized_git_blob_sha1": "6a7f4255583d94c4a7d84f7c81192f4f8f412447",
+        "normalized_git_blob_sha1": "50a1ef025ee43f0934324e947fc8a9b6d3125003",
         "path": "nodes.py",
         "top_level": {
           "class_count": 2,
@@ -45725,29 +45660,6 @@
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
-        "kind": "static_from",
-        "line": 525,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/first_pass_cache.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache",
         "kind": "static_from",
         "line": 525,
         "optional": false,

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "44d338bbc4ea6322edc83ab03928e8d14b5d8775",
+    "base_commit": "d36caf8af5b528a9f8ac6a80d5fc93f925784bf3",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -13,7 +13,8 @@
       "B-10b3",
       "B-10b4",
       "B-10b5",
-      "B-10b6"
+      "B-10b6",
+      "B-10b7"
     ]
   },
   "enums": {
@@ -48,7 +49,7 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 390,
+    "nodes_canonical_bindings": 389,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 3,
@@ -1040,6 +1041,11 @@
     }
   },
   "retired_private_bindings": {
+    "_clear_aio_first_pass_cache": {
+      "canonical_target": "easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache",
+      "owner": "#184/#188 B-10b7",
+      "reason": "tests call the canonical cache owner directly"
+    },
     "_image_scale_by_multiple_size": {
       "canonical_target": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
       "owner": "#184/#188 B-10b6",
@@ -1191,35 +1197,6 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.first_pass_cache:unsupported_test_only",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_clear_aio_first_pass_cache": "_clear_aio_first_pass_cache"
-      },
-      "classification": "unsupported_test_only",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.first_pass_cache",
-      "target_state": "canonical",
-      "identity_requirement": "not_applicable",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.first_pass_cache",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "repository tests may import this root name"
-      ],
-      "evidence": [
-        "AST:no nodes.py runtime load",
-        "test-only consumption is not public support evidence"
-      ],
-      "removal_gates": [
-        "test imports migrate to canonical targets",
-        "no production consumer evidence",
-        "separate B-10b removal review"
-      ],
-      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.generation_normalization:transitional_private_seam",

--- a/tests/test_aio_first_pass_cache.py
+++ b/tests/test_aio_first_pass_cache.py
@@ -20,7 +20,6 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
             "_AIO_FIRST_PASS_CACHE",
             "_AIO_FIRST_PASS_CACHE_ORDER",
             "_clone_aio_cache_value",
-            "_clear_aio_first_pass_cache",
             "_aio_first_pass_cache_key",
             "_get_aio_first_pass_cache",
             "_put_aio_first_pass_cache",

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -6,6 +6,7 @@ import unittest
 from unittest.mock import patch
 
 import nodes
+from easyuse_anima.aio import first_pass_cache
 from easyuse_anima.nodes import aio_nodes
 from tests.test_node_contracts import _loaded_package_entrypoint
 
@@ -29,6 +30,7 @@ class AIONodeContractTests(unittest.TestCase):
             nodes._require_easy_use_anima_input,
             aio_nodes._require_easy_use_anima_input,
         )
+        self.assertFalse(hasattr(nodes, "_clear_aio_first_pass_cache"))
 
         with _loaded_package_entrypoint() as (package_entrypoint, package_nodes):
             canonical_module = sys.modules[
@@ -59,6 +61,7 @@ class AIONodeContractTests(unittest.TestCase):
                 package_nodes._require_easy_use_anima_input,
                 canonical_module._require_easy_use_anima_input,
             )
+            self.assertFalse(hasattr(package_nodes, "_clear_aio_first_pass_cache"))
 
     def test_input_types_resolve_root_runtime_values_at_call_time(self):
         calls = []
@@ -2291,7 +2294,7 @@ class AIOFinalUpscaleStageTests(unittest.TestCase):
 
 class AIOGeneratorRuntimeTests(unittest.TestCase):
     def setUp(self):
-        nodes._clear_aio_first_pass_cache()
+        first_pass_cache._clear_aio_first_pass_cache()
 
     def _context(self):
         return {
@@ -2375,7 +2378,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
 
         for index, (backend, expected_model, expect_standalone_mod, expect_comfy_patch, expect_internal_mod) in enumerate(cases):
             with self.subTest(backend=backend):
-                nodes._clear_aio_first_pass_cache()
+                first_pass_cache._clear_aio_first_pass_cache()
                 context = self._context()
 
                 with (

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,9 +73,9 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "6a7f4255583d94c4a7d84f7c81192f4f8f412447")
-        # Issue #184 B-10b6 retires four unsupported/test-only image scaling
-        # aliases after production consumers moved to the canonical owner.
+        self.assertEqual(report["git_blob_sha1"], "50a1ef025ee43f0934324e947fc8a9b6d3125003")
+        # Issue #184 B-10b7 retires the unsupported/test-only cache-clear alias
+        # after repository tests moved to the canonical owner.
         self.assertEqual(report["top_level"]["function_count"], 41)
         self.assertEqual(report["top_level"]["class_count"], 2)
         self.assertEqual(report["line_count"], 2_712)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -15,7 +15,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "44d338bbc4ea6322edc83ab03928e8d14b5d8775"
+BASE_COMMIT = "d36caf8af5b528a9f8ac6a80d5fc93f925784bf3"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -56,6 +56,13 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "sqrt": "math:sqrt",
 }
 RETIRED_PRIVATE_BINDINGS = {
+    "_clear_aio_first_pass_cache": {
+        "canonical_target": (
+            "easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache"
+        ),
+        "owner": "#184/#188 B-10b7",
+        "reason": "tests call the canonical cache owner directly",
+    },
     "_image_scale_by_multiple_size": {
         "canonical_target": (
             "easyuse_anima.image.scaling:_image_scale_by_multiple_size"
@@ -701,6 +708,7 @@ def _build_document() -> dict[str, Any]:
                 "B-10b4",
                 "B-10b5",
                 "B-10b6",
+                "B-10b7",
             ],
         },
         "enums": {
@@ -713,7 +721,7 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 390,
+            "nodes_canonical_bindings": 389,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 3,


### PR DESCRIPTION
## 작업

- Task: B-10b7 / #184, #188
- 분류: Contract (private compatibility cleanup)
- Base SHA: `d36caf8af5b528a9f8ac6a80d5fc93f925784bf3`
- Final head SHA: `4b37d74bdc8dd7088569781735dec8ef0b441743`

## 구현 전 inventory

### symbol / owner

- 제거 대상: root `nodes.py`의 `_clear_aio_first_pass_cache` relative/flat direct alias 2곳
- canonical owner: `easyuse_anima.aio.first_pass_cache._clear_aio_first_pass_cache`
- 현재 분류: `unsupported_test_only`
- root production caller: 없음

### caller / test consumer

- `tests/test_aio_nodes.py`: 테스트 setup 및 subtest 사이 cache reset 2곳이 root alias를 호출
- `tests/test_aio_first_pass_cache.py`: root/canonical identity tuple에 1곳 포함
- canonical cache 동작 테스트는 이미 canonical owner를 직접 호출

### alias / compatibility

- 함수 자체는 canonical module에서 root runtime resolver를 통해 `_AIO_FIRST_PASS_CACHE`와 `_AIO_FIRST_PASS_CACHE_ORDER`를 비움
- 제거하려는 root 함수 alias는 resolver가 조회하는 이름도, production monkeypatch seam도 아님
- cache state globals, max-entry constant, clone/key/get/put 함수와 binder/resolver는 유지
- public mapped node class, workflow/API/persistence surface 변경 없음

### global state / lifecycle

- mutable cache 객체와 정리 순서, LRU 정책, clone/eviction 동작은 변경하지 않음
- `easyuse_anima/aio/first_pass_cache.py` production behavior는 수정하지 않음
- 테스트의 root cache state monkeypatch 계약은 유지하고 reset 호출만 canonical owner로 이동

## 허용 경계

- `nodes.py`
- `tests/test_aio_first_pass_cache.py`
- `tests/test_aio_nodes.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_backend_baseline.json`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 금지 경계

- cache key/entry count/LRU/clone/clear semantics 변경
- cache state owner 또는 runtime binder/resolver 변경
- AiO stage, seed, queue, workflow, API, frontend 동작 변경
- 다른 private alias 또는 public class re-export 정리
- B-11 registration/bootstrap Move와 혼합

## 검증

- focused `unittest`: cache, AiO adapter, analyzer, compatibility surface — 118 passed
- `git diff --check` — passed
- exact-head official full — passed
  - Python `unittest`: 871 passed
  - frontend: 114 JavaScript files, TypeScript 6.0.3
  - Pyright baseline: 60 files / 60 existing errors / no increase
  - import boundary: 6 groups / 0 violations
  - Ruff: 105 existing report-only findings
  - compile 및 `git diff --check`: passed
- 독립 read-only review: findings 없음
- live ComfyUI smoke: 동작 변경이 없는 private test-only alias cleanup이므로 미실행

## 롤백 / 잔여 부채

- 롤백은 위 단일 alias와 canonical test import 변경으로 제한
- B-11은 residual root implementation 및 남은 unsupported/test-only 그룹 때문에 계속 차단됨
