### PR TITLE
refactor(backend): retire wildcard note root alias (B-10b8)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `d36caf8af5b528a9f8ac6a80d5fc93f925784bf3`
+- Integrated `dev` snapshot commit: `e559f017ff112ef701951f5b79ad03e32cccc917`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-10b6; B-10b7 AiO cache-clear alias cleanup in review in PR #278 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
+| B - `nodes.py` extraction | Integrated through B-10b7; B-10b8 wildcard-note alias cleanup in review in PR #279 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -295,7 +295,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 10 | B-09b1 AiO legacy orchestration body move | COMPLETE on `dev` | Move | #184 | PR #269 / `7484dc7` |
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
-| 13 | B-10b private alias reduction | IN REVIEW: B-10b7 PR #278 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
+| 13 | B-10b private alias reduction | IN REVIEW: B-10b8 PR #279 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | BLOCKED by B-10b | Move | #184 | Supported alias surface frozen after scoped cleanup |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
@@ -621,8 +621,8 @@ reported as unexecuted, not passed.
 
 ### B-10b — Private alias reduction
 
-- **Status:** B-10b1 through B-10b6 are complete on `dev` through PR #277 /
-  `d36caf8`; B-10b7 is in review in PR #278 from that integrated base.
+- **Status:** B-10b1 through B-10b7 are complete on `dev` through PR #278 /
+  `e559f01`; B-10b8 is in review in PR #279 from that integrated base.
 - **Type:** small compatibility cleanup PRs, one owner/surface at a time
 - Remove unsupported/test-only aliases after tests use canonical paths.
 - Retain an actual monkeypatch seam only when the consumer and call-time binding
@@ -675,6 +675,12 @@ root import surfaces. Repository tests call the canonical
 `easyuse_anima.aio.first_pass_cache` owner directly; no production caller,
 runtime resolver, or monkeypatch seam consumes the root function alias. Mutable
 cache state, binding, key, clone, get/put, LRU, and clear behavior stay unchanged.
+
+B-10b8 removes only `WILDCARD_SEED_RANGE_NOTE` from the relative and flat root
+import surfaces. The canonical Wildcard adapter owns and consumes its immutable
+tooltip note directly; no production caller, runtime resolver, binder, mapping,
+or monkeypatch seam consumes the root alias. Wildcard parsing, populated text,
+mode, seed, tooltip content, and mapped class identity stay unchanged.
 
 ### B-11 — Registration, bootstrap, and final `nodes.py` shim
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,13 +3,13 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `d36caf8af5b528a9f8ac6a80d5fc93f925784bf3`
+  `e559f017ff112ef701951f5b79ad03e32cccc917`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-10b6 is integrated; B-10b7 in PR #278 removes one audited
-  unsupported/test-only AiO cache-clear root alias
+- Current state: B-10b7 is integrated; B-10b8 in PR #279 removes one audited
+  unsupported/test-only wildcard tooltip-note root alias
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -74,8 +74,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 389 at the
-  B-10b7 PR head, with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 388 at the
+  B-10b8 PR head, with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -93,7 +93,7 @@ inferring public support from spelling or test imports:
   `_align_up`, `_aligned_size_near_scale`, `_alignment_value`,
   `_image_scale_by_multiple_size`, `_max_long_edge_value`,
   `_normalize_image_scale_options`, `_scale_by_value`, and
-  `_clear_aio_first_pass_cache`; their production
+  `_clear_aio_first_pass_cache`, plus `WILDCARD_SEED_RANGE_NOTE`; their production
   consumers import or call the corresponding canonical owners directly;
 - repository test files with a direct `nodes` import: 21, recorded as migration
   consumers rather than public-support evidence.
@@ -233,6 +233,10 @@ EasyUseAnimaWildcard
   `easyuse_anima.aio.first_pass_cache` owner directly; normal-package and
   synthetic package-entrypoint tests reject the retired root name. Mutable
   cache state and the remaining binder/resolver seams stay unchanged.
+- B-10b8 wildcard-note cleanup: `WILDCARD_SEED_RANGE_NOTE` is no longer a root
+  alias. The canonical Wildcard adapter owns and consumes the immutable tooltip
+  string directly; normal-package and synthetic package-entrypoint tests reject
+  the retired root name while preserving the canonical tooltip and mapped class.
 - B-08b2 internal AiO model-variant transition: Spectrum correction/forecast
   model patching and ephemeral model cleanup move to
   `easyuse_anima.aio.model_preparation`. Their four root private names remain

--- a/nodes.py
+++ b/nodes.py
@@ -458,7 +458,7 @@ try:
     )
     from .easyuse_anima.nodes.wildcard_nodes import (
         EasyUseAnimaWildcard as EasyUseAnimaWildcard,
-        WILDCARD_SEED_RANGE_NOTE as WILDCARD_SEED_RANGE_NOTE,
+        # B-10b8 retires the test-only root wildcard-note alias.
         _bind_wildcard_node_runtime as _bind_wildcard_node_runtime,
     )
     from .easyuse_anima.lora.metadata import (
@@ -971,7 +971,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     )
     from easyuse_anima.nodes.wildcard_nodes import (
         EasyUseAnimaWildcard as EasyUseAnimaWildcard,
-        WILDCARD_SEED_RANGE_NOTE as WILDCARD_SEED_RANGE_NOTE,
+        # B-10b8 retires the test-only root wildcard-note alias.
         _bind_wildcard_node_runtime as _bind_wildcard_node_runtime,
     )
     from easyuse_anima.lora.metadata import (

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -24876,37 +24876,6 @@
         "target": "easyuse_anima/nodes/wildcard_nodes.py"
       },
       {
-        "alias": "WILDCARD_SEED_RANGE_NOTE",
-        "bound_name": "WILDCARD_SEED_RANGE_NOTE",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "WILDCARD_SEED_RANGE_NOTE",
-          "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
-        "kind": "static_from",
-        "line": 459,
-        "name": "WILDCARD_SEED_RANGE_NOTE",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.wildcard_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/wildcard_nodes.py"
-      },
-      {
         "alias": "_bind_wildcard_node_runtime",
         "bound_name": "_bind_wildcard_node_runtime",
         "branch_context": [
@@ -38858,40 +38827,6 @@
         "target": "easyuse_anima/nodes/wildcard_nodes.py"
       },
       {
-        "alias": "WILDCARD_SEED_RANGE_NOTE",
-        "bound_name": "WILDCARD_SEED_RANGE_NOTE",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "WILDCARD_SEED_RANGE_NOTE",
-          "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
-        "kind": "static_from",
-        "line": 972,
-        "name": "WILDCARD_SEED_RANGE_NOTE",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.wildcard_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/wildcard_nodes.py"
-      },
-      {
         "alias": "_bind_wildcard_node_runtime",
         "bound_name": "_bind_wildcard_node_runtime",
         "branch_context": [
@@ -44206,7 +44141,7 @@
         "is_package": false,
         "loc": 2712,
         "module": "nodes",
-        "normalized_git_blob_sha1": "50a1ef025ee43f0934324e947fc8a9b6d3125003",
+        "normalized_git_blob_sha1": "5dd028142914295ced6ea5d1c6e3e2d4ef73e0bc",
         "path": "nodes.py",
         "top_level": {
           "class_count": 2,
@@ -53871,29 +53806,6 @@
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
-        "kind": "static_from",
-        "line": 972,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/wildcard_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
         "line": 972,
         "optional": false,

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "d36caf8af5b528a9f8ac6a80d5fc93f925784bf3",
+    "base_commit": "e559f017ff112ef701951f5b79ad03e32cccc917",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -14,7 +14,8 @@
       "B-10b4",
       "B-10b5",
       "B-10b6",
-      "B-10b7"
+      "B-10b7",
+      "B-10b8"
     ]
   },
   "enums": {
@@ -49,7 +50,7 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 389,
+    "nodes_canonical_bindings": 388,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 3,
@@ -1041,6 +1042,11 @@
     }
   },
   "retired_private_bindings": {
+    "WILDCARD_SEED_RANGE_NOTE": {
+      "canonical_target": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
+      "owner": "#184/#188 B-10b8",
+      "reason": "canonical wildcard adapter owns and consumes the note directly"
+    },
     "_clear_aio_first_pass_cache": {
       "canonical_target": "easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache",
       "owner": "#184/#188 B-10b7",
@@ -2694,35 +2700,6 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.wildcard_nodes:unsupported_test_only",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "WILDCARD_SEED_RANGE_NOTE": "WILDCARD_SEED_RANGE_NOTE"
-      },
-      "classification": "unsupported_test_only",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.nodes.wildcard_nodes",
-      "target_state": "canonical",
-      "identity_requirement": "not_applicable",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.nodes.wildcard_nodes",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "repository tests may import this root name"
-      ],
-      "evidence": [
-        "AST:no nodes.py runtime load",
-        "test-only consumption is not public support evidence"
-      ],
-      "removal_gates": [
-        "test imports migrate to canonical targets",
-        "no production consumer evidence",
-        "separate B-10b removal review"
-      ],
-      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.advanced:transitional_private_seam",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -873,9 +873,12 @@ class WildcardNaiaMoveContractTests(unittest.TestCase):
             nodes.EasyUseAnimaNAIARandomPrompt,
             naia_nodes.EasyUseAnimaNAIARandomPrompt,
         )
-        self.assertIs(
-            nodes.WILDCARD_SEED_RANGE_NOTE,
+        self.assertFalse(hasattr(nodes, "WILDCARD_SEED_RANGE_NOTE"))
+        self.assertIn(
             wildcard_nodes.WILDCARD_SEED_RANGE_NOTE,
+            wildcard_nodes.EasyUseAnimaWildcard.INPUT_TYPES()["required"]["seed"][1][
+                "tooltip"
+            ],
         )
 
     def test_package_loaded_root_wildcard_naia_objects_are_direct_canonical_aliases(self):
@@ -905,6 +908,7 @@ class WildcardNaiaMoveContractTests(unittest.TestCase):
                 package_nodes.EasyUseAnimaNAIARandomPrompt,
                 package_naia_nodes.EasyUseAnimaNAIARandomPrompt,
             )
+            self.assertFalse(hasattr(package_nodes, "WILDCARD_SEED_RANGE_NOTE"))
 
 
 class LoraPresetMoveContractTests(unittest.TestCase):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,9 +73,9 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "50a1ef025ee43f0934324e947fc8a9b6d3125003")
-        # Issue #184 B-10b7 retires the unsupported/test-only cache-clear alias
-        # after repository tests moved to the canonical owner.
+        self.assertEqual(report["git_blob_sha1"], "5dd028142914295ced6ea5d1c6e3e2d4ef73e0bc")
+        # Issue #184 B-10b8 retires the unsupported/test-only wildcard-note
+        # alias after its root-only test assertion moved to the canonical owner.
         self.assertEqual(report["top_level"]["function_count"], 41)
         self.assertEqual(report["top_level"]["class_count"], 2)
         self.assertEqual(report["line_count"], 2_712)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -15,7 +15,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "d36caf8af5b528a9f8ac6a80d5fc93f925784bf3"
+BASE_COMMIT = "e559f017ff112ef701951f5b79ad03e32cccc917"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -56,6 +56,13 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "sqrt": "math:sqrt",
 }
 RETIRED_PRIVATE_BINDINGS = {
+    "WILDCARD_SEED_RANGE_NOTE": {
+        "canonical_target": (
+            "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE"
+        ),
+        "owner": "#184/#188 B-10b8",
+        "reason": "canonical wildcard adapter owns and consumes the note directly",
+    },
     "_clear_aio_first_pass_cache": {
         "canonical_target": (
             "easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache"
@@ -709,6 +716,7 @@ def _build_document() -> dict[str, Any]:
                 "B-10b5",
                 "B-10b6",
                 "B-10b7",
+                "B-10b8",
             ],
         },
         "enums": {
@@ -721,7 +729,7 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 389,
+            "nodes_canonical_bindings": 388,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 3,


### PR DESCRIPTION
## 작업

- Task: B-10b8 / #184, #188
- 분류: Contract (private compatibility cleanup)
- Base SHA: `e559f017ff112ef701951f5b79ad03e32cccc917`
- Final head SHA: `457e528dc36c0b78b925b8df16023ff7cb3029f7`

## 구현 전 inventory

### symbol / owner

- 제거 대상: root `nodes.py`의 `WILDCARD_SEED_RANGE_NOTE` relative/flat direct alias 2곳
- canonical owner: `easyuse_anima.nodes.wildcard_nodes.WILDCARD_SEED_RANGE_NOTE`
- 현재 분류: `unsupported_test_only`
- root production caller: 없음

### caller / alias

- repository root 소비는 `tests/test_node_contracts.py`의 normal-root identity assertion 1곳뿐
- canonical `EasyUseAnimaWildcard.INPUT_TYPES()`는 같은 module의 상수를 직접 사용
- Advanced/Regional Prompt Studio는 각 adapter module이 소유한 별도 설명 상수를 직접 사용
- runtime resolver, binder, monkeypatch, mapping, workflow consumer는 없음

### global state / behavior

- 제거 대상은 immutable 설명 문자열의 root 별칭이며 mutable state 없음
- canonical 설명 문자열과 Wildcard node tooltip/input/seed 동작은 수정하지 않음
- normal/synthetic root에서 별칭 부재를 고정하고 mapped public node class identity는 유지

## 허용 경계

- `nodes.py`
- `tests/test_node_contracts.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_backend_baseline.json`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 금지 경계

- wildcard parsing, expansion, populated-text, seed 또는 mode 동작 변경
- canonical tooltip 문구 변경이나 세 adapter의 상수 통합
- mapped `EasyUseAnimaWildcard` root re-export 제거
- 다른 private alias, legacy wildcard owner 또는 B-11 Move와 혼합

## 검증

- focused `unittest`: 147 passed
  - 명령: `python -m unittest tests.test_node_contracts tests.test_wildcards tests.test_nodes_module_analyzer tests.test_python_backend_analyzer tests.test_python_compatibility_surface`
  - 작업 경로: B-10b8 전용 worktree
  - 최초 sandbox 실행: `TEMP/TMP/TMPDIR=D:\ComfyUI\.codex_tmp\temp`; `tempfile` setup/cleanup의 WinError 5로 31 errors, assertion failure 없음
  - 분류 후 재실행: 작업 전용 `focused-temp`와 비샌드박스 runner에서 147 passed
- `git diff --check`: passed
- exact-head official full: passed
  - Python `unittest`: 871 passed
  - frontend: 114 JavaScript files, TypeScript 6.0.3
  - Pyright baseline: 60 files / 60 existing errors / no increase
  - import boundary: 6 groups / 0 violations
  - Ruff: 105 existing report-only findings
  - compile 및 `git diff --check`: passed
- 독립 read-only review: findings 없음
- live ComfyUI smoke: 동작 변경이 없는 private test-only 문자열 alias cleanup이므로 미실행

## 롤백 / 잔여 부채

- 롤백은 위 단일 alias와 root absence assertions로 제한
- B-11은 residual root implementation과 남은 compatibility cleanup 때문에 계속 차단됨
