### PR TITLE
refactor(backend): retire prompt field default root aliases (B-10b10)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `8deec4132c42e5851d586ded8cd4cd87a1137eb3`
+- Integrated `dev` snapshot commit: `8b99c03dac1a89317ea5f2738cf6b894fd751022`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-10b8; B-10b9 SAM3 helper alias cleanup in review in PR #280 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
+| B - `nodes.py` extraction | Integrated through B-10b9; B-10b10 prompt-default alias cleanup in review in PR #281 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -295,7 +295,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 10 | B-09b1 AiO legacy orchestration body move | COMPLETE on `dev` | Move | #184 | PR #269 / `7484dc7` |
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
-| 13 | B-10b private alias reduction | IN REVIEW: B-10b9 PR #280 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
+| 13 | B-10b private alias reduction | IN REVIEW: B-10b10 PR #281 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | BLOCKED by B-10b | Move | #184 | Supported alias surface frozen after scoped cleanup |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
@@ -621,8 +621,8 @@ reported as unexecuted, not passed.
 
 ### B-10b — Private alias reduction
 
-- **Status:** B-10b1 through B-10b8 are complete on `dev` through PR #279 /
-  `8deec41`; B-10b9 is in review in PR #280 from that integrated base.
+- **Status:** B-10b1 through B-10b9 are complete on `dev` through PR #280 /
+  `8b99c03`; B-10b10 is in review in PR #281 from that integrated base.
 - **Type:** small compatibility cleanup PRs, one owner/surface at a time
 - Remove unsupported/test-only aliases after tests use canonical paths.
 - Retain an actual monkeypatch seam only when the consumer and call-time binding
@@ -689,6 +689,12 @@ B-10b9 removes only `_call_impact_detailer`, `_empty_mask_for_image`,
 surfaces. Canonical SAM3 and Impact adapters already import their owner
 directly. Context/state helpers and the runtime binder remain root seams;
 resolver timing, prompt formatting, masks/SEGS, and Impact delegation do not change.
+
+B-10b10 removes only `DEFAULT_QUALITY_TAGS` and
+`DEFAULT_TRAILING_QUALITY_TAGS` from the relative and flat root import
+surfaces. Canonical Prompt Builder/Studio and advanced-prompt consumers already
+import the immutable defaults from `easyuse_anima.prompt.fields` directly. The
+stored strings, input defaults, workflow schema, and prompt behavior do not change.
 
 ### B-11 — Registration, bootstrap, and final `nodes.py` shim
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,13 +3,13 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `8deec4132c42e5851d586ded8cd4cd87a1137eb3`
+  `8b99c03dac1a89317ea5f2738cf6b894fd751022`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-10b8 is integrated; B-10b9 in PR #280 removes one audited
-  unsupported/test-only SAM3 helper root-alias group
+- Current state: B-10b9 is integrated; B-10b10 in PR #281 removes one audited
+  unsupported/test-only prompt-default root-alias group
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -74,8 +74,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 381 at the
-  B-10b9 PR head, with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 379 at the
+  B-10b10 PR head, with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -93,8 +93,8 @@ inferring public support from spelling or test imports:
   `_align_up`, `_aligned_size_near_scale`, `_alignment_value`,
   `_image_scale_by_multiple_size`, `_max_long_edge_value`,
   `_normalize_image_scale_options`, `_scale_by_value`, and
-  `_clear_aio_first_pass_cache`, plus `WILDCARD_SEED_RANGE_NOTE` and the seven
-  B-10b9 SAM3 helpers; their production
+  `_clear_aio_first_pass_cache`, plus `WILDCARD_SEED_RANGE_NOTE`, the seven
+  B-10b9 SAM3 helpers, and the two B-10b10 prompt-default constants; their production
   consumers import or call the corresponding canonical owners directly;
 - repository test files with a direct `nodes` import: 21, recorded as migration
   consumers rather than public-support evidence.
@@ -245,6 +245,12 @@ EasyUseAnimaWildcard
   root aliases. Canonical SAM3 and Impact adapters import the owner directly;
   normal-package and synthetic package tests reject the retired names while
   preserving resolver timing, formatting, masks/SEGS, and delegation contracts.
+- B-10b10 prompt-default cleanup: `DEFAULT_QUALITY_TAGS` and
+  `DEFAULT_TRAILING_QUALITY_TAGS` are no longer root aliases. Prompt Builder,
+  Prompt Studio, and advanced-prompt consumers import their immutable defaults
+  directly from `easyuse_anima.prompt.fields`; normal-package and synthetic
+  package tests reject the retired names while preserving the exact strings and
+  input defaults.
 - B-08b2 internal AiO model-variant transition: Spectrum correction/forecast
   model patching and ephemeral model cleanup move to
   `easyuse_anima.aio.model_preparation`. Their four root private names remain

--- a/nodes.py
+++ b/nodes.py
@@ -120,8 +120,8 @@ try:
         _translate_prompt_text as _translate_prompt_text,
     )
     from .easyuse_anima.prompt.fields import (
-        DEFAULT_QUALITY_TAGS as DEFAULT_QUALITY_TAGS,
-        DEFAULT_TRAILING_QUALITY_TAGS as DEFAULT_TRAILING_QUALITY_TAGS,
+        # B-10b10 retires the two prompt-default root aliases.
+        # Canonical prompt consumers import their immutable defaults directly.
         _HASH_COMMENT_RE as _HASH_COMMENT_RE,
         _INLINE_SPACE_RE as _INLINE_SPACE_RE,
         _WEIGHTED_TOKEN_RE as _WEIGHTED_TOKEN_RE,
@@ -633,8 +633,8 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _translate_prompt_text as _translate_prompt_text,
     )
     from easyuse_anima.prompt.fields import (
-        DEFAULT_QUALITY_TAGS as DEFAULT_QUALITY_TAGS,
-        DEFAULT_TRAILING_QUALITY_TAGS as DEFAULT_TRAILING_QUALITY_TAGS,
+        # B-10b10 retires the two prompt-default root aliases.
+        # Canonical prompt consumers import their immutable defaults directly.
         _HASH_COMMENT_RE as _HASH_COMMENT_RE,
         _INLINE_SPACE_RE as _INLINE_SPACE_RE,
         _WEIGHTED_TOKEN_RE as _WEIGHTED_TOKEN_RE,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -16227,68 +16227,6 @@
         "target": "easyuse_anima/prompt/correction.py"
       },
       {
-        "alias": "DEFAULT_QUALITY_TAGS",
-        "bound_name": "DEFAULT_QUALITY_TAGS",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "DEFAULT_QUALITY_TAGS",
-          "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
-        "kind": "static_from",
-        "line": 122,
-        "name": "DEFAULT_QUALITY_TAGS",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.fields",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/fields.py"
-      },
-      {
-        "alias": "DEFAULT_TRAILING_QUALITY_TAGS",
-        "bound_name": "DEFAULT_TRAILING_QUALITY_TAGS",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "DEFAULT_TRAILING_QUALITY_TAGS",
-          "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
-        "kind": "static_from",
-        "line": 122,
-        "name": "DEFAULT_TRAILING_QUALITY_TAGS",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.fields",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/fields.py"
-      },
-      {
         "alias": "_HASH_COMMENT_RE",
         "bound_name": "_HASH_COMMENT_RE",
         "branch_context": [
@@ -29122,74 +29060,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/prompt/correction.py"
-      },
-      {
-        "alias": "DEFAULT_QUALITY_TAGS",
-        "bound_name": "DEFAULT_QUALITY_TAGS",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "DEFAULT_QUALITY_TAGS",
-          "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
-        "kind": "static_from",
-        "line": 635,
-        "name": "DEFAULT_QUALITY_TAGS",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.fields",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/fields.py"
-      },
-      {
-        "alias": "DEFAULT_TRAILING_QUALITY_TAGS",
-        "bound_name": "DEFAULT_TRAILING_QUALITY_TAGS",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "DEFAULT_TRAILING_QUALITY_TAGS",
-          "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
-        "kind": "static_from",
-        "line": 635,
-        "name": "DEFAULT_TRAILING_QUALITY_TAGS",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.fields",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/fields.py"
       },
       {
         "alias": "_HASH_COMMENT_RE",
@@ -43686,7 +43556,7 @@
         "is_package": false,
         "loc": 2712,
         "module": "nodes",
-        "normalized_git_blob_sha1": "04e04a6baf22caf9cbaa6fb27c40f63262d8968b",
+        "normalized_git_blob_sha1": "bd8fa79c8c14aa4cc6ee2fcbda7224d42d39f2f2",
         "path": "nodes.py",
         "top_level": {
           "class_count": 2,
@@ -46940,52 +46810,6 @@
         "role": "compatibility_fallback",
         "source": "nodes.py",
         "target": "easyuse_anima/prompt/correction.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
-        "kind": "static_from",
-        "line": 635,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/fields.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
-        "kind": "static_from",
-        "line": 635,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/fields.py"
       },
       {
         "branch_context": [

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "8deec4132c42e5851d586ded8cd4cd87a1137eb3",
+    "base_commit": "8b99c03dac1a89317ea5f2738cf6b894fd751022",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -16,7 +16,8 @@
       "B-10b6",
       "B-10b7",
       "B-10b8",
-      "B-10b9"
+      "B-10b9",
+      "B-10b10"
     ]
   },
   "enums": {
@@ -51,7 +52,7 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 381,
+    "nodes_canonical_bindings": 379,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 3,
@@ -1043,6 +1044,16 @@
     }
   },
   "retired_private_bindings": {
+    "DEFAULT_QUALITY_TAGS": {
+      "canonical_target": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
+      "owner": "#184/#188 B-10b10",
+      "reason": "canonical prompt consumers import the immutable default directly"
+    },
+    "DEFAULT_TRAILING_QUALITY_TAGS": {
+      "canonical_target": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
+      "owner": "#184/#188 B-10b10",
+      "reason": "canonical prompt consumers import the immutable default directly"
+    },
     "_call_impact_detailer": {
       "canonical_target": "easyuse_anima.image.sam3:_call_impact_detailer",
       "owner": "#184/#188 B-10b9",
@@ -3199,36 +3210,6 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.prompt.fields:unsupported_test_only",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "DEFAULT_QUALITY_TAGS": "DEFAULT_QUALITY_TAGS",
-        "DEFAULT_TRAILING_QUALITY_TAGS": "DEFAULT_TRAILING_QUALITY_TAGS"
-      },
-      "classification": "unsupported_test_only",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.prompt.fields",
-      "target_state": "canonical",
-      "identity_requirement": "not_applicable",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.prompt.fields",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "repository tests may import this root name"
-      ],
-      "evidence": [
-        "AST:no nodes.py runtime load",
-        "test-only consumption is not public support evidence"
-      ],
-      "removal_gates": [
-        "test imports migrate to canonical targets",
-        "no production consumer evidence",
-        "separate B-10b removal review"
-      ],
-      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.regional:transitional_private_seam",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1356,9 +1356,11 @@ print(json.dumps({{
 
 
 class PromptBuilderStudioMoveContractTests(unittest.TestCase):
-    FIELD_OBJECTS = (
+    RETIRED_FIELD_DEFAULTS = (
         "DEFAULT_QUALITY_TAGS",
         "DEFAULT_TRAILING_QUALITY_TAGS",
+    )
+    FIELD_OBJECTS = (
         "_HASH_COMMENT_RE",
         "_INLINE_SPACE_RE",
         "_WEIGHTED_TOKEN_RE",
@@ -1375,6 +1377,9 @@ class PromptBuilderStudioMoveContractTests(unittest.TestCase):
     )
 
     def test_root_prompt_builder_studio_objects_are_direct_canonical_aliases(self):
+        for name in self.RETIRED_FIELD_DEFAULTS:
+            with self.subTest(retired=name):
+                self.assertFalse(hasattr(nodes, name))
         for name in self.FIELD_OBJECTS:
             with self.subTest(module="fields", name=name):
                 self.assertIs(getattr(nodes, name), getattr(prompt_fields, name))
@@ -1390,6 +1395,9 @@ class PromptBuilderStudioMoveContractTests(unittest.TestCase):
                 f"{package_name}.easyuse_anima.nodes.prompt_nodes"
             ]
 
+            for name in self.RETIRED_FIELD_DEFAULTS:
+                with self.subTest(retired=name):
+                    self.assertFalse(hasattr(package_nodes, name))
             for name in self.FIELD_OBJECTS:
                 with self.subTest(module="fields", name=name):
                     self.assertIs(getattr(package_nodes, name), getattr(package_fields, name))

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,8 +73,8 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "04e04a6baf22caf9cbaa6fb27c40f63262d8968b")
-        # Issue #184 B-10b9 retires seven unsupported/test-only SAM3 helpers
+        self.assertEqual(report["git_blob_sha1"], "bd8fa79c8c14aa4cc6ee2fcbda7224d42d39f2f2")
+        # Issue #184 B-10b10 retires two unsupported/test-only prompt defaults
         # after production and tests use the canonical owner directly.
         self.assertEqual(report["top_level"]["function_count"], 41)
         self.assertEqual(report["top_level"]["class_count"], 2)

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -13,6 +13,10 @@ from unittest.mock import patch
 
 import autocomplete_dataset
 import settings as easyuse_settings
+from easyuse_anima.prompt.fields import (
+    DEFAULT_QUALITY_TAGS,
+    DEFAULT_TRAILING_QUALITY_TAGS,
+)
 from nodes import (
     ADVANCED_FIELDS_WORKFLOW_PROPERTY,
     ADVANCED_RESOLUTION_BUCKETS,
@@ -26,8 +30,6 @@ from nodes import (
     ARTIST_TAG_POSITION_BACK,
     ARTIST_TAG_POSITION_CORRECT,
     ARTIST_TAG_POSITION_FRONT,
-    DEFAULT_QUALITY_TAGS,
-    DEFAULT_TRAILING_QUALITY_TAGS,
     PROMPT_DATA_SCHEMA,
     PROMPT_DATA_TYPE,
     EasyUseAnimaArtistMixConditioning,

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -15,7 +15,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "8deec4132c42e5851d586ded8cd4cd87a1137eb3"
+BASE_COMMIT = "8b99c03dac1a89317ea5f2738cf6b894fd751022"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -56,6 +56,18 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "sqrt": "math:sqrt",
 }
 RETIRED_PRIVATE_BINDINGS = {
+    "DEFAULT_QUALITY_TAGS": {
+        "canonical_target": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
+        "owner": "#184/#188 B-10b10",
+        "reason": "canonical prompt consumers import the immutable default directly",
+    },
+    "DEFAULT_TRAILING_QUALITY_TAGS": {
+        "canonical_target": (
+            "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS"
+        ),
+        "owner": "#184/#188 B-10b10",
+        "reason": "canonical prompt consumers import the immutable default directly",
+    },
     "_call_impact_detailer": {
         "canonical_target": "easyuse_anima.image.sam3:_call_impact_detailer",
         "owner": "#184/#188 B-10b9",
@@ -757,6 +769,7 @@ def _build_document() -> dict[str, Any]:
                 "B-10b7",
                 "B-10b8",
                 "B-10b9",
+                "B-10b10",
             ],
         },
         "enums": {
@@ -769,7 +782,7 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 381,
+            "nodes_canonical_bindings": 379,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 3,


### PR DESCRIPTION
## 변경 요약

Issue #184/#188의 B-10b10 Contract 정리입니다. easyuse_anima.prompt.fields가 소유한 기본 프롬프트 상수 2개의 unsupported/test-only root alias만 제거합니다.

- DEFAULT_QUALITY_TAGS
- DEFAULT_TRAILING_QUALITY_TAGS

상수 값, canonical owner, Prompt Builder/Studio 입력 기본값, advanced prompt 소비 경로, workflow schema와 프롬프트 동작은 변경하지 않습니다.

## 작업 전 inventory

### Symbols / alias shape

- canonical owner: easyuse_anima.prompt.fields
- nodes.py의 relative-package 및 flat-fallback import branch에 같은 이름으로 직접 결합
- compatibility classification: unsupported_test_only

### Callers / consumers

- canonical production:
  - easyuse_anima.prompt.advanced가 owner를 직접 import
  - easyuse_anima.nodes.prompt_nodes가 owner를 직접 import
- root test:
  - tests/test_node_contracts.py의 normal/synthetic-package identity loop
  - tests/test_prompt_corrector.py의 root import 및 INPUT_TYPES 기본값 비교
- production root caller, runtime resolver, binder, mapping consumer: 없음

### Global state / monkeypatch seams

- 두 값은 immutable 문자열 상수
- mutable global state, binder, resolver, late binding, root monkeypatch 소비 없음
- 저장 workflow의 문자열 값과 노드 기본값은 canonical 상수를 계속 사용

## Allowed-file boundary

- nodes.py
- tests/test_prompt_corrector.py
- tests/test_node_contracts.py
- tests/test_nodes_module_analyzer.py
- tests/test_python_compatibility_surface.py
- tests/fixtures/python_backend_baseline.json
- tests/fixtures/python_compatibility_surface.v1.json
- docs/architecture/python-backend-execution-roadmap.md
- docs/architecture/python-compatibility-shims.md

## 구현

- 두 root import alias를 relative/flat branch에서 제거
- Prompt Corrector 테스트가 canonical owner에서 상수를 import하도록 변경
- normal/synthetic package root에서 두 이름의 부재를 계약으로 고정
- compatibility retired ledger에 B-10b10 2건 기록
- analyzer/compatibility fixture와 roadmap/shim 문서를 exact delta로 갱신

## 검증

Exact head: 922d395f1ca6e855f638260507bd638469942698

### Focused unittest

python -m unittest tests.test_node_contracts tests.test_prompt_corrector tests.test_python_compatibility_surface tests.test_nodes_module_analyzer tests.test_python_backend_analyzer tests.test_python_package_skeleton

- 217 tests passed

### Official full checkpoint

tools/check_project.ps1 -Profile full

- Python unittest: 871 passed
- Frontend: 114 JavaScript files passed
- Pyright baseline: 60 files / 60 known errors / no increase
- Python import boundary: 6 completed groups / 0 violations
- Python compile and git diff check: passed
- Ruff: 105 existing findings, G-01 report-only; blocking execution/configuration failure 없음

### Exact fixture delta

- backend import edges: 1560 -> 1556, 두 심볼의 relative/flat 4건만 제거
- compatibility fallback registry: 466 -> 464, flat fallback 2건만 제거
- canonical bindings: 381 -> 379
- groups: 67 -> 66
- unsupported groups: 10 -> 9
- retired bindings: 20 -> 22
- state, side effects, public root, mappings, residuals, binders: unchanged

### Review

- 독립 read-only diff review: findings 없음
- dirty sibling prompt-translation worktree와 hunk/semantic overlap 없음

## 테스트 표면

- ComfyUI Codex test environment: repository full runner
- Live ComfyUI/browser smoke: 실행하지 않음; canonical runtime 구현과 frontend는 변경하지 않은 Contract-only cleanup

## 위험 / rollback

외부 코드가 비공개 nodes root 상수를 직접 import했다면 실패할 수 있습니다. 지원 canonical 경로 easyuse_anima.prompt.fields에는 두 상수가 그대로 유지됩니다. 문제가 있으면 이 PR의 root alias 제거와 retired metadata/test 변경만 한 단위로 되돌릴 수 있습니다.

## 다음 단계

B-11은 아직 남은 unsupported/test-only 및 root residual/runtime seam 감사 때문에 진입하지 않습니다. B-10b의 다음 단일-owner 후보를 별도 PR에서 재검토합니다.