### PR TITLE
refactor(backend): retire Prompt Studio Extend root alias (B-10b11)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `8b99c03dac1a89317ea5f2738cf6b894fd751022`
+- Integrated `dev` snapshot commit: `6a6fe14d26e0d30b59ee18c55fe25591b93b15e4`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-10b9; B-10b10 prompt-default alias cleanup in review in PR #281 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
+| B - `nodes.py` extraction | Integrated through B-10b10; B-10b11 legacy Extend alias cleanup in review in PR #282 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -295,7 +295,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 10 | B-09b1 AiO legacy orchestration body move | COMPLETE on `dev` | Move | #184 | PR #269 / `7484dc7` |
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
-| 13 | B-10b private alias reduction | IN REVIEW: B-10b10 PR #281 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
+| 13 | B-10b private alias reduction | IN REVIEW: B-10b11 PR #282 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | BLOCKED by B-10b | Move | #184 | Supported alias surface frozen after scoped cleanup |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
@@ -621,8 +621,8 @@ reported as unexecuted, not passed.
 
 ### B-10b — Private alias reduction
 
-- **Status:** B-10b1 through B-10b9 are complete on `dev` through PR #280 /
-  `8b99c03`; B-10b10 is in review in PR #281 from that integrated base.
+- **Status:** B-10b1 through B-10b10 are complete on `dev` through PR #281 /
+  `6a6fe14`; B-10b11 is in review in PR #282 from that integrated base.
 - **Type:** small compatibility cleanup PRs, one owner/surface at a time
 - Remove unsupported/test-only aliases after tests use canonical paths.
 - Retain an actual monkeypatch seam only when the consumer and call-time binding
@@ -695,6 +695,13 @@ B-10b10 removes only `DEFAULT_QUALITY_TAGS` and
 surfaces. Canonical Prompt Builder/Studio and advanced-prompt consumers already
 import the immutable defaults from `easyuse_anima.prompt.fields` directly. The
 stored strings, input defaults, workflow schema, and prompt behavior do not change.
+
+B-10b11 removes only `EasyUseAnimaPromptStudioExtend` from the relative and
+flat root import surfaces. The canonical legacy class stays in
+`easyuse_anima.nodes.prompt_advanced_nodes`, and frontend Extend type hooks stay
+unchanged. The class is already absent from backend node/display mappings and
+the reviewed workflow fixture, so node registration and saved-workflow support
+do not change.
 
 ### B-11 — Registration, bootstrap, and final `nodes.py` shim
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,13 +3,13 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `8b99c03dac1a89317ea5f2738cf6b894fd751022`
+  `6a6fe14d26e0d30b59ee18c55fe25591b93b15e4`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-10b9 is integrated; B-10b10 in PR #281 removes one audited
-  unsupported/test-only prompt-default root-alias group
+- Current state: B-10b10 is integrated; B-10b11 in PR #282 removes one audited
+  unsupported/test-only legacy Extend root-alias group
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -74,14 +74,15 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 379 at the
-  B-10b10 PR head, with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 378 at the
+  B-10b11 PR head, with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
 - mapped supported public class re-exports: 18;
-- unmapped classes: `EasyUseAnimaPromptStudioExtend`,
-  `EasyUseAnimaSAM3Context`, and `EasyUseAnimaSAM3Detailer`;
+- unmapped root classes: `EasyUseAnimaSAM3Context` and
+  `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
+  owner module without a root alias or backend mapping;
 - root-owned residual implementation: 41 functions, 2 classes, and 33 assigned
   globals.
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
@@ -94,7 +95,8 @@ inferring public support from spelling or test imports:
   `_image_scale_by_multiple_size`, `_max_long_edge_value`,
   `_normalize_image_scale_options`, `_scale_by_value`, and
   `_clear_aio_first_pass_cache`, plus `WILDCARD_SEED_RANGE_NOTE`, the seven
-  B-10b9 SAM3 helpers, and the two B-10b10 prompt-default constants; their production
+  B-10b9 SAM3 helpers, the two B-10b10 prompt-default constants, and the
+  B-10b11 legacy Extend class root alias; their production
   consumers import or call the corresponding canonical owners directly;
 - repository test files with a direct `nodes` import: 21, recorded as migration
   consumers rather than public-support evidence.
@@ -251,6 +253,11 @@ EasyUseAnimaWildcard
   directly from `easyuse_anima.prompt.fields`; normal-package and synthetic
   package tests reject the retired names while preserving the exact strings and
   input defaults.
+- B-10b11 legacy Extend cleanup: `EasyUseAnimaPromptStudioExtend` is no longer
+  a root alias. Its canonical class and frontend type hooks remain unchanged;
+  normal-package and synthetic package tests reject the retired root name while
+  behavior tests import the canonical class directly. Backend node/display
+  mappings and the reviewed workflow fixture continue to omit Extend.
 - B-08b2 internal AiO model-variant transition: Spectrum correction/forecast
   model patching and ephemeral model cleanup move to
   `easyuse_anima.aio.model_preparation`. Their four root private names remain

--- a/nodes.py
+++ b/nodes.py
@@ -320,7 +320,7 @@ try:
     from .easyuse_anima.nodes.prompt_advanced_nodes import (
         EasyUseAnimaPromptStudioAdvanced as EasyUseAnimaPromptStudioAdvanced,
         EasyUseAnimaPromptStudioAdvancedV2 as EasyUseAnimaPromptStudioAdvancedV2,
-        EasyUseAnimaPromptStudioExtend as EasyUseAnimaPromptStudioExtend,
+        # B-10b11 retires the unmapped legacy Extend root alias.
         _bind_prompt_advanced_node_runtime as _bind_prompt_advanced_node_runtime,
     )
     from .easyuse_anima.nodes.aio_nodes import (
@@ -833,7 +833,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.nodes.prompt_advanced_nodes import (
         EasyUseAnimaPromptStudioAdvanced as EasyUseAnimaPromptStudioAdvanced,
         EasyUseAnimaPromptStudioAdvancedV2 as EasyUseAnimaPromptStudioAdvancedV2,
-        EasyUseAnimaPromptStudioExtend as EasyUseAnimaPromptStudioExtend,
+        # B-10b11 retires the unmapped legacy Extend root alias.
         _bind_prompt_advanced_node_runtime as _bind_prompt_advanced_node_runtime,
     )
     from easyuse_anima.nodes.aio_nodes import (

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -21931,37 +21931,6 @@
         "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
       },
       {
-        "alias": "EasyUseAnimaPromptStudioExtend",
-        "bound_name": "EasyUseAnimaPromptStudioExtend",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "EasyUseAnimaPromptStudioExtend",
-          "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
-        "kind": "static_from",
-        "line": 320,
-        "name": "EasyUseAnimaPromptStudioExtend",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
-      },
-      {
         "alias": "_bind_prompt_advanced_node_runtime",
         "bound_name": "_bind_prompt_advanced_node_runtime",
         "branch_context": [
@@ -35318,40 +35287,6 @@
         "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
       },
       {
-        "alias": "EasyUseAnimaPromptStudioExtend",
-        "bound_name": "EasyUseAnimaPromptStudioExtend",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "EasyUseAnimaPromptStudioExtend",
-          "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
-        "kind": "static_from",
-        "line": 833,
-        "name": "EasyUseAnimaPromptStudioExtend",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
-      },
-      {
         "alias": "_bind_prompt_advanced_node_runtime",
         "bound_name": "_bind_prompt_advanced_node_runtime",
         "branch_context": [
@@ -43556,7 +43491,7 @@
         "is_package": false,
         "loc": 2712,
         "module": "nodes",
-        "normalized_git_blob_sha1": "bd8fa79c8c14aa4cc6ee2fcbda7224d42d39f2f2",
+        "normalized_git_blob_sha1": "b6632e400cfd4042e649bbf15316ad4ce899369c",
         "path": "nodes.py",
         "top_level": {
           "class_count": 2,
@@ -51036,29 +50971,6 @@
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
-        "kind": "static_from",
-        "line": 833,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
         "kind": "static_from",
         "line": 833,
         "optional": false,

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "8b99c03dac1a89317ea5f2738cf6b894fd751022",
+    "base_commit": "6a6fe14d26e0d30b59ee18c55fe25591b93b15e4",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -17,7 +17,8 @@
       "B-10b7",
       "B-10b8",
       "B-10b9",
-      "B-10b10"
+      "B-10b10",
+      "B-10b11"
     ]
   },
   "enums": {
@@ -52,10 +53,10 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 379,
+    "nodes_canonical_bindings": 378,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
-    "unmapped_classes": 3,
+    "unmapped_classes": 2,
     "root_residual_functions": 41,
     "root_residual_classes": 2,
     "root_residual_globals": 33,
@@ -83,7 +84,6 @@
     "EasyUseAnimaWildcard"
   ],
   "unmapped_classes": [
-    "EasyUseAnimaPromptStudioExtend",
     "EasyUseAnimaSAM3Context",
     "EasyUseAnimaSAM3Detailer"
   ],
@@ -1044,6 +1044,11 @@
     }
   },
   "retired_private_bindings": {
+    "EasyUseAnimaPromptStudioExtend": {
+      "canonical_target": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
+      "owner": "#184/#188 B-10b11",
+      "reason": "legacy class is canonical but absent from backend node mappings"
+    },
     "DEFAULT_QUALITY_TAGS": {
       "canonical_target": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
       "owner": "#184/#188 B-10b10",
@@ -2413,35 +2418,6 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.prompt_advanced_nodes:unsupported_test_only",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "EasyUseAnimaPromptStudioExtend": "EasyUseAnimaPromptStudioExtend"
-      },
-      "classification": "unsupported_test_only",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.nodes.prompt_advanced_nodes",
-      "target_state": "canonical",
-      "identity_requirement": "not_applicable",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.nodes.prompt_advanced_nodes",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "repository tests may import this root name"
-      ],
-      "evidence": [
-        "AST:no nodes.py runtime load",
-        "test-only consumption is not public support evidence"
-      ],
-      "removal_gates": [
-        "test imports migrate to canonical targets",
-        "no production consumer evidence",
-        "separate B-10b removal review"
-      ],
-      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.prompt_data_nodes:supported_public_reexport",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1549,6 +1549,9 @@ print(json.dumps({{
 
 
 class PromptAdvancedMoveContractTests(unittest.TestCase):
+    RETIRED_NODE_CLASSES = (
+        "EasyUseAnimaPromptStudioExtend",
+    )
     SERVICE_OBJECTS = (
         "ADVANCED_FIELD_TYPES",
         "ADVANCED_FIELD_PANES",
@@ -1574,10 +1577,12 @@ class PromptAdvancedMoveContractTests(unittest.TestCase):
     NODE_CLASSES = (
         "EasyUseAnimaPromptStudioAdvanced",
         "EasyUseAnimaPromptStudioAdvancedV2",
-        "EasyUseAnimaPromptStudioExtend",
     )
 
     def test_root_advanced_objects_are_direct_canonical_aliases(self):
+        for name in self.RETIRED_NODE_CLASSES:
+            with self.subTest(retired=name):
+                self.assertFalse(hasattr(nodes, name))
         for name in self.SERVICE_OBJECTS:
             with self.subTest(module="advanced", name=name):
                 self.assertIs(getattr(nodes, name), getattr(prompt_advanced, name))
@@ -1593,6 +1598,9 @@ class PromptAdvancedMoveContractTests(unittest.TestCase):
                 f"{package_name}.easyuse_anima.nodes.prompt_advanced_nodes"
             ]
 
+            for name in self.RETIRED_NODE_CLASSES:
+                with self.subTest(retired=name):
+                    self.assertFalse(hasattr(package_nodes, name))
             for name in self.SERVICE_OBJECTS:
                 with self.subTest(module="advanced", name=name):
                     self.assertIs(getattr(package_nodes, name), getattr(package_advanced, name))

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,9 +73,9 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "bd8fa79c8c14aa4cc6ee2fcbda7224d42d39f2f2")
-        # Issue #184 B-10b10 retires two unsupported/test-only prompt defaults
-        # after production and tests use the canonical owner directly.
+        self.assertEqual(report["git_blob_sha1"], "b6632e400cfd4042e649bbf15316ad4ce899369c")
+        # Issue #184 B-10b11 retires the unsupported/test-only Extend root alias
+        # while preserving its unmapped canonical legacy class.
         self.assertEqual(report["top_level"]["function_count"], 41)
         self.assertEqual(report["top_level"]["class_count"], 2)
         self.assertEqual(report["line_count"], 2_712)

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import autocomplete_dataset
 import settings as easyuse_settings
+from easyuse_anima.nodes.prompt_advanced_nodes import EasyUseAnimaPromptStudioExtend
 from easyuse_anima.prompt.fields import (
     DEFAULT_QUALITY_TAGS,
     DEFAULT_TRAILING_QUALITY_TAGS,
@@ -42,7 +43,6 @@ from nodes import (
     EasyUseAnimaPromptStudio,
     EasyUseAnimaPromptStudioAdvanced,
     EasyUseAnimaPromptStudioAdvancedV2,
-    EasyUseAnimaPromptStudioExtend,
     _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED,
     _clean_prompt,
     _generate_empty_latent_with_comfy,

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -15,7 +15,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "8b99c03dac1a89317ea5f2738cf6b894fd751022"
+BASE_COMMIT = "6a6fe14d26e0d30b59ee18c55fe25591b93b15e4"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -56,6 +56,13 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "sqrt": "math:sqrt",
 }
 RETIRED_PRIVATE_BINDINGS = {
+    "EasyUseAnimaPromptStudioExtend": {
+        "canonical_target": (
+            "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend"
+        ),
+        "owner": "#184/#188 B-10b11",
+        "reason": "legacy class is canonical but absent from backend node mappings",
+    },
     "DEFAULT_QUALITY_TAGS": {
         "canonical_target": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "owner": "#184/#188 B-10b10",
@@ -770,6 +777,7 @@ def _build_document() -> dict[str, Any]:
                 "B-10b8",
                 "B-10b9",
                 "B-10b10",
+                "B-10b11",
             ],
         },
         "enums": {
@@ -782,10 +790,10 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 379,
+            "nodes_canonical_bindings": 378,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
-            "unmapped_classes": 3,
+            "unmapped_classes": 2,
             "root_residual_functions": 41,
             "root_residual_classes": 2,
             "root_residual_globals": 33,
@@ -920,7 +928,6 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             self.document["unmapped_classes"],
             [
-                "EasyUseAnimaPromptStudioExtend",
                 "EasyUseAnimaSAM3Context",
                 "EasyUseAnimaSAM3Detailer",
             ],


### PR DESCRIPTION
## 변경 요약

Issue #184/#188의 B-10b11 Contract 정리입니다. canonical legacy class와 frontend hooks는 유지하면서 EasyUseAnimaPromptStudioExtend의 unsupported/test-only nodes.py root re-export 하나만 제거합니다.

## 작업 전 inventory

### Symbol / alias shape

- symbol: EasyUseAnimaPromptStudioExtend
- canonical owner: easyuse_anima.nodes.prompt_advanced_nodes
- root shape: nodes.py relative-package / flat-fallback 양쪽 direct class import
- compatibility classification: unsupported_test_only, identity not_applicable

### Callers / consumers

- root production caller, runtime resolver, binder, mutable global-state, root monkeypatch consumer: 없음
- root test consumers:
  - tests/test_node_contracts.py normal/synthetic-package alias identity
  - tests/test_prompt_corrector.py root import 뒤 legacy Extend behavior tests
- canonical class 내부 self-reference와 canonical behavior tests는 유지
- prompt advanced runtime binder는 유지되며 이 class alias 자체를 결합하지 않음

### Mapping / workflow / frontend

- NODE_CLASS_MAPPINGS / NODE_DISPLAY_NAME_MAPPINGS: Extend 없음
- 0.5.2 node/workflow contract fixture와 tracked workflow JSON: Extend 없음
- root package entrypoint import: 없음
- frontend EXTEND_NODE_TYPE 문자열과 UI/serialization hooks는 Python root alias와 독립
- canonical class, frontend 문자열, mapping/workflow 상태는 변경하지 않음

### Dirty sibling overlap

- feature-prompt-translation-runtime의 nodes.py hunk는 residual translation/AiO 영역
- 이번 root import hunk와 파일 내 위치 및 의미가 겹치지 않음

## Allowed-file boundary

- nodes.py
- tests/test_node_contracts.py
- tests/test_prompt_corrector.py
- tests/test_nodes_module_analyzer.py
- tests/test_python_compatibility_surface.py
- tests/fixtures/python_backend_baseline.json
- tests/fixtures/python_compatibility_surface.v1.json
- docs/architecture/python-backend-execution-roadmap.md
- docs/architecture/python-compatibility-shims.md

## 구현

- relative/flat nodes.py import에서 Extend root alias만 제거
- normal/synthetic root에 class 이름이 없음을 계약으로 고정
- Extend behavior tests가 canonical class를 직접 import하도록 변경
- retired compatibility ledger와 analyzer fixtures/docs 갱신
- canonical Python, __init__.py, web, workflow fixture는 변경하지 않음

## 검증

Exact head: 45aba9309efe7a6000b1ae50e2fe776a2cb3136f

### Focused

- Python unittest: 217 passed
- Frontend Prompt Studio Advanced queue seed runtime smoke: passed
- Regional runtime lifecycle smoke: passed

### Official full checkpoint

tools/check_project.ps1 -Profile full

- Python unittest: 871 passed
- Frontend: 114 JavaScript files passed
- Pyright baseline: 60 files / 60 known errors / no increase
- Python import boundary: 6 completed groups / 0 violations
- Python compile and git diff check: passed
- Ruff: 105 existing findings, G-01 report-only; blocking execution/configuration failure 없음

### Exact fixture delta

- backend import edges: 1556 -> 1554, relative/flat alias 2건만 제거
- compatibility fallback registry: 464 -> 463, flat alias 1건만 제거
- canonical bindings: 379 -> 378
- groups: 66 -> 65
- unmapped root classes: 3 -> 2
- unsupported groups: 9 -> 8
- retired bindings: 22 -> 23
- state, side effects, public root, mapped classes 18, binders 28: unchanged

### Review

- 독립 read-only diff review: findings 없음
- canonical class/self-reference/binder, __init__.py mappings, web tree, workflow fixture: base/head 동일
- dirty sibling과 hunk/semantic overlap 없음

## 테스트 표면

- ComfyUI Codex test environment: repository full runner
- Live ComfyUI/browser smoke: 실행하지 않음; registered node/runtime/frontend 변경이 없는 Contract-only cleanup

## 위험 / rollback

외부 코드가 미지원 nodes root class alias를 직접 import했다면 실패할 수 있습니다. canonical class는 easyuse_anima.nodes.prompt_advanced_nodes에 그대로 남습니다. 문제가 있으면 root alias 제거와 retired metadata/test 변경만 한 단위로 되돌릴 수 있습니다.

## 다음 단계

B-11은 남은 unsupported/test-only 그룹과 root residual/runtime seam 때문에 계속 blocked입니다. B-10b의 다음 single-owner 후보를 별도 PR에서 재감사합니다.