### PR TITLE
refactor(backend): retire prompt data root aliases (B-10b12)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `6a6fe14d26e0d30b59ee18c55fe25591b93b15e4`
+- Integrated `dev` snapshot commit: `3c49e6c02489fa5d467c1a5028bcb2392c47bc83`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-10b10; B-10b11 legacy Extend alias cleanup in review in PR #282 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
+| B - `nodes.py` extraction | Integrated through B-10b11; B-10b12 prompt-data alias cleanup in review in PR #283 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -295,7 +295,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 10 | B-09b1 AiO legacy orchestration body move | COMPLETE on `dev` | Move | #184 | PR #269 / `7484dc7` |
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
-| 13 | B-10b private alias reduction | IN REVIEW: B-10b11 PR #282 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
+| 13 | B-10b private alias reduction | IN REVIEW: B-10b12 PR #283 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | BLOCKED by B-10b | Move | #184 | Supported alias surface frozen after scoped cleanup |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
@@ -621,8 +621,8 @@ reported as unexecuted, not passed.
 
 ### B-10b — Private alias reduction
 
-- **Status:** B-10b1 through B-10b10 are complete on `dev` through PR #281 /
-  `6a6fe14`; B-10b11 is in review in PR #282 from that integrated base.
+- **Status:** B-10b1 through B-10b11 are complete on `dev` through PR #282 /
+  `3c49e6c`; B-10b12 is in review in PR #283 from that integrated base.
 - **Type:** small compatibility cleanup PRs, one owner/surface at a time
 - Remove unsupported/test-only aliases after tests use canonical paths.
 - Retain an actual monkeypatch seam only when the consumer and call-time binding
@@ -702,6 +702,13 @@ flat root import surfaces. The canonical legacy class stays in
 unchanged. The class is already absent from backend node/display mappings and
 the reviewed workflow fixture, so node registration and saved-workflow support
 do not change.
+
+B-10b12 removes the nine unsupported/test-only `easyuse_anima.prompt.data`
+root aliases recorded in the compatibility fixture. Canonical prompt-data
+adapters and services already import their schema, version, socket tuples, and
+helpers directly. `PROMPT_DATA_TYPE`, runtime-resolver helpers, mapped classes,
+schema values, socket order, nested fallbacks, dict updates, and serialization
+behavior stay unchanged.
 
 ### B-11 — Registration, bootstrap, and final `nodes.py` shim
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,13 +3,13 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `6a6fe14d26e0d30b59ee18c55fe25591b93b15e4`
+  `3c49e6c02489fa5d467c1a5028bcb2392c47bc83`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-10b10 is integrated; B-10b11 in PR #282 removes one audited
-  unsupported/test-only legacy Extend root-alias group
+- Current state: B-10b11 is integrated; B-10b12 in PR #283 removes one audited
+  unsupported/test-only prompt-data root-alias group
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -74,8 +74,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 378 at the
-  B-10b11 PR head, with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 369 at the
+  B-10b12 PR head, with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -96,7 +96,8 @@ inferring public support from spelling or test imports:
   `_normalize_image_scale_options`, `_scale_by_value`, and
   `_clear_aio_first_pass_cache`, plus `WILDCARD_SEED_RANGE_NOTE`, the seven
   B-10b9 SAM3 helpers, the two B-10b10 prompt-default constants, and the
-  B-10b11 legacy Extend class root alias; their production
+  B-10b11 legacy Extend class root alias, and the nine B-10b12 prompt-data
+  aliases; their production
   consumers import or call the corresponding canonical owners directly;
 - repository test files with a direct `nodes` import: 21, recorded as migration
   consumers rather than public-support evidence.
@@ -258,6 +259,12 @@ EasyUseAnimaWildcard
   normal-package and synthetic package tests reject the retired root name while
   behavior tests import the canonical class directly. Backend node/display
   mappings and the reviewed workflow fixture continue to omit Extend.
+- B-10b12 prompt-data cleanup: the nine audited unsupported aliases for compat
+  output tuples, schema/version, and internal nested/output/set helpers are no
+  longer root aliases. Canonical prompt-data adapters and services import or
+  call the owner directly; normal-package and synthetic package tests reject
+  the retired names while preserving the retained prompt-data type, runtime
+  helpers, mapped classes, schema values, socket contract, and fallback behavior.
 - B-08b2 internal AiO model-variant transition: Spectrum correction/forecast
   model patching and ephemeral model cleanup move to
   `easyuse_anima.aio.model_preparation`. Their four root private names remain

--- a/nodes.py
+++ b/nodes.py
@@ -134,22 +134,22 @@ try:
         _prompt_tokens as _prompt_tokens,
     )
     from .easyuse_anima.prompt.data import (
-        PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS as PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS,
-        PROMPT_DATA_COMPAT_RETURN_NAMES as PROMPT_DATA_COMPAT_RETURN_NAMES,
-        PROMPT_DATA_COMPAT_RETURN_TYPES as PROMPT_DATA_COMPAT_RETURN_TYPES,
-        PROMPT_DATA_SCHEMA as PROMPT_DATA_SCHEMA,
+        # B-10b12 retires nine unsupported prompt-data root aliases.
+        # Canonical schema, tuple, and helper consumers import their owner directly.
+        # Socket tooltip/name/type tuples stay canonical.
+        # Schema and version values stay canonical.
+        # Input-default resolution stays canonical.
+        # Nested/output fallback stays canonical.
+        # Dict output mutation stays canonical.
+        # Retained type and runtime-resolver helpers stay root seams.
+        # Mapped prompt-data adapters stay unchanged.
         PROMPT_DATA_TYPE as PROMPT_DATA_TYPE,
-        PROMPT_DATA_VERSION as PROMPT_DATA_VERSION,
         _advanced_outputs_from_prompt_data as _advanced_outputs_from_prompt_data,
         _apply_prompt_data_overrides as _apply_prompt_data_overrides,
         _copy_prompt_data_for_update as _copy_prompt_data_for_update,
         _normalize_prompt_data as _normalize_prompt_data,
-        _prompt_data_input_default as _prompt_data_input_default,
         _prompt_data_json_safe as _prompt_data_json_safe,
-        _prompt_data_nested as _prompt_data_nested,
-        _prompt_data_output as _prompt_data_output,
         _prompt_data_parameter_snapshot as _prompt_data_parameter_snapshot,
-        _set_prompt_data_output as _set_prompt_data_output,
     )
     from .easyuse_anima.prompt.advanced import (
         ADVANCED_FIELDS_WORKFLOW_PROPERTY as ADVANCED_FIELDS_WORKFLOW_PROPERTY,
@@ -647,22 +647,22 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _prompt_tokens as _prompt_tokens,
     )
     from easyuse_anima.prompt.data import (
-        PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS as PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS,
-        PROMPT_DATA_COMPAT_RETURN_NAMES as PROMPT_DATA_COMPAT_RETURN_NAMES,
-        PROMPT_DATA_COMPAT_RETURN_TYPES as PROMPT_DATA_COMPAT_RETURN_TYPES,
-        PROMPT_DATA_SCHEMA as PROMPT_DATA_SCHEMA,
+        # B-10b12 retires nine unsupported prompt-data root aliases.
+        # Canonical schema, tuple, and helper consumers import their owner directly.
+        # Socket tooltip/name/type tuples stay canonical.
+        # Schema and version values stay canonical.
+        # Input-default resolution stays canonical.
+        # Nested/output fallback stays canonical.
+        # Dict output mutation stays canonical.
+        # Retained type and runtime-resolver helpers stay root seams.
+        # Mapped prompt-data adapters stay unchanged.
         PROMPT_DATA_TYPE as PROMPT_DATA_TYPE,
-        PROMPT_DATA_VERSION as PROMPT_DATA_VERSION,
         _advanced_outputs_from_prompt_data as _advanced_outputs_from_prompt_data,
         _apply_prompt_data_overrides as _apply_prompt_data_overrides,
         _copy_prompt_data_for_update as _copy_prompt_data_for_update,
         _normalize_prompt_data as _normalize_prompt_data,
-        _prompt_data_input_default as _prompt_data_input_default,
         _prompt_data_json_safe as _prompt_data_json_safe,
-        _prompt_data_nested as _prompt_data_nested,
-        _prompt_data_output as _prompt_data_output,
         _prompt_data_parameter_snapshot as _prompt_data_parameter_snapshot,
-        _set_prompt_data_output as _set_prompt_data_output,
     )
     from easyuse_anima.prompt.advanced import (
         ADVANCED_FIELDS_WORKFLOW_PROPERTY as ADVANCED_FIELDS_WORKFLOW_PROPERTY,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -16537,130 +16537,6 @@
         "target": "easyuse_anima/prompt/fields.py"
       },
       {
-        "alias": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
-        "bound_name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
-        "kind": "static_from",
-        "line": 136,
-        "name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.data",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "alias": "PROMPT_DATA_COMPAT_RETURN_NAMES",
-        "bound_name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
-        "kind": "static_from",
-        "line": 136,
-        "name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.data",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "alias": "PROMPT_DATA_COMPAT_RETURN_TYPES",
-        "bound_name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
-        "kind": "static_from",
-        "line": 136,
-        "name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.data",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "alias": "PROMPT_DATA_SCHEMA",
-        "bound_name": "PROMPT_DATA_SCHEMA",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PROMPT_DATA_SCHEMA",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
-        "kind": "static_from",
-        "line": 136,
-        "name": "PROMPT_DATA_SCHEMA",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.data",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
         "alias": "PROMPT_DATA_TYPE",
         "bound_name": "PROMPT_DATA_TYPE",
         "branch_context": [
@@ -16684,37 +16560,6 @@
         "kind": "static_from",
         "line": 136,
         "name": "PROMPT_DATA_TYPE",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.data",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "alias": "PROMPT_DATA_VERSION",
-        "bound_name": "PROMPT_DATA_VERSION",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PROMPT_DATA_VERSION",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
-        "kind": "static_from",
-        "line": 136,
-        "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
         "role": "compatibility_primary",
@@ -16847,37 +16692,6 @@
         "target": "easyuse_anima/prompt/data.py"
       },
       {
-        "alias": "_prompt_data_input_default",
-        "bound_name": "_prompt_data_input_default",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_prompt_data_input_default",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.data:_prompt_data_input_default",
-        "kind": "static_from",
-        "line": 136,
-        "name": "_prompt_data_input_default",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.data",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
         "alias": "_prompt_data_json_safe",
         "bound_name": "_prompt_data_json_safe",
         "branch_context": [
@@ -16909,68 +16723,6 @@
         "target": "easyuse_anima/prompt/data.py"
       },
       {
-        "alias": "_prompt_data_nested",
-        "bound_name": "_prompt_data_nested",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_prompt_data_nested",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.data:_prompt_data_nested",
-        "kind": "static_from",
-        "line": 136,
-        "name": "_prompt_data_nested",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.data",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "alias": "_prompt_data_output",
-        "bound_name": "_prompt_data_output",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_prompt_data_output",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.data:_prompt_data_output",
-        "kind": "static_from",
-        "line": 136,
-        "name": "_prompt_data_output",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.data",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
         "alias": "_prompt_data_parameter_snapshot",
         "bound_name": "_prompt_data_parameter_snapshot",
         "branch_context": [
@@ -16994,37 +16746,6 @@
         "kind": "static_from",
         "line": 136,
         "name": "_prompt_data_parameter_snapshot",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.data",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "alias": "_set_prompt_data_output",
-        "bound_name": "_set_prompt_data_output",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_set_prompt_data_output",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.data:_set_prompt_data_output",
-        "kind": "static_from",
-        "line": 136,
-        "name": "_set_prompt_data_output",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
         "role": "compatibility_primary",
@@ -29371,142 +29092,6 @@
         "target": "easyuse_anima/prompt/fields.py"
       },
       {
-        "alias": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
-        "bound_name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
-        "kind": "static_from",
-        "line": 649,
-        "name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.data",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "alias": "PROMPT_DATA_COMPAT_RETURN_NAMES",
-        "bound_name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
-        "kind": "static_from",
-        "line": 649,
-        "name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.data",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "alias": "PROMPT_DATA_COMPAT_RETURN_TYPES",
-        "bound_name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
-        "kind": "static_from",
-        "line": 649,
-        "name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.data",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "alias": "PROMPT_DATA_SCHEMA",
-        "bound_name": "PROMPT_DATA_SCHEMA",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PROMPT_DATA_SCHEMA",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
-        "kind": "static_from",
-        "line": 649,
-        "name": "PROMPT_DATA_SCHEMA",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.data",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
         "alias": "PROMPT_DATA_TYPE",
         "bound_name": "PROMPT_DATA_TYPE",
         "branch_context": [
@@ -29533,40 +29118,6 @@
         "kind": "static_from",
         "line": 649,
         "name": "PROMPT_DATA_TYPE",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.data",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "alias": "PROMPT_DATA_VERSION",
-        "bound_name": "PROMPT_DATA_VERSION",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "PROMPT_DATA_VERSION",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
-        "kind": "static_from",
-        "line": 649,
-        "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
         "role": "compatibility_fallback",
@@ -29711,40 +29262,6 @@
         "target": "easyuse_anima/prompt/data.py"
       },
       {
-        "alias": "_prompt_data_input_default",
-        "bound_name": "_prompt_data_input_default",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_prompt_data_input_default",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
-        "kind": "static_from",
-        "line": 649,
-        "name": "_prompt_data_input_default",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.data",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
         "alias": "_prompt_data_json_safe",
         "bound_name": "_prompt_data_json_safe",
         "branch_context": [
@@ -29779,74 +29296,6 @@
         "target": "easyuse_anima/prompt/data.py"
       },
       {
-        "alias": "_prompt_data_nested",
-        "bound_name": "_prompt_data_nested",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_prompt_data_nested",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
-        "kind": "static_from",
-        "line": 649,
-        "name": "_prompt_data_nested",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.data",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "alias": "_prompt_data_output",
-        "bound_name": "_prompt_data_output",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_prompt_data_output",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:_prompt_data_output",
-        "kind": "static_from",
-        "line": 649,
-        "name": "_prompt_data_output",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.data",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
         "alias": "_prompt_data_parameter_snapshot",
         "bound_name": "_prompt_data_parameter_snapshot",
         "branch_context": [
@@ -29873,40 +29322,6 @@
         "kind": "static_from",
         "line": 649,
         "name": "_prompt_data_parameter_snapshot",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.data",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "alias": "_set_prompt_data_output",
-        "bound_name": "_set_prompt_data_output",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_set_prompt_data_output",
-          "target": "easyuse_anima/prompt/data.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
-        "kind": "static_from",
-        "line": 649,
-        "name": "_set_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
         "role": "compatibility_fallback",
@@ -43491,7 +42906,7 @@
         "is_package": false,
         "loc": 2712,
         "module": "nodes",
-        "normalized_git_blob_sha1": "b6632e400cfd4042e649bbf15316ad4ce899369c",
+        "normalized_git_blob_sha1": "722ffd432213ae3a1a83eb93c4600990a1d9c82a",
         "path": "nodes.py",
         "top_level": {
           "class_count": 2,
@@ -46991,122 +46406,7 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
-        "kind": "static_from",
-        "line": 649,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
-        "kind": "static_from",
-        "line": 649,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
-        "kind": "static_from",
-        "line": 649,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
-        "kind": "static_from",
-        "line": 649,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
-        "kind": "static_from",
-        "line": 649,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
         "line": 649,
         "optional": false,
@@ -47221,29 +46521,6 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
-        "kind": "static_from",
-        "line": 649,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
         "line": 649,
@@ -47267,76 +46544,7 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
-        "kind": "static_from",
-        "line": 649,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:_prompt_data_output",
-        "kind": "static_from",
-        "line": 649,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
-        "kind": "static_from",
-        "line": 649,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/data.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
         "line": 649,
         "optional": false,

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "6a6fe14d26e0d30b59ee18c55fe25591b93b15e4",
+    "base_commit": "3c49e6c02489fa5d467c1a5028bcb2392c47bc83",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -18,7 +18,8 @@
       "B-10b8",
       "B-10b9",
       "B-10b10",
-      "B-10b11"
+      "B-10b11",
+      "B-10b12"
     ]
   },
   "enums": {
@@ -53,7 +54,7 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 378,
+    "nodes_canonical_bindings": 369,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
@@ -1044,6 +1045,51 @@
     }
   },
   "retired_private_bindings": {
+    "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS": {
+      "canonical_target": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
+      "owner": "#184/#188 B-10b12",
+      "reason": "canonical prompt-data adapter imports the tuple directly"
+    },
+    "PROMPT_DATA_COMPAT_RETURN_NAMES": {
+      "canonical_target": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
+      "owner": "#184/#188 B-10b12",
+      "reason": "canonical prompt-data adapter imports the tuple directly"
+    },
+    "PROMPT_DATA_COMPAT_RETURN_TYPES": {
+      "canonical_target": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
+      "owner": "#184/#188 B-10b12",
+      "reason": "canonical prompt-data adapter imports the tuple directly"
+    },
+    "PROMPT_DATA_SCHEMA": {
+      "canonical_target": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
+      "owner": "#184/#188 B-10b12",
+      "reason": "canonical advanced prompt service imports the schema directly"
+    },
+    "PROMPT_DATA_VERSION": {
+      "canonical_target": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
+      "owner": "#184/#188 B-10b12",
+      "reason": "canonical advanced prompt service imports the version directly"
+    },
+    "_prompt_data_input_default": {
+      "canonical_target": "easyuse_anima.prompt.data:_prompt_data_input_default",
+      "owner": "#184/#188 B-10b12",
+      "reason": "canonical prompt-data owner consumes the helper internally"
+    },
+    "_prompt_data_nested": {
+      "canonical_target": "easyuse_anima.prompt.data:_prompt_data_nested",
+      "owner": "#184/#188 B-10b12",
+      "reason": "canonical prompt services import or call the owner directly"
+    },
+    "_prompt_data_output": {
+      "canonical_target": "easyuse_anima.prompt.data:_prompt_data_output",
+      "owner": "#184/#188 B-10b12",
+      "reason": "canonical prompt services import or call the owner directly"
+    },
+    "_set_prompt_data_output": {
+      "canonical_target": "easyuse_anima.prompt.data:_set_prompt_data_output",
+      "owner": "#184/#188 B-10b12",
+      "reason": "canonical prompt-data owner consumes the helper internally"
+    },
     "EasyUseAnimaPromptStudioExtend": {
       "canonical_target": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
       "owner": "#184/#188 B-10b11",
@@ -3100,43 +3146,6 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.prompt.data:unsupported_test_only",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
-        "PROMPT_DATA_COMPAT_RETURN_NAMES": "PROMPT_DATA_COMPAT_RETURN_NAMES",
-        "PROMPT_DATA_COMPAT_RETURN_TYPES": "PROMPT_DATA_COMPAT_RETURN_TYPES",
-        "PROMPT_DATA_SCHEMA": "PROMPT_DATA_SCHEMA",
-        "PROMPT_DATA_VERSION": "PROMPT_DATA_VERSION",
-        "_prompt_data_input_default": "_prompt_data_input_default",
-        "_prompt_data_nested": "_prompt_data_nested",
-        "_prompt_data_output": "_prompt_data_output",
-        "_set_prompt_data_output": "_set_prompt_data_output"
-      },
-      "classification": "unsupported_test_only",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.prompt.data",
-      "target_state": "canonical",
-      "identity_requirement": "not_applicable",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.prompt.data",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "repository tests may import this root name"
-      ],
-      "evidence": [
-        "AST:no nodes.py runtime load",
-        "test-only consumption is not public support evidence"
-      ],
-      "removal_gates": [
-        "test imports migrate to canonical targets",
-        "no production consumer evidence",
-        "separate B-10b removal review"
-      ],
-      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.fields:transitional_private_seam",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1229,6 +1229,17 @@ print(json.dumps({{
 
 
 class PromptDataConditioningMoveContractTests(unittest.TestCase):
+    RETIRED_PROMPT_DATA_ALIASES = (
+        "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
+        "PROMPT_DATA_COMPAT_RETURN_NAMES",
+        "PROMPT_DATA_COMPAT_RETURN_TYPES",
+        "PROMPT_DATA_SCHEMA",
+        "PROMPT_DATA_VERSION",
+        "_prompt_data_input_default",
+        "_prompt_data_nested",
+        "_prompt_data_output",
+        "_set_prompt_data_output",
+    )
     NODE_CLASSES = (
         "EasyUseAnimaPromptDataUnpack",
         "EasyUseAnimaArtistMixConditioning",
@@ -1237,7 +1248,6 @@ class PromptDataConditioningMoveContractTests(unittest.TestCase):
     MOVED_HELPERS = {
         prompt_data: (
             "_normalize_prompt_data",
-            "_prompt_data_output",
             "_prompt_data_parameter_snapshot",
             "_advanced_outputs_from_prompt_data",
             "_apply_prompt_data_overrides",
@@ -1259,6 +1269,9 @@ class PromptDataConditioningMoveContractTests(unittest.TestCase):
     }
 
     def test_root_prompt_data_conditioning_objects_are_direct_canonical_aliases(self):
+        for name in self.RETIRED_PROMPT_DATA_ALIASES:
+            with self.subTest(retired=name):
+                self.assertFalse(hasattr(nodes, name))
         for name in self.NODE_CLASSES:
             with self.subTest(module="prompt_data_nodes", name=name):
                 self.assertIs(getattr(nodes, name), getattr(prompt_data_nodes, name))
@@ -1278,6 +1291,9 @@ class PromptDataConditioningMoveContractTests(unittest.TestCase):
             package_adapters = sys.modules[
                 f"{package_name}.easyuse_anima.nodes.prompt_data_nodes"
             ]
+            for name in self.RETIRED_PROMPT_DATA_ALIASES:
+                with self.subTest(retired=name):
+                    self.assertFalse(hasattr(package_nodes, name))
             for name in self.NODE_CLASSES:
                 with self.subTest(name=name):
                     canonical_class = getattr(package_adapters, name)

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,9 +73,9 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "b6632e400cfd4042e649bbf15316ad4ce899369c")
-        # Issue #184 B-10b11 retires the unsupported/test-only Extend root alias
-        # while preserving its unmapped canonical legacy class.
+        self.assertEqual(report["git_blob_sha1"], "722ffd432213ae3a1a83eb93c4600990a1d9c82a")
+        # Issue #184 B-10b12 retires nine unsupported/test-only prompt-data
+        # aliases while preserving schema, tuples, and helper behavior.
         self.assertEqual(report["top_level"]["function_count"], 41)
         self.assertEqual(report["top_level"]["class_count"], 2)
         self.assertEqual(report["line_count"], 2_712)

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 import autocomplete_dataset
 import settings as easyuse_settings
 from easyuse_anima.nodes.prompt_advanced_nodes import EasyUseAnimaPromptStudioExtend
+from easyuse_anima.prompt.data import PROMPT_DATA_SCHEMA
 from easyuse_anima.prompt.fields import (
     DEFAULT_QUALITY_TAGS,
     DEFAULT_TRAILING_QUALITY_TAGS,
@@ -31,7 +32,6 @@ from nodes import (
     ARTIST_TAG_POSITION_BACK,
     ARTIST_TAG_POSITION_CORRECT,
     ARTIST_TAG_POSITION_FRONT,
-    PROMPT_DATA_SCHEMA,
     PROMPT_DATA_TYPE,
     EasyUseAnimaArtistMixConditioning,
     EasyUseAnimaDetailerAlignHook,

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -15,7 +15,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "6a6fe14d26e0d30b59ee18c55fe25591b93b15e4"
+BASE_COMMIT = "3c49e6c02489fa5d467c1a5028bcb2392c47bc83"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -56,6 +56,57 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "sqrt": "math:sqrt",
 }
 RETIRED_PRIVATE_BINDINGS = {
+    "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS": {
+        "canonical_target": (
+            "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS"
+        ),
+        "owner": "#184/#188 B-10b12",
+        "reason": "canonical prompt-data adapter imports the tuple directly",
+    },
+    "PROMPT_DATA_COMPAT_RETURN_NAMES": {
+        "canonical_target": (
+            "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES"
+        ),
+        "owner": "#184/#188 B-10b12",
+        "reason": "canonical prompt-data adapter imports the tuple directly",
+    },
+    "PROMPT_DATA_COMPAT_RETURN_TYPES": {
+        "canonical_target": (
+            "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES"
+        ),
+        "owner": "#184/#188 B-10b12",
+        "reason": "canonical prompt-data adapter imports the tuple directly",
+    },
+    "PROMPT_DATA_SCHEMA": {
+        "canonical_target": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
+        "owner": "#184/#188 B-10b12",
+        "reason": "canonical advanced prompt service imports the schema directly",
+    },
+    "PROMPT_DATA_VERSION": {
+        "canonical_target": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
+        "owner": "#184/#188 B-10b12",
+        "reason": "canonical advanced prompt service imports the version directly",
+    },
+    "_prompt_data_input_default": {
+        "canonical_target": "easyuse_anima.prompt.data:_prompt_data_input_default",
+        "owner": "#184/#188 B-10b12",
+        "reason": "canonical prompt-data owner consumes the helper internally",
+    },
+    "_prompt_data_nested": {
+        "canonical_target": "easyuse_anima.prompt.data:_prompt_data_nested",
+        "owner": "#184/#188 B-10b12",
+        "reason": "canonical prompt services import or call the owner directly",
+    },
+    "_prompt_data_output": {
+        "canonical_target": "easyuse_anima.prompt.data:_prompt_data_output",
+        "owner": "#184/#188 B-10b12",
+        "reason": "canonical prompt services import or call the owner directly",
+    },
+    "_set_prompt_data_output": {
+        "canonical_target": "easyuse_anima.prompt.data:_set_prompt_data_output",
+        "owner": "#184/#188 B-10b12",
+        "reason": "canonical prompt-data owner consumes the helper internally",
+    },
     "EasyUseAnimaPromptStudioExtend": {
         "canonical_target": (
             "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend"
@@ -778,6 +829,7 @@ def _build_document() -> dict[str, Any]:
                 "B-10b9",
                 "B-10b10",
                 "B-10b11",
+                "B-10b12",
             ],
         },
         "enums": {
@@ -790,7 +842,7 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 378,
+            "nodes_canonical_bindings": 369,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,


### PR DESCRIPTION
## 변경 요약

Issue #184/#188의 B-10b12 Contract 정리입니다. easyuse_anima.prompt.data가 소유한 unsupported/test-only root alias 9개만 퇴역합니다. Prompt Data schema, version, socket tuples, fallback, mutation, serialization behavior는 변경하지 않습니다.

## 작업 전 inventory

### Retired symbols

- PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS
- PROMPT_DATA_COMPAT_RETURN_NAMES
- PROMPT_DATA_COMPAT_RETURN_TYPES
- PROMPT_DATA_SCHEMA
- PROMPT_DATA_VERSION
- _prompt_data_input_default
- _prompt_data_nested
- _prompt_data_output
- _set_prompt_data_output

canonical owner: easyuse_anima.prompt.data

### Callers / consumers

- root exposure: nodes.py relative-package / flat-fallback import branch
- production root caller, runtime resolver, binder, root monkeypatch, module-global mutable-state consumer: 없음
- root tests:
  - tests/test_prompt_corrector.py가 PROMPT_DATA_SCHEMA만 import
  - tests/test_node_contracts.py identity loop가 _prompt_data_output만 검사
- canonical production:
  - prompt_data_nodes가 compat tooltip/name/type tuples 직접 import
  - prompt.advanced가 schema/version 직접 import
  - prompt.artist_mix가 nested/output helpers 직접 import
  - owner 내부가 input-default/output/set-output 직접 사용

### Retained seams

- PROMPT_DATA_TYPE
- _advanced_outputs_from_prompt_data
- _apply_prompt_data_overrides
- _copy_prompt_data_for_update
- _normalize_prompt_data
- _prompt_data_json_safe
- _prompt_data_parameter_snapshot
- _bind_prompt_data_node_runtime 및 mapped prompt-data node classes 3개

### Behavior boundary

- schema/version/return tuples는 immutable runtime contract이며 값 변경 없음
- _set_prompt_data_output은 전달된 dict만 갱신하고 module/root global state 없음
- saved workflow, socket order/names/types, nested fallback keys, copy/JSON serialization 동작은 canonical owner에서 유지

### Dirty sibling overlap

- feature-prompt-translation-runtime의 nodes.py hunk는 residual translation/AiO 영역
- 이번 prompt.data import hunk와 위치 및 의미가 겹치지 않음
- 다른 allowed file overlap 없음

## Allowed-file boundary

- nodes.py
- tests/test_node_contracts.py
- tests/test_prompt_corrector.py
- tests/test_nodes_module_analyzer.py
- tests/test_python_compatibility_surface.py
- tests/fixtures/python_backend_baseline.json
- tests/fixtures/python_compatibility_surface.v1.json
- docs/architecture/python-backend-execution-roadmap.md
- docs/architecture/python-compatibility-shims.md

## 구현

- 9개 이름을 relative/flat root import에서 제거
- normal/synthetic root 부재를 계약으로 고정
- schema test import를 canonical owner로 이동
- retained helper/class identity, mapping, display, socket contract assertions 유지
- retired compatibility ledger, analyzer fixtures, roadmap/shim 문서 갱신
- canonical 구현, mapping, workflow, frontend 파일은 변경하지 않음

## 검증

Exact head: 04f712bf4fbbd91f7f59cad3327ad84a93f5b4dd

### Focused unittest

- Prompt Data schema/contract 포함 235 tests passed

### Official full checkpoint

tools/check_project.ps1 -Profile full

- Python unittest: 871 passed
- Frontend: 114 JavaScript files passed
- Pyright baseline: 60 files / 60 known errors / no increase
- Python import boundary: 6 completed groups / 0 violations
- Python compile and git diff check: passed
- Ruff: 105 existing findings, G-01 report-only; blocking execution/configuration failure 없음

### Exact fixture delta

- backend import edges: 1554 -> 1536, 9 relative + 9 flat 제거만 발생
- compatibility fallback registry: 463 -> 454, 9 flat 제거만 발생
- canonical bindings: 378 -> 369
- groups: 65 -> 64
- unsupported groups: 8 -> 7
- retired bindings: 23 -> 32
- modules 77, mapped classes 18, binders 28, state, side effects, public surface: unchanged

### Review

- 독립 read-only diff review: findings 없음
- canonical data.py, prompt_data_nodes.py, advanced.py, artist_mix.py, __init__.py, web/workflows: base/head 동일
- dirty sibling과 hunk/semantic overlap 없음

## 테스트 표면

- ComfyUI Codex test environment: repository full runner
- Live ComfyUI/browser smoke: 실행하지 않음; canonical runtime/mapping/workflow/frontend 변경이 없는 Contract-only cleanup

## 위험 / rollback

외부 코드가 미지원 nodes root constants/helpers를 직접 import했다면 실패할 수 있습니다. canonical owner에는 모든 값과 함수가 그대로 유지됩니다. 문제가 있으면 root alias 제거와 retired metadata/test 변경만 한 단위로 되돌릴 수 있습니다.

## 다음 단계

B-11은 남은 unsupported/test-only 7그룹과 root residual/runtime seam 때문에 계속 blocked입니다. 다음 B-10b single-owner 후보는 별도 PR에서 재감사합니다.