### PR TITLE
refactor(backend): retire conditioning root aliases (B-10b15)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `13a9cf4976b9b847dc68ddacca1763d862e647f9`
+- Integrated `dev` snapshot commit: `a06ed305ae43253ef04d1650fb486784b2aed943`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-10b13; B-10b14 NAIA resolution alias cleanup in review in PR #285 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
+| B - `nodes.py` extraction | Integrated through B-10b14; B-10b15 conditioning alias cleanup in review in PR #286 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -295,7 +295,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 10 | B-09b1 AiO legacy orchestration body move | COMPLETE on `dev` | Move | #184 | PR #269 / `7484dc7` |
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
-| 13 | B-10b private alias reduction | IN REVIEW: B-10b14 PR #285 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
+| 13 | B-10b private alias reduction | IN REVIEW: B-10b15 PR #286 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | BLOCKED by B-10b | Move | #184 | Supported alias surface frozen after scoped cleanup |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
@@ -621,8 +621,8 @@ reported as unexecuted, not passed.
 
 ### B-10b — Private alias reduction
 
-- **Status:** B-10b1 through B-10b13 are complete on `dev` through PR #284 /
-  `13a9cf4`; B-10b14 is in review in PR #285 from that integrated base.
+- **Status:** B-10b1 through B-10b14 are complete on `dev` through PR #285 /
+  `a06ed30`; B-10b15 is in review in PR #286 from that integrated base.
 - **Type:** small compatibility cleanup PRs, one owner/surface at a time
 - Remove unsupported/test-only aliases after tests use canonical paths.
 - Retain an actual monkeypatch seam only when the consumer and call-time binding
@@ -723,6 +723,13 @@ Prompt Advanced, and Regional consumers already import or call the owner
 directly. Five runtime-resolved label/selection helpers remain root seams;
 bucket data/order, scale/max-long-edge policy, 32-pixel snapping, nearest-fit,
 input defaults, mapped classes, and workflow behavior stay unchanged.
+
+B-10b15 removes the five unsupported/test-only
+`easyuse_anima.prompt.conditioning` root aliases recorded in the compatibility
+fixture. Canonical conditioning and Prompt Data consumers already import or
+call the owner directly. Nine runtime-resolved conditioning seams remain;
+mode/profile values, mapped classes, Spectrum old-signature fallback,
+warning-once behavior, and saved-workflow contracts stay unchanged.
 
 ### B-11 — Registration, bootstrap, and final `nodes.py` shim
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,13 +3,13 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `13a9cf4976b9b847dc68ddacca1763d862e647f9`
+  `a06ed305ae43253ef04d1650fb486784b2aed943`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-10b13 is integrated; B-10b14 in PR #285 removes one audited
-  unsupported/test-only NAIA resolution root-alias group
+- Current state: B-10b14 is integrated; B-10b15 in PR #286 removes one audited
+  unsupported/test-only conditioning root-alias group
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -74,8 +74,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 340 at the
-  B-10b14 PR head, with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 335 at the
+  B-10b15 PR head, with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -97,8 +97,8 @@ inferring public support from spelling or test imports:
   `_clear_aio_first_pass_cache`, plus `WILDCARD_SEED_RANGE_NOTE`, the seven
   B-10b9 SAM3 helpers, the two B-10b10 prompt-default constants, and the
   B-10b11 legacy Extend class root alias, the nine B-10b12 prompt-data aliases,
-  the 13 B-10b13 NAIA client aliases, and the 16 B-10b14 NAIA resolution
-  aliases; their production
+  the 13 B-10b13 NAIA client aliases, the 16 B-10b14 NAIA resolution aliases,
+  and the five B-10b15 conditioning aliases; their production
   consumers import or call the corresponding canonical owners directly;
 - repository test files with a direct `nodes` import: 21, recorded as migration
   consumers rather than public-support evidence.
@@ -280,6 +280,13 @@ EasyUseAnimaWildcard
   normal-package and synthetic package tests reject the retired names while
   preserving five runtime-resolved label/selection seams, bucket contents/order,
   input defaults, mapped classes, settings, and workflow behavior.
+- B-10b15 conditioning cleanup: the five audited unsupported aliases for the
+  enabled/disabled mode constants, profile choices, and Spectrum old-signature
+  warning state/dispatch are no longer root aliases. Canonical conditioning and
+  Prompt Data consumers import or call the owner directly; normal-package and
+  synthetic package tests reject the retired names while preserving nine
+  runtime-resolved conditioning seams, profile/mode values, mapped classes,
+  Spectrum fallback, warning-once behavior, and saved-workflow contracts.
 - B-08b2 internal AiO model-variant transition: Spectrum correction/forecast
   model patching and ephemeral model cleanup move to
   `easyuse_anima.aio.model_preparation`. Their four root private names remain

--- a/nodes.py
+++ b/nodes.py
@@ -218,18 +218,18 @@ try:
     from .easyuse_anima.prompt.conditioning import (
         ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE as ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE,
         ANIMA_MOD_GUIDANCE_MODES as ANIMA_MOD_GUIDANCE_MODES,
-        ANIMA_MOD_GUIDANCE_MODE_DISABLED as ANIMA_MOD_GUIDANCE_MODE_DISABLED,
-        ANIMA_MOD_GUIDANCE_MODE_ENABLED as ANIMA_MOD_GUIDANCE_MODE_ENABLED,
+        # B-10b15: disabled/enabled mode constants remain canonical-only.
+        # B-10b15: profile choices remain canonical-only.
         ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA as ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA,
-        ANIMA_MOD_GUIDANCE_PROFILES as ANIMA_MOD_GUIDANCE_PROFILES,
+        # B-10b15: the warning-once state remains canonical-only.
         ANIMA_MOD_GUIDANCE_PROFILE_OFF as ANIMA_MOD_GUIDANCE_PROFILE_OFF,
-        _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED as _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED,
+        # B-10b15: warning dispatch remains canonical-only.
         _apply_spectrum_anima_mod_guidance as _apply_spectrum_anima_mod_guidance,
         _bind_conditioning_runtime as _bind_conditioning_runtime,
         _find_spectrum_anima_mod_guidance_class as _find_spectrum_anima_mod_guidance_class,
         _normalize_anima_mod_guidance_profile as _normalize_anima_mod_guidance_profile,
         _resolve_anima_mod_guidance_enabled as _resolve_anima_mod_guidance_enabled,
-        _warn_old_spectrum_anima_mod_guidance_once as _warn_old_spectrum_anima_mod_guidance_once,
+        # B-10b15: five unsupported conditioning aliases were retired.
     )
     from .easyuse_anima.prompt.artist_mix import (
         ARTIST_MIX_CONTROL_KEY as ARTIST_MIX_CONTROL_KEY,
@@ -731,18 +731,18 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.prompt.conditioning import (
         ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE as ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE,
         ANIMA_MOD_GUIDANCE_MODES as ANIMA_MOD_GUIDANCE_MODES,
-        ANIMA_MOD_GUIDANCE_MODE_DISABLED as ANIMA_MOD_GUIDANCE_MODE_DISABLED,
-        ANIMA_MOD_GUIDANCE_MODE_ENABLED as ANIMA_MOD_GUIDANCE_MODE_ENABLED,
+        # B-10b15: disabled/enabled mode constants remain canonical-only.
+        # B-10b15: profile choices remain canonical-only.
         ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA as ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA,
-        ANIMA_MOD_GUIDANCE_PROFILES as ANIMA_MOD_GUIDANCE_PROFILES,
+        # B-10b15: the warning-once state remains canonical-only.
         ANIMA_MOD_GUIDANCE_PROFILE_OFF as ANIMA_MOD_GUIDANCE_PROFILE_OFF,
-        _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED as _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED,
+        # B-10b15: warning dispatch remains canonical-only.
         _apply_spectrum_anima_mod_guidance as _apply_spectrum_anima_mod_guidance,
         _bind_conditioning_runtime as _bind_conditioning_runtime,
         _find_spectrum_anima_mod_guidance_class as _find_spectrum_anima_mod_guidance_class,
         _normalize_anima_mod_guidance_profile as _normalize_anima_mod_guidance_profile,
         _resolve_anima_mod_guidance_enabled as _resolve_anima_mod_guidance_enabled,
-        _warn_old_spectrum_anima_mod_guidance_once as _warn_old_spectrum_anima_mod_guidance_once,
+        # B-10b15: five unsupported conditioning aliases were retired.
     )
     from easyuse_anima.prompt.artist_mix import (
         ARTIST_MIX_CONTROL_KEY as ARTIST_MIX_CONTROL_KEY,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -18676,68 +18676,6 @@
         "target": "easyuse_anima/prompt/conditioning.py"
       },
       {
-        "alias": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
-        "bound_name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
-          "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
-        "kind": "static_from",
-        "line": 218,
-        "name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.conditioning",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "alias": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
-        "bound_name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
-          "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
-        "kind": "static_from",
-        "line": 218,
-        "name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.conditioning",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
         "alias": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "bound_name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "branch_context": [
@@ -18769,37 +18707,6 @@
         "target": "easyuse_anima/prompt/conditioning.py"
       },
       {
-        "alias": "ANIMA_MOD_GUIDANCE_PROFILES",
-        "bound_name": "ANIMA_MOD_GUIDANCE_PROFILES",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "ANIMA_MOD_GUIDANCE_PROFILES",
-          "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
-        "kind": "static_from",
-        "line": 218,
-        "name": "ANIMA_MOD_GUIDANCE_PROFILES",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.conditioning",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
         "alias": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "branch_context": [
@@ -18823,37 +18730,6 @@
         "kind": "static_from",
         "line": 218,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.conditioning",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "alias": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
-        "bound_name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
-          "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
-        "kind": "static_from",
-        "line": 218,
-        "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
         "role": "compatibility_primary",
@@ -19009,37 +18885,6 @@
         "kind": "static_from",
         "line": 218,
         "name": "_resolve_anima_mod_guidance_enabled",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.conditioning",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "alias": "_warn_old_spectrum_anima_mod_guidance_once",
-        "bound_name": "_warn_old_spectrum_anima_mod_guidance_once",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_warn_old_spectrum_anima_mod_guidance_once",
-          "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
-        "kind": "static_from",
-        "line": 218,
-        "name": "_warn_old_spectrum_anima_mod_guidance_once",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
         "role": "compatibility_primary",
@@ -30539,74 +30384,6 @@
         "target": "easyuse_anima/prompt/conditioning.py"
       },
       {
-        "alias": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
-        "bound_name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
-          "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
-        "kind": "static_from",
-        "line": 731,
-        "name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.conditioning",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "alias": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
-        "bound_name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
-          "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
-        "kind": "static_from",
-        "line": 731,
-        "name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.conditioning",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
         "alias": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "bound_name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "branch_context": [
@@ -30641,40 +30418,6 @@
         "target": "easyuse_anima/prompt/conditioning.py"
       },
       {
-        "alias": "ANIMA_MOD_GUIDANCE_PROFILES",
-        "bound_name": "ANIMA_MOD_GUIDANCE_PROFILES",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "ANIMA_MOD_GUIDANCE_PROFILES",
-          "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
-        "kind": "static_from",
-        "line": 731,
-        "name": "ANIMA_MOD_GUIDANCE_PROFILES",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.conditioning",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
         "alias": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "branch_context": [
@@ -30701,40 +30444,6 @@
         "kind": "static_from",
         "line": 731,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.conditioning",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "alias": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
-        "bound_name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
-          "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
-        "kind": "static_from",
-        "line": 731,
-        "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
         "role": "compatibility_fallback",
@@ -30905,40 +30614,6 @@
         "kind": "static_from",
         "line": 731,
         "name": "_resolve_anima_mod_guidance_enabled",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.conditioning",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "alias": "_warn_old_spectrum_anima_mod_guidance_once",
-        "bound_name": "_warn_old_spectrum_anima_mod_guidance_once",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_warn_old_spectrum_anima_mod_guidance_once",
-          "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
-        "kind": "static_from",
-        "line": 731,
-        "name": "_warn_old_spectrum_anima_mod_guidance_once",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
         "role": "compatibility_fallback",
@@ -41021,7 +40696,7 @@
         "is_package": false,
         "loc": 2712,
         "module": "nodes",
-        "normalized_git_blob_sha1": "7cf4adc4a966c03fd3912db31f91b98f3d87d83b",
+        "normalized_git_blob_sha1": "84292b4cce402a0376c690600df7db0129f7ab93",
         "path": "nodes.py",
         "top_level": {
           "class_count": 2,
@@ -46108,52 +45783,6 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
-        "kind": "static_from",
-        "line": 731,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
-        "kind": "static_from",
-        "line": 731,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
         "line": 731,
@@ -46177,53 +45806,7 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
-        "kind": "static_from",
-        "line": 731,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
-        "kind": "static_from",
-        "line": 731,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
         "line": 731,
         "optional": false,
@@ -46339,29 +45922,6 @@
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
-        "kind": "static_from",
-        "line": 731,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
         "line": 731,
         "optional": false,

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "13a9cf4976b9b847dc68ddacca1763d862e647f9",
+    "base_commit": "a06ed305ae43253ef04d1650fb486784b2aed943",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -21,7 +21,8 @@
       "B-10b11",
       "B-10b12",
       "B-10b13",
-      "B-10b14"
+      "B-10b14",
+      "B-10b15"
     ]
   },
   "enums": {
@@ -56,7 +57,7 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 340,
+    "nodes_canonical_bindings": 335,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
@@ -1047,6 +1048,31 @@
     }
   },
   "retired_private_bindings": {
+    "ANIMA_MOD_GUIDANCE_MODE_DISABLED": {
+      "canonical_target": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
+      "owner": "#184/#188 B-10b15",
+      "reason": "canonical conditioning owner consumes the disabled mode internally"
+    },
+    "ANIMA_MOD_GUIDANCE_MODE_ENABLED": {
+      "canonical_target": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
+      "owner": "#184/#188 B-10b15",
+      "reason": "canonical conditioning owner consumes the enabled mode internally"
+    },
+    "ANIMA_MOD_GUIDANCE_PROFILES": {
+      "canonical_target": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
+      "owner": "#184/#188 B-10b15",
+      "reason": "canonical Prompt Data adapter imports the profiles directly"
+    },
+    "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED": {
+      "canonical_target": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
+      "owner": "#184/#188 B-10b15",
+      "reason": "canonical conditioning owner retains its warning-once state"
+    },
+    "_warn_old_spectrum_anima_mod_guidance_once": {
+      "canonical_target": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
+      "owner": "#184/#188 B-10b15",
+      "reason": "canonical modulation helper calls warning dispatch internally"
+    },
     "ADVANCED_RESOLUTION_BUCKETS": {
       "canonical_target": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
       "owner": "#184/#188 B-10b14",
@@ -3086,39 +3112,6 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.prompt.conditioning:unsupported_test_only",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "ANIMA_MOD_GUIDANCE_MODE_DISABLED": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
-        "ANIMA_MOD_GUIDANCE_MODE_ENABLED": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
-        "ANIMA_MOD_GUIDANCE_PROFILES": "ANIMA_MOD_GUIDANCE_PROFILES",
-        "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
-        "_warn_old_spectrum_anima_mod_guidance_once": "_warn_old_spectrum_anima_mod_guidance_once"
-      },
-      "classification": "unsupported_test_only",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.prompt.conditioning",
-      "target_state": "canonical",
-      "identity_requirement": "not_applicable",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.prompt.conditioning",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "repository tests may import this root name"
-      ],
-      "evidence": [
-        "AST:no nodes.py runtime load",
-        "test-only consumption is not public support evidence"
-      ],
-      "removal_gates": [
-        "test imports migrate to canonical targets",
-        "no production consumer evidence",
-        "separate B-10b removal review"
-      ],
-      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.correction:transitional_private_seam",

--- a/tests/test_aio_schema_contract.py
+++ b/tests/test_aio_schema_contract.py
@@ -15,6 +15,7 @@ import nodes
 from easyuse_anima.aio.generation_settings import (
     _aio_generation_config_from_dict,
 )
+from easyuse_anima.prompt.conditioning import ANIMA_MOD_GUIDANCE_PROFILES
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -392,7 +393,7 @@ def _authoritative_static_enum_choices() -> dict[tuple[str, ...], tuple[str, ...
         ),
         ("model_patches", "kj", "torch_compile", "dynamic"): ("auto", "true", "false"),
         ("mod_guidance", "mode"): tuple(nodes.ANIMA_MOD_GUIDANCE_MODES),
-        ("mod_guidance", "profile"): tuple(nodes.ANIMA_MOD_GUIDANCE_PROFILES),
+        ("mod_guidance", "profile"): tuple(ANIMA_MOD_GUIDANCE_PROFILES),
         ("artist_mix", "mode"): tuple(nodes.ARTIST_MIX_INPUT_MODES),
         ("highres", "upscale_method"): tuple(nodes.IMAGE_UPSCALE_METHODS),
         ("highres", "multiple"): tuple(nodes.IMAGE_SCALE_MULTIPLES),
@@ -425,7 +426,7 @@ def _authoritative_static_enum_choices() -> dict[tuple[str, ...], tuple[str, ...
 
 def _runtime_static_enum_choices(path: tuple[str, ...]) -> tuple[str, ...]:
     if path == ("mod_guidance", "profile"):
-        return tuple(nodes.ANIMA_MOD_GUIDANCE_PROFILES)
+        return tuple(ANIMA_MOD_GUIDANCE_PROFILES)
 
     marker = "__capture_runtime_static_enum_choices__"
     observed: list[tuple[str, ...]] = []

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1256,6 +1256,13 @@ class PromptDataConditioningMoveContractTests(unittest.TestCase):
         "_prompt_data_output",
         "_set_prompt_data_output",
     )
+    RETIRED_CONDITIONING_ALIASES = (
+        "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
+        "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
+        "ANIMA_MOD_GUIDANCE_PROFILES",
+        "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
+        "_warn_old_spectrum_anima_mod_guidance_once",
+    )
     NODE_CLASSES = (
         "EasyUseAnimaPromptDataUnpack",
         "EasyUseAnimaArtistMixConditioning",
@@ -1285,7 +1292,10 @@ class PromptDataConditioningMoveContractTests(unittest.TestCase):
     }
 
     def test_root_prompt_data_conditioning_objects_are_direct_canonical_aliases(self):
-        for name in self.RETIRED_PROMPT_DATA_ALIASES:
+        for name in (
+            *self.RETIRED_PROMPT_DATA_ALIASES,
+            *self.RETIRED_CONDITIONING_ALIASES,
+        ):
             with self.subTest(retired=name):
                 self.assertFalse(hasattr(nodes, name))
         for name in self.NODE_CLASSES:
@@ -1307,7 +1317,10 @@ class PromptDataConditioningMoveContractTests(unittest.TestCase):
             package_adapters = sys.modules[
                 f"{package_name}.easyuse_anima.nodes.prompt_data_nodes"
             ]
-            for name in self.RETIRED_PROMPT_DATA_ALIASES:
+            for name in (
+                *self.RETIRED_PROMPT_DATA_ALIASES,
+                *self.RETIRED_CONDITIONING_ALIASES,
+            ):
                 with self.subTest(retired=name):
                     self.assertFalse(hasattr(package_nodes, name))
             for name in self.NODE_CLASSES:

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,9 +73,9 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "7cf4adc4a966c03fd3912db31f91b98f3d87d83b")
-        # Issue #184 B-10b14 retires 16 unsupported/test-only NAIA resolution
-        # aliases while preserving bucket, scale, fit, and node behavior.
+        self.assertEqual(report["git_blob_sha1"], "84292b4cce402a0376c690600df7db0129f7ab93")
+        # Issue #184 B-10b15 retires five unsupported/test-only conditioning
+        # aliases while preserving mode/profile and Spectrum fallback behavior.
         self.assertEqual(report["top_level"]["function_count"], 41)
         self.assertEqual(report["top_level"]["class_count"], 2)
         self.assertEqual(report["line_count"], 2_712)

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -16,13 +16,13 @@ import settings as easyuse_settings
 from easyuse_anima.naia.client import _clean_prompt
 from easyuse_anima.naia.resolution import ADVANCED_RESOLUTION_BUCKETS
 from easyuse_anima.nodes.prompt_advanced_nodes import EasyUseAnimaPromptStudioExtend
+from easyuse_anima.prompt.conditioning import (
+    _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED,
+)
 from easyuse_anima.prompt.data import PROMPT_DATA_SCHEMA
 from easyuse_anima.prompt.fields import (
     DEFAULT_QUALITY_TAGS,
     DEFAULT_TRAILING_QUALITY_TAGS,
-)
-from easyuse_anima.prompt.conditioning import (
-    _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED,
 )
 from nodes import (
     ADVANCED_FIELDS_WORKFLOW_PROPERTY,

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -21,6 +21,9 @@ from easyuse_anima.prompt.fields import (
     DEFAULT_QUALITY_TAGS,
     DEFAULT_TRAILING_QUALITY_TAGS,
 )
+from easyuse_anima.prompt.conditioning import (
+    _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED,
+)
 from nodes import (
     ADVANCED_FIELDS_WORKFLOW_PROPERTY,
     ARTIST_MIX_CONTROL_KEY,
@@ -44,7 +47,6 @@ from nodes import (
     EasyUseAnimaPromptStudio,
     EasyUseAnimaPromptStudioAdvanced,
     EasyUseAnimaPromptStudioAdvancedV2,
-    _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED,
     _generate_empty_latent_with_comfy,
     _prompt_tokens,
 )

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -15,7 +15,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "13a9cf4976b9b847dc68ddacca1763d862e647f9"
+BASE_COMMIT = "a06ed305ae43253ef04d1650fb486784b2aed943"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -56,6 +56,40 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "sqrt": "math:sqrt",
 }
 RETIRED_PRIVATE_BINDINGS = {
+    "ANIMA_MOD_GUIDANCE_MODE_DISABLED": {
+        "canonical_target": (
+            "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED"
+        ),
+        "owner": "#184/#188 B-10b15",
+        "reason": "canonical conditioning owner consumes the disabled mode internally",
+    },
+    "ANIMA_MOD_GUIDANCE_MODE_ENABLED": {
+        "canonical_target": (
+            "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED"
+        ),
+        "owner": "#184/#188 B-10b15",
+        "reason": "canonical conditioning owner consumes the enabled mode internally",
+    },
+    "ANIMA_MOD_GUIDANCE_PROFILES": {
+        "canonical_target": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
+        "owner": "#184/#188 B-10b15",
+        "reason": "canonical Prompt Data adapter imports the profiles directly",
+    },
+    "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED": {
+        "canonical_target": (
+            "easyuse_anima.prompt.conditioning:"
+            "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"
+        ),
+        "owner": "#184/#188 B-10b15",
+        "reason": "canonical conditioning owner retains its warning-once state",
+    },
+    "_warn_old_spectrum_anima_mod_guidance_once": {
+        "canonical_target": (
+            "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once"
+        ),
+        "owner": "#184/#188 B-10b15",
+        "reason": "canonical modulation helper calls warning dispatch internally",
+    },
     "ADVANCED_RESOLUTION_BUCKETS": {
         "canonical_target": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "owner": "#184/#188 B-10b14",
@@ -991,6 +1025,7 @@ def _build_document() -> dict[str, Any]:
                 "B-10b12",
                 "B-10b13",
                 "B-10b14",
+                "B-10b15",
             ],
         },
         "enums": {
@@ -1003,7 +1038,7 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 340,
+            "nodes_canonical_bindings": 335,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,


### PR DESCRIPTION
## 변경 성격

- B-10b15 Contract-only cleanup
- Move/Behavior 변경 없음
- 기준: `dev@a06ed305ae43253ef04d1650fb486784b2aed943`

## 작업 전 inventory

### 제거할 root aliases (5)

- `ANIMA_MOD_GUIDANCE_MODE_DISABLED`
- `ANIMA_MOD_GUIDANCE_MODE_ENABLED`
- `ANIMA_MOD_GUIDANCE_PROFILES`
- `_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED`
- `_warn_old_spectrum_anima_mod_guidance_once`

### symbol / caller / alias

- canonical owner: `easyuse_anima.prompt.conditioning`
- `nodes.py`에는 relative/flat fallback import alias만 존재하며 production root caller는 없음
- `ANIMA_MOD_GUIDANCE_PROFILES`는 canonical Prompt Data adapter가 canonical module에서 직접 소비
- warning helper는 canonical `_apply_spectrum_anima_mod_guidance`가 owner 내부에서 직접 호출
- repository의 root 직접 소비는 테스트뿐이며 canonical import로 이동 예정
- runtime resolver, binder lookup, monkeypatch/setattr seam과 제거 대상의 교집합은 없음

### global state

- `_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED`는 canonical module이 소유하는 mutable set
- 현재 root alias는 같은 객체를 가리키지만 repository 소비는 테스트의 `.clear()`뿐이며 root rebinding seam은 아님
- canonical set과 warning-once 동작은 변경하지 않음

### 반드시 유지할 같은-owner transitional seams (9)

- `ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE`
- `ANIMA_MOD_GUIDANCE_MODES`
- `ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA`
- `ANIMA_MOD_GUIDANCE_PROFILE_OFF`
- `_apply_spectrum_anima_mod_guidance`
- `_bind_conditioning_runtime`
- `_find_spectrum_anima_mod_guidance_class`
- `_normalize_anima_mod_guidance_profile`
- `_resolve_anima_mod_guidance_enabled`

AiO resolver, root binder, defaults와 기존 테스트 patch seam이 실제 소비하므로 유지합니다.

## allowed-file boundary

- `nodes.py`
- `tests/test_node_contracts.py`
- `tests/test_prompt_corrector.py`
- `tests/test_aio_schema_contract.py`
- `tests/test_python_compatibility_surface.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## forbidden boundary

- `easyuse_anima/prompt/conditioning.py`
- `easyuse_anima/nodes/prompt_data_nodes.py`
- `easyuse_anima/aio/**`, `__init__.py`
- frontend, workflow fixture, release/Registry 파일
- widget/profile 문자열, mapping, Spectrum fallback 및 warning behavior 변경

## 예상 계약 변화

- canonical root bindings `340 → 335`
- compatibility groups `62 → 61`, canonical groups `52 → 51`, unsupported groups `5 → 4`
- retired bindings `61 → 66`
- backend import edges `1478 → 1468`
- legacy/mapped/residual/binder/resolver/direct-root-test 지표는 유지

## 검증 계획

- focused `unittest`: Prompt Data conditioning contract/behavior, AiO schema, compatibility surface, analyzer
- 독립 diff review
- merge 전 exact-head `tools/check_project.ps1 -Profile full`

## 구현 및 focused 검증

- root relative/flat import에서 위 5개 alias만 제거
- `test_aio_schema_contract.py`의 profile choices와
  `test_prompt_corrector.py`의 warning-once set을 canonical import로 이동
- normal root 및 synthetic package root에서 retired names 부재를 검증
- compatibility surface: canonical bindings `340 → 335`, retired `61 → 66`
- backend analyzer: import edges `1478 → 1468`(제거 10, 추가 0),
  compatibility fallback `425 → 420`(제거 5, 추가 0)
- module graph, SCC, state, side effect, public surface, package closure는 동일
- focused `unittest`: 59 tests passed
- focused 실행 환경: ComfyUI Codex test-instance Python, repository worktree
- live ComfyUI smoke: 미실행(실행 behavior와 workflow/UI payload를 바꾸지 않는 Contract-only cleanup)

## 독립 리뷰 및 공식 full

- 독립 review 최초 finding: roadmap 통합 기준 SHA 1곳 불일치
- 조치: 실제 base `a06ed305ae43253ef04d1650fb486784b2aed943`로 수정
- exact head `82016ad8dea9fc226a79679b849b3dff61f2085e` 재검토: findings 없음
- 공식 full runner: 통과
  - Python `unittest`: 871 passed
  - frontend: 114 JavaScript files passed
  - Pyright baseline ratchet: 60 files / 60 known errors / 증가 없음
  - import boundary: 6 package groups / 0 violations
  - Python compile, analyzer/fixture, `git diff --check`: 통과
  - Ruff: 기존 105건 report-only, blocking failure 없음

## 위험 및 미확인

- 문서화되지 않은 외부 `from nodes import ...` 소비자는 이번 unsupported alias retirement로 중단될 수 있음
- repository mapping, workflow, runtime caller에는 해당 소비가 없음을 확인함
- live ComfyUI/browser smoke는 Contract-only root alias 정리 범위에서 수행하지 않음
