### PR TITLE
refactor(backend): retire Artist Mix parsing aliases (B-10b18)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `251bf0c5a38637cf3c1fd41d262f532399bd83aa`
+- Integrated `dev` snapshot commit: `048c4f6df845206dd2c32090dcaa0440aec9e92e`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-10b16; B-10b17 Regional alias cleanup in review in PR #288 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
+| B - `nodes.py` extraction | Integrated through B-10b17; B-10b18 Artist Mix parsing alias cleanup in review in PR #289 | Integrate scoped B-10b cleanup before registration/bootstrap and the final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -295,7 +295,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 10 | B-09b1 AiO legacy orchestration body move | COMPLETE on `dev` | Move | #184 | PR #269 / `7484dc7` |
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
-| 13 | B-10b private alias reduction | IN REVIEW: B-10b17 PR #288 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
+| 13 | B-10b private alias reduction | IN REVIEW: B-10b18 PR #289 | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | BLOCKED by B-10b | Move | #184 | Supported alias surface frozen after scoped cleanup |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
@@ -621,8 +621,8 @@ reported as unexecuted, not passed.
 
 ### B-10b — Private alias reduction
 
-- **Status:** B-10b1 through B-10b16 are complete on `dev` through PR #287 /
-  `251bf0c`; B-10b17 is in review in PR #288 from that integrated base.
+- **Status:** B-10b1 through B-10b17 are complete on `dev` through PR #288 /
+  `048c4f6`; B-10b18 is in review in PR #289 from that integrated base.
 - **Type:** small compatibility cleanup PRs, one owner/surface at a time
 - Remove unsupported/test-only aliases after tests use canonical paths.
 - Retain an actual monkeypatch seam only when the consumer and call-time binding
@@ -746,6 +746,14 @@ owner directly. Fourteen runtime-resolved Regional seams remain; schema/type
 and workflow-property strings, mask geometry, prompt/conditioning assembly,
 mapped classes, frontend properties, and saved-workflow contracts stay
 unchanged.
+
+B-10b18 removes 11 private parsing/config helpers from the 53-symbol
+`easyuse_anima.prompt.artist_mix` unsupported root-alias group. Canonical
+Artist Mix code already calls these helpers lexically; no root runtime caller,
+resolver, binder, or patch seam consumes them. The remaining 42 Artist Mix
+aliases are deliberately split into a constants/mode unit and a conditioning/
+tensor unit. Parser/config behavior, 25 runtime-resolved seams, mapped classes,
+metadata, sockets, and saved-workflow contracts stay unchanged.
 
 ### B-11 — Registration, bootstrap, and final `nodes.py` shim
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,13 +3,13 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `251bf0c5a38637cf3c1fd41d262f532399bd83aa`
+  `048c4f6df845206dd2c32090dcaa0440aec9e92e`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-10b16 is integrated; B-10b17 in PR #288 removes one audited
-  unsupported/test-only Regional root-alias group
+- Current state: B-10b17 is integrated; B-10b18 in PR #289 removes the first
+  audited Artist Mix parsing/config subset
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -74,8 +74,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 311 at the
-  B-10b17 PR head, with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 300 at the
+  B-10b18 PR head, with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -99,7 +99,8 @@ inferring public support from spelling or test imports:
   B-10b11 legacy Extend class root alias, the nine B-10b12 prompt-data aliases,
   the 13 B-10b13 NAIA client aliases, the 16 B-10b14 NAIA resolution aliases,
   the five B-10b15 conditioning aliases, the 12 B-10b16 Prompt Advanced aliases,
-  and the 12 B-10b17 Regional aliases; their production
+  the 12 B-10b17 Regional aliases, and the 11 B-10b18 Artist Mix parsing/config
+  aliases; their production
   consumers import or call the corresponding canonical owners directly;
 - repository test files with a direct `nodes` import: 21, recorded as migration
   consumers rather than public-support evidence.
@@ -303,6 +304,12 @@ EasyUseAnimaWildcard
   tests reject the retired names while preserving 14 runtime-resolved Regional
   seams, exact serialized strings/payloads, mask/prompt behavior, mapped
   classes, frontend properties, and saved-workflow contracts.
+- B-10b18 Artist Mix parsing/config cleanup: 11 audited private helpers for
+  token/block/item/group parsing and prompt-data artist config are no longer
+  root aliases. Canonical Artist Mix code calls the owner helpers lexically;
+  normal-package and synthetic package tests reject the retired names while
+  preserving the remaining 42 audited aliases, 25 runtime-resolved seams,
+  exact parser/config/tensor/mode behavior, mappings, and workflow contracts.
 - B-08b2 internal AiO model-variant transition: Spectrum correction/forecast
   model patching and ephemeral model cleanup move to
   `easyuse_anima.aio.model_preparation`. Their four root private names remain

--- a/nodes.py
+++ b/nodes.py
@@ -265,18 +265,18 @@ try:
         ARTIST_TAG_POSITION_MODES as ARTIST_TAG_POSITION_MODES,
         _artist_conditioning_feature as _artist_conditioning_feature,
         _artist_delta_rms_from_encoded as _artist_delta_rms_from_encoded,
-        _artist_group_token as _artist_group_token,
+        # B-10b18: artist group-token parsing remains canonical-only.
         _artist_mix_inline_prompt as _artist_mix_inline_prompt,
         _artist_mix_mode_tooltip as _artist_mix_mode_tooltip,
-        _artist_mix_prompt_tags as _artist_mix_prompt_tags,
+        # B-10b18: parsed prompt tags remain canonical-only.
         _artist_prompt_with_position as _artist_prompt_with_position,
         _artist_tags_from_prompt as _artist_tags_from_prompt,
-        _artist_variant_prompt_from_prompt_data as _artist_variant_prompt_from_prompt_data,
+        # B-10b18: prompt-data artist variants remain canonical-only.
         _bind_artist_mix_runtime as _bind_artist_mix_runtime,
         _blend_conditionings as _blend_conditionings,
         _bounded_artist_mix_float as _bounded_artist_mix_float,
         _bounded_artist_mix_int as _bounded_artist_mix_int,
-        _coalesce_artist_mix_items as _coalesce_artist_mix_items,
+        # B-10b18: parsed item coalescing remains canonical-only.
         _conditionings_with_range as _conditionings_with_range,
         _conditionings_with_strength as _conditionings_with_strength,
         _conditionings_with_values as _conditionings_with_values,
@@ -302,14 +302,14 @@ try:
         _normalize_weight_values as _normalize_weight_values,
         _normalized_artist_weights as _normalized_artist_weights,
         _pad_conditioning_tensor as _pad_conditioning_tensor,
-        _parse_artist_mix_entries as _parse_artist_mix_entries,
-        _parse_artist_mix_group as _parse_artist_mix_group,
+        # B-10b18: Artist Mix entry parsing remains canonical-only.
+        # B-10b18: Artist Mix group parsing remains canonical-only.
         _parse_artist_mix_items as _parse_artist_mix_items,
-        _prompt_data_artist_base_prompt as _prompt_data_artist_base_prompt,
-        _prompt_data_artist_mix_config as _prompt_data_artist_mix_config,
-        _prompt_data_positive_fields as _prompt_data_positive_fields,
-        _split_artist_mix_blocks as _split_artist_mix_blocks,
-        _split_artist_mix_items as _split_artist_mix_items,
+        # B-10b18: prompt-data artist base prompt remains canonical-only.
+        # B-10b18: prompt-data Artist Mix config remains canonical-only.
+        # B-10b18: prompt-data positive fields remain canonical-only.
+        # B-10b18: Artist Mix block splitting remains canonical-only.
+        # B-10b18: Artist Mix item splitting remains canonical-only.
     )
     from .easyuse_anima.nodes.prompt_data_nodes import (
         EasyUseAnimaArtistMixConditioning as EasyUseAnimaArtistMixConditioning,
@@ -778,18 +778,18 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         ARTIST_TAG_POSITION_MODES as ARTIST_TAG_POSITION_MODES,
         _artist_conditioning_feature as _artist_conditioning_feature,
         _artist_delta_rms_from_encoded as _artist_delta_rms_from_encoded,
-        _artist_group_token as _artist_group_token,
+        # B-10b18: artist group-token parsing remains canonical-only.
         _artist_mix_inline_prompt as _artist_mix_inline_prompt,
         _artist_mix_mode_tooltip as _artist_mix_mode_tooltip,
-        _artist_mix_prompt_tags as _artist_mix_prompt_tags,
+        # B-10b18: parsed prompt tags remain canonical-only.
         _artist_prompt_with_position as _artist_prompt_with_position,
         _artist_tags_from_prompt as _artist_tags_from_prompt,
-        _artist_variant_prompt_from_prompt_data as _artist_variant_prompt_from_prompt_data,
+        # B-10b18: prompt-data artist variants remain canonical-only.
         _bind_artist_mix_runtime as _bind_artist_mix_runtime,
         _blend_conditionings as _blend_conditionings,
         _bounded_artist_mix_float as _bounded_artist_mix_float,
         _bounded_artist_mix_int as _bounded_artist_mix_int,
-        _coalesce_artist_mix_items as _coalesce_artist_mix_items,
+        # B-10b18: parsed item coalescing remains canonical-only.
         _conditionings_with_range as _conditionings_with_range,
         _conditionings_with_strength as _conditionings_with_strength,
         _conditionings_with_values as _conditionings_with_values,
@@ -815,14 +815,14 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _normalize_weight_values as _normalize_weight_values,
         _normalized_artist_weights as _normalized_artist_weights,
         _pad_conditioning_tensor as _pad_conditioning_tensor,
-        _parse_artist_mix_entries as _parse_artist_mix_entries,
-        _parse_artist_mix_group as _parse_artist_mix_group,
+        # B-10b18: Artist Mix entry parsing remains canonical-only.
+        # B-10b18: Artist Mix group parsing remains canonical-only.
         _parse_artist_mix_items as _parse_artist_mix_items,
-        _prompt_data_artist_base_prompt as _prompt_data_artist_base_prompt,
-        _prompt_data_artist_mix_config as _prompt_data_artist_mix_config,
-        _prompt_data_positive_fields as _prompt_data_positive_fields,
-        _split_artist_mix_blocks as _split_artist_mix_blocks,
-        _split_artist_mix_items as _split_artist_mix_items,
+        # B-10b18: prompt-data artist base prompt remains canonical-only.
+        # B-10b18: prompt-data Artist Mix config remains canonical-only.
+        # B-10b18: prompt-data positive fields remain canonical-only.
+        # B-10b18: Artist Mix block splitting remains canonical-only.
+        # B-10b18: Artist Mix item splitting remains canonical-only.
     )
     from easyuse_anima.nodes.prompt_data_nodes import (
         EasyUseAnimaArtistMixConditioning as EasyUseAnimaArtistMixConditioning,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -19172,37 +19172,6 @@
         "target": "easyuse_anima/prompt/artist_mix.py"
       },
       {
-        "alias": "_artist_group_token",
-        "bound_name": "_artist_group_token",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_artist_group_token",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.artist_mix:_artist_group_token",
-        "kind": "static_from",
-        "line": 234,
-        "name": "_artist_group_token",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
         "alias": "_artist_mix_inline_prompt",
         "bound_name": "_artist_mix_inline_prompt",
         "branch_context": [
@@ -19265,37 +19234,6 @@
         "target": "easyuse_anima/prompt/artist_mix.py"
       },
       {
-        "alias": "_artist_mix_prompt_tags",
-        "bound_name": "_artist_mix_prompt_tags",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_artist_mix_prompt_tags",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
-        "kind": "static_from",
-        "line": 234,
-        "name": "_artist_mix_prompt_tags",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
         "alias": "_artist_prompt_with_position",
         "bound_name": "_artist_prompt_with_position",
         "branch_context": [
@@ -19350,37 +19288,6 @@
         "kind": "static_from",
         "line": 234,
         "name": "_artist_tags_from_prompt",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_artist_variant_prompt_from_prompt_data",
-        "bound_name": "_artist_variant_prompt_from_prompt_data",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_artist_variant_prompt_from_prompt_data",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
-        "kind": "static_from",
-        "line": 234,
-        "name": "_artist_variant_prompt_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
         "role": "compatibility_primary",
@@ -19505,37 +19412,6 @@
         "kind": "static_from",
         "line": 234,
         "name": "_bounded_artist_mix_int",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_coalesce_artist_mix_items",
-        "bound_name": "_coalesce_artist_mix_items",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_coalesce_artist_mix_items",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
-        "kind": "static_from",
-        "line": 234,
-        "name": "_coalesce_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
         "role": "compatibility_primary",
@@ -20319,68 +20195,6 @@
         "target": "easyuse_anima/prompt/artist_mix.py"
       },
       {
-        "alias": "_parse_artist_mix_entries",
-        "bound_name": "_parse_artist_mix_entries",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_parse_artist_mix_entries",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
-        "kind": "static_from",
-        "line": 234,
-        "name": "_parse_artist_mix_entries",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_parse_artist_mix_group",
-        "bound_name": "_parse_artist_mix_group",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_parse_artist_mix_group",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
-        "kind": "static_from",
-        "line": 234,
-        "name": "_parse_artist_mix_group",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
         "alias": "_parse_artist_mix_items",
         "bound_name": "_parse_artist_mix_items",
         "branch_context": [
@@ -20404,161 +20218,6 @@
         "kind": "static_from",
         "line": 234,
         "name": "_parse_artist_mix_items",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_prompt_data_artist_base_prompt",
-        "bound_name": "_prompt_data_artist_base_prompt",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_prompt_data_artist_base_prompt",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
-        "kind": "static_from",
-        "line": 234,
-        "name": "_prompt_data_artist_base_prompt",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_prompt_data_artist_mix_config",
-        "bound_name": "_prompt_data_artist_mix_config",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_prompt_data_artist_mix_config",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
-        "kind": "static_from",
-        "line": 234,
-        "name": "_prompt_data_artist_mix_config",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_prompt_data_positive_fields",
-        "bound_name": "_prompt_data_positive_fields",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_prompt_data_positive_fields",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
-        "kind": "static_from",
-        "line": 234,
-        "name": "_prompt_data_positive_fields",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_split_artist_mix_blocks",
-        "bound_name": "_split_artist_mix_blocks",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_split_artist_mix_blocks",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
-        "kind": "static_from",
-        "line": 234,
-        "name": "_split_artist_mix_blocks",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_split_artist_mix_items",
-        "bound_name": "_split_artist_mix_items",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_split_artist_mix_items",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
-        "kind": "static_from",
-        "line": 234,
-        "name": "_split_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
         "role": "compatibility_primary",
@@ -30184,40 +29843,6 @@
         "target": "easyuse_anima/prompt/artist_mix.py"
       },
       {
-        "alias": "_artist_group_token",
-        "bound_name": "_artist_group_token",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_artist_group_token",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
-        "kind": "static_from",
-        "line": 747,
-        "name": "_artist_group_token",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
         "alias": "_artist_mix_inline_prompt",
         "bound_name": "_artist_mix_inline_prompt",
         "branch_context": [
@@ -30286,40 +29911,6 @@
         "target": "easyuse_anima/prompt/artist_mix.py"
       },
       {
-        "alias": "_artist_mix_prompt_tags",
-        "bound_name": "_artist_mix_prompt_tags",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_artist_mix_prompt_tags",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
-        "kind": "static_from",
-        "line": 747,
-        "name": "_artist_mix_prompt_tags",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
         "alias": "_artist_prompt_with_position",
         "bound_name": "_artist_prompt_with_position",
         "branch_context": [
@@ -30380,40 +29971,6 @@
         "kind": "static_from",
         "line": 747,
         "name": "_artist_tags_from_prompt",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_artist_variant_prompt_from_prompt_data",
-        "bound_name": "_artist_variant_prompt_from_prompt_data",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_artist_variant_prompt_from_prompt_data",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
-        "kind": "static_from",
-        "line": 747,
-        "name": "_artist_variant_prompt_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
         "role": "compatibility_fallback",
@@ -30550,40 +30107,6 @@
         "kind": "static_from",
         "line": 747,
         "name": "_bounded_artist_mix_int",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_coalesce_artist_mix_items",
-        "bound_name": "_coalesce_artist_mix_items",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_coalesce_artist_mix_items",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
-        "kind": "static_from",
-        "line": 747,
-        "name": "_coalesce_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
         "role": "compatibility_fallback",
@@ -31442,74 +30965,6 @@
         "target": "easyuse_anima/prompt/artist_mix.py"
       },
       {
-        "alias": "_parse_artist_mix_entries",
-        "bound_name": "_parse_artist_mix_entries",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_parse_artist_mix_entries",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
-        "kind": "static_from",
-        "line": 747,
-        "name": "_parse_artist_mix_entries",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_parse_artist_mix_group",
-        "bound_name": "_parse_artist_mix_group",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_parse_artist_mix_group",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
-        "kind": "static_from",
-        "line": 747,
-        "name": "_parse_artist_mix_group",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
         "alias": "_parse_artist_mix_items",
         "bound_name": "_parse_artist_mix_items",
         "branch_context": [
@@ -31536,176 +30991,6 @@
         "kind": "static_from",
         "line": 747,
         "name": "_parse_artist_mix_items",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_prompt_data_artist_base_prompt",
-        "bound_name": "_prompt_data_artist_base_prompt",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_prompt_data_artist_base_prompt",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
-        "kind": "static_from",
-        "line": 747,
-        "name": "_prompt_data_artist_base_prompt",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_prompt_data_artist_mix_config",
-        "bound_name": "_prompt_data_artist_mix_config",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_prompt_data_artist_mix_config",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
-        "kind": "static_from",
-        "line": 747,
-        "name": "_prompt_data_artist_mix_config",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_prompt_data_positive_fields",
-        "bound_name": "_prompt_data_positive_fields",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_prompt_data_positive_fields",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
-        "kind": "static_from",
-        "line": 747,
-        "name": "_prompt_data_positive_fields",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_split_artist_mix_blocks",
-        "bound_name": "_split_artist_mix_blocks",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_split_artist_mix_blocks",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
-        "kind": "static_from",
-        "line": 747,
-        "name": "_split_artist_mix_blocks",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_split_artist_mix_items",
-        "bound_name": "_split_artist_mix_items",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_split_artist_mix_items",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 11
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
-        "kind": "static_from",
-        "line": 747,
-        "name": "_split_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
         "role": "compatibility_fallback",
@@ -39136,7 +38421,7 @@
         "is_package": false,
         "loc": 2712,
         "module": "nodes",
-        "normalized_git_blob_sha1": "c05df92f2abb2aac76c9ff9fd3757d02750f1893",
+        "normalized_git_blob_sha1": "e4cb8e09d2d1e0eed72bf385f9a5c5ad8ff21721",
         "path": "nodes.py",
         "top_level": {
           "class_count": 2,
@@ -44591,29 +43876,6 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
-        "kind": "static_from",
-        "line": 747,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
         "line": 747,
@@ -44660,29 +43922,6 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
-        "kind": "static_from",
-        "line": 747,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
         "line": 747,
@@ -44707,29 +43946,6 @@
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
-        "kind": "static_from",
-        "line": 747,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
         "line": 747,
         "optional": false,
@@ -44822,29 +44038,6 @@
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
-        "kind": "static_from",
-        "line": 747,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
         "line": 747,
         "optional": false,
@@ -45442,168 +44635,7 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
-        "kind": "static_from",
-        "line": 747,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
-        "kind": "static_from",
-        "line": 747,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
-        "kind": "static_from",
-        "line": 747,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
-        "kind": "static_from",
-        "line": 747,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
-        "kind": "static_from",
-        "line": 747,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
-        "kind": "static_from",
-        "line": 747,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
-        "kind": "static_from",
-        "line": 747,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 524,
-            "kind": "try",
-            "line": 11
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
         "line": 747,
         "optional": false,

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "251bf0c5a38637cf3c1fd41d262f532399bd83aa",
+    "base_commit": "048c4f6df845206dd2c32090dcaa0440aec9e92e",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -24,7 +24,8 @@
       "B-10b14",
       "B-10b15",
       "B-10b16",
-      "B-10b17"
+      "B-10b17",
+      "B-10b18"
     ]
   },
   "enums": {
@@ -59,7 +60,7 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 311,
+    "nodes_canonical_bindings": 300,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
@@ -1050,6 +1051,61 @@
     }
   },
   "retired_private_bindings": {
+    "_artist_group_token": {
+      "canonical_target": "easyuse_anima.prompt.artist_mix:_artist_group_token",
+      "owner": "#184/#188 B-10b18",
+      "reason": "canonical Artist Mix parser calls group-token handling internally"
+    },
+    "_artist_mix_prompt_tags": {
+      "canonical_target": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
+      "owner": "#184/#188 B-10b18",
+      "reason": "canonical Artist Mix owner extracts parsed prompt tags internally"
+    },
+    "_artist_variant_prompt_from_prompt_data": {
+      "canonical_target": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
+      "owner": "#184/#188 B-10b18",
+      "reason": "canonical Artist Mix owner builds prompt-data variants internally"
+    },
+    "_coalesce_artist_mix_items": {
+      "canonical_target": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
+      "owner": "#184/#188 B-10b18",
+      "reason": "canonical Artist Mix parser coalesces items internally"
+    },
+    "_parse_artist_mix_entries": {
+      "canonical_target": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
+      "owner": "#184/#188 B-10b18",
+      "reason": "canonical Artist Mix owner parses entries internally"
+    },
+    "_parse_artist_mix_group": {
+      "canonical_target": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
+      "owner": "#184/#188 B-10b18",
+      "reason": "canonical Artist Mix owner parses groups internally"
+    },
+    "_prompt_data_artist_base_prompt": {
+      "canonical_target": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
+      "owner": "#184/#188 B-10b18",
+      "reason": "canonical Artist Mix owner resolves the base prompt internally"
+    },
+    "_prompt_data_artist_mix_config": {
+      "canonical_target": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
+      "owner": "#184/#188 B-10b18",
+      "reason": "canonical Artist Mix owner resolves prompt-data config internally"
+    },
+    "_prompt_data_positive_fields": {
+      "canonical_target": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
+      "owner": "#184/#188 B-10b18",
+      "reason": "canonical Artist Mix owner reads positive fields internally"
+    },
+    "_split_artist_mix_blocks": {
+      "canonical_target": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
+      "owner": "#184/#188 B-10b18",
+      "reason": "canonical Artist Mix parser splits blocks internally"
+    },
+    "_split_artist_mix_items": {
+      "canonical_target": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
+      "owner": "#184/#188 B-10b18",
+      "reason": "canonical Artist Mix parser splits items internally"
+    },
     "REGIONAL_CONFIG_VERSION": {
       "canonical_target": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
       "owner": "#184/#188 B-10b17",
@@ -3095,10 +3151,6 @@
         "ARTIST_TAG_POSITION_MODES": "ARTIST_TAG_POSITION_MODES",
         "_artist_conditioning_feature": "_artist_conditioning_feature",
         "_artist_delta_rms_from_encoded": "_artist_delta_rms_from_encoded",
-        "_artist_group_token": "_artist_group_token",
-        "_artist_mix_prompt_tags": "_artist_mix_prompt_tags",
-        "_artist_variant_prompt_from_prompt_data": "_artist_variant_prompt_from_prompt_data",
-        "_coalesce_artist_mix_items": "_coalesce_artist_mix_items",
         "_conditionings_with_range": "_conditionings_with_range",
         "_conditionings_with_strength": "_conditionings_with_strength",
         "_conditionings_with_values": "_conditionings_with_values",
@@ -3117,14 +3169,7 @@
         "_mark_artist_mix_conditioning": "_mark_artist_mix_conditioning",
         "_normalize_weight_values": "_normalize_weight_values",
         "_normalized_artist_weights": "_normalized_artist_weights",
-        "_pad_conditioning_tensor": "_pad_conditioning_tensor",
-        "_parse_artist_mix_entries": "_parse_artist_mix_entries",
-        "_parse_artist_mix_group": "_parse_artist_mix_group",
-        "_prompt_data_artist_base_prompt": "_prompt_data_artist_base_prompt",
-        "_prompt_data_artist_mix_config": "_prompt_data_artist_mix_config",
-        "_prompt_data_positive_fields": "_prompt_data_positive_fields",
-        "_split_artist_mix_blocks": "_split_artist_mix_blocks",
-        "_split_artist_mix_items": "_split_artist_mix_items"
+        "_pad_conditioning_tensor": "_pad_conditioning_tensor"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1265,6 +1265,19 @@ class PromptDataConditioningMoveContractTests(unittest.TestCase):
         "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "_warn_old_spectrum_anima_mod_guidance_once",
     )
+    RETIRED_ARTIST_MIX_PARSING_ALIASES = (
+        "_artist_group_token",
+        "_artist_mix_prompt_tags",
+        "_artist_variant_prompt_from_prompt_data",
+        "_coalesce_artist_mix_items",
+        "_parse_artist_mix_entries",
+        "_parse_artist_mix_group",
+        "_prompt_data_artist_base_prompt",
+        "_prompt_data_artist_mix_config",
+        "_prompt_data_positive_fields",
+        "_split_artist_mix_blocks",
+        "_split_artist_mix_items",
+    )
     NODE_CLASSES = (
         "EasyUseAnimaPromptDataUnpack",
         "EasyUseAnimaArtistMixConditioning",
@@ -1297,6 +1310,7 @@ class PromptDataConditioningMoveContractTests(unittest.TestCase):
         for name in (
             *self.RETIRED_PROMPT_DATA_ALIASES,
             *self.RETIRED_CONDITIONING_ALIASES,
+            *self.RETIRED_ARTIST_MIX_PARSING_ALIASES,
         ):
             with self.subTest(retired=name):
                 self.assertFalse(hasattr(nodes, name))
@@ -1322,6 +1336,7 @@ class PromptDataConditioningMoveContractTests(unittest.TestCase):
             for name in (
                 *self.RETIRED_PROMPT_DATA_ALIASES,
                 *self.RETIRED_CONDITIONING_ALIASES,
+                *self.RETIRED_ARTIST_MIX_PARSING_ALIASES,
             ):
                 with self.subTest(retired=name):
                     self.assertFalse(hasattr(package_nodes, name))

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,9 +73,9 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "c05df92f2abb2aac76c9ff9fd3757d02750f1893")
-        # Issue #184 B-10b17 retires 12 unsupported/test-only Regional aliases
-        # while preserving schema, mask, prompt, workflow, and node behavior.
+        self.assertEqual(report["git_blob_sha1"], "e4cb8e09d2d1e0eed72bf385f9a5c5ad8ff21721")
+        # Issue #184 B-10b18 retires 11 unsupported Artist Mix parsing/config
+        # aliases while preserving parser, tensor, prompt, and node behavior.
         self.assertEqual(report["top_level"]["function_count"], 41)
         self.assertEqual(report["top_level"]["class_count"], 2)
         self.assertEqual(report["line_count"], 2_712)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -15,7 +15,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "251bf0c5a38637cf3c1fd41d262f532399bd83aa"
+BASE_COMMIT = "048c4f6df845206dd2c32090dcaa0440aec9e92e"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -56,6 +56,67 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "sqrt": "math:sqrt",
 }
 RETIRED_PRIVATE_BINDINGS = {
+    "_artist_group_token": {
+        "canonical_target": "easyuse_anima.prompt.artist_mix:_artist_group_token",
+        "owner": "#184/#188 B-10b18",
+        "reason": "canonical Artist Mix parser calls group-token handling internally",
+    },
+    "_artist_mix_prompt_tags": {
+        "canonical_target": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
+        "owner": "#184/#188 B-10b18",
+        "reason": "canonical Artist Mix owner extracts parsed prompt tags internally",
+    },
+    "_artist_variant_prompt_from_prompt_data": {
+        "canonical_target": (
+            "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data"
+        ),
+        "owner": "#184/#188 B-10b18",
+        "reason": "canonical Artist Mix owner builds prompt-data variants internally",
+    },
+    "_coalesce_artist_mix_items": {
+        "canonical_target": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
+        "owner": "#184/#188 B-10b18",
+        "reason": "canonical Artist Mix parser coalesces items internally",
+    },
+    "_parse_artist_mix_entries": {
+        "canonical_target": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
+        "owner": "#184/#188 B-10b18",
+        "reason": "canonical Artist Mix owner parses entries internally",
+    },
+    "_parse_artist_mix_group": {
+        "canonical_target": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
+        "owner": "#184/#188 B-10b18",
+        "reason": "canonical Artist Mix owner parses groups internally",
+    },
+    "_prompt_data_artist_base_prompt": {
+        "canonical_target": (
+            "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt"
+        ),
+        "owner": "#184/#188 B-10b18",
+        "reason": "canonical Artist Mix owner resolves the base prompt internally",
+    },
+    "_prompt_data_artist_mix_config": {
+        "canonical_target": (
+            "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config"
+        ),
+        "owner": "#184/#188 B-10b18",
+        "reason": "canonical Artist Mix owner resolves prompt-data config internally",
+    },
+    "_prompt_data_positive_fields": {
+        "canonical_target": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
+        "owner": "#184/#188 B-10b18",
+        "reason": "canonical Artist Mix owner reads positive fields internally",
+    },
+    "_split_artist_mix_blocks": {
+        "canonical_target": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
+        "owner": "#184/#188 B-10b18",
+        "reason": "canonical Artist Mix parser splits blocks internally",
+    },
+    "_split_artist_mix_items": {
+        "canonical_target": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
+        "owner": "#184/#188 B-10b18",
+        "reason": "canonical Artist Mix parser splits items internally",
+    },
     "REGIONAL_CONFIG_VERSION": {
         "canonical_target": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
         "owner": "#184/#188 B-10b17",
@@ -1170,6 +1231,7 @@ def _build_document() -> dict[str, Any]:
                 "B-10b15",
                 "B-10b16",
                 "B-10b17",
+                "B-10b18",
             ],
         },
         "enums": {
@@ -1182,7 +1244,7 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 311,
+            "nodes_canonical_bindings": 300,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,


### PR DESCRIPTION
## 변경 성격

- B-10b18 Contract-only cleanup
- Move/Behavior 변경 없음
- 기준: `dev@048c4f6df845206dd2c32090dcaa0440aec9e92e`
- Artist Mix 53개 전체를 섞지 않고 parsing/config private helper 11개만 처리

## 작업 전 inventory

### 제거할 root aliases (11)

- `_split_artist_mix_items`
- `_split_artist_mix_blocks`
- `_parse_artist_mix_group`
- `_artist_group_token`
- `_parse_artist_mix_entries`
- `_coalesce_artist_mix_items`
- `_artist_mix_prompt_tags`
- `_prompt_data_positive_fields`
- `_prompt_data_artist_base_prompt`
- `_artist_variant_prompt_from_prompt_data`
- `_prompt_data_artist_mix_config`

### symbol / caller / alias

- canonical owner: `easyuse_anima.prompt.artist_mix`
- `nodes.py`에는 relative/flat fallback import alias만 존재하며 제거 대상의 production root caller는 없음
- parsing/group/config helper는 canonical owner 내부 lexical call로만 소비
- repository 테스트도 위 11개를 root에서 직접 import/patch하지 않음
- runtime resolver, binder lookup, monkeypatch/setattr seam과 제거 대상의 교집합은 없음

### global state

- 제거 대상 11개는 mutable global을 소유하지 않는 pure/private helper
- canonical 함수 객체와 parser/config behavior는 변경하지 않음

### 반드시 유지할 같은-owner transitional seams (25)

- `ARTIST_MIX_DEFAULT_CLUSTER_COUNT`
- `ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION`, `ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD`
- `ARTIST_MIX_DEFAULT_EXACT_TOP_K`, `ARTIST_MIX_DEFAULT_RMS_SCALE_CAP`
- `ARTIST_MIX_DEFAULT_START_PERCENT`, `ARTIST_MIX_DEFAULT_STRENGTH_SCALE`
- `ARTIST_MIX_DEFAULT_STYLE_GAIN`
- `ARTIST_MIX_INPUT_MODES`, `ARTIST_MIX_MODE_FROM_PROMPT_DATA`
- `_artist_mix_inline_prompt`, `_artist_mix_mode_tooltip`
- `_artist_prompt_with_position`, `_artist_tags_from_prompt`
- `_bind_artist_mix_runtime`, `_blend_conditionings`
- `_bounded_artist_mix_float`, `_bounded_artist_mix_int`
- `_encode_artist_clustered`, `_encode_artist_delta_rms`
- `_encode_prompt_data_positive_conditioning`
- `_join_artist_mix_source_prompts`
- `_normalize_artist_mix_mode`, `_normalize_artist_tag_position`
- `_parse_artist_mix_items`

Prompt Data adapter resolver/binder와 production encoding path가 실제 소비하므로 유지합니다.

### 후속 분리 경계

- Artist Mix mode/constants 21개: 별도 Contract PR
- conditioning/tensor helpers 21개: 별도 Contract PR
- `EasyUseAnimaArtistMixConditioning` mapped public class와 Advanced/V2 mappings 유지

## allowed-file boundary

- `nodes.py`
- `tests/test_node_contracts.py`
- `tests/test_python_compatibility_surface.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## forbidden boundary

- `easyuse_anima/prompt/artist_mix.py`
- prompt-data/Prompt Advanced/AiO production modules
- frontend, locales, workflows, node-contract fixture, API/settings
- parser/config/tensor/mode value/order/metadata/socket/mapping behavior 변경
- 나머지 Artist Mix 42개 alias 제거

## 예상 계약 변화

- canonical root bindings `311 → 300`
- Artist Mix unsupported group symbols `53 → 42`; group 수와 unsupported group 수는 유지
- retired bindings `90 → 101`
- backend import edges `1420 → 1398`
- internal edges `697 → 686`
- compatibility fallback `396 → 385`
- legacy/mapped/residual/binder/resolver/direct-root-test 지표는 유지

## 검증 계획

- focused `unittest`: Artist Mix contract/representative parsing behavior, compatibility surface, analyzer
- 독립 diff review
- merge 전 exact-head `tools/check_project.ps1 -Profile full`

## 구현 및 focused 검증

- root relative/flat import에서 위 11개 alias만 제거
- normal root 및 synthetic package root에서 retired names 부재를 검증
- compatibility surface: canonical bindings `311 → 300`, retired `90 → 101`,
  Artist Mix unsupported symbols `53 → 42`
- backend analyzer: import edges `1420 → 1398`(제거 22, 추가 0),
  internal edges `697 → 686`, compatibility fallback `396 → 385`
- module graph, SCC, state, side effect, public surface, package closure는 동일
- focused `unittest`: 42 tests passed
- focused 실행 환경: ComfyUI Codex test-instance Python, repository worktree
- live ComfyUI smoke: 미실행(실행 behavior와 workflow/UI payload를 바꾸지 않는 Contract-only cleanup)

## 위험 및 미확인

- 문서화되지 않은 외부 `from nodes import ...` 소비자는 중단될 수 있음
- repository production/runtime/test seam에는 해당 소비가 없음을 확인함
- live ComfyUI/browser smoke는 Contract-only root alias 정리 범위에서 수행하지 않음

## 독립 리뷰

- findings 없음
- allowed 8 files와 제거 대상 11개 경계를 준수함
- `_parse_artist_mix_items`를 포함한 retained 25 seams와 나머지 Artist Mix 42개 alias를 유지함
- canonical owner, frontend, workflow 및 보호된 compatibility surface가 불변임을 확인함

## 공식 full 검증

- exact head: `809c42df7c1beb6f225a268996e48e5025913e5f`
- `tools/check_project.ps1 -Profile full`: passed
- Python `unittest`: 873 tests passed
- frontend: 114 JavaScript files passed
- Pyright baseline ratchet: 60 files / 60 errors / 증가 없음
- import boundary gate: 6 package groups / 0 violations
- Python compile 및 `git diff --check`: passed
- Ruff: 기존 G-01 report-only 105건, blocking 증가 없음
