### PR TITLE
refactor(backend): move shared input type residuals (B-11c1)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -53,9 +53,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   canonical under `easyuse_anima.nodes.aio_nodes`; root `nodes.py` retains its
   direct class/helper aliases and remaining support seams.
 - B-11a moved mapping composition to the pure `easyuse_anima.registration`
-  owner in PR #292. B-11b moves route-table registration and wildcard startup
-  to guarded `easyuse_anima.bootstrap` ownership in PR #293; the final
-  `nodes.py` shim remains, so B-11 is not complete.
+  owner in PR #292. B-11b moved route-table registration and wildcard startup
+  to guarded `easyuse_anima.bootstrap` ownership in PR #293 / `f2a2ec0`.
+  B-11c is split into residual-owner Moves before the final `nodes.py` shim;
+  B-11c1 starts with shared private input types in PR #294.
 
 ### Current quality baseline
 
@@ -297,7 +298,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a complete in PR #292 / `20c8b4d`; B-11b PR #293; B-11c remains | Move, split PRs | #184 | Supported alias surface frozen after scoped cleanup |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 input types PR #294 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -783,10 +784,19 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     `easyuse_anima.registration` and preserves root mapping/class identity.
     This unit is complete on `dev` in PR #292 / `20c8b4d`.
   - B-11b moves existing route and wildcard-directory initialization to a
-    guarded, idempotent `easyuse_anima.bootstrap` owner. PR #293 implements
-    this unit without changing route handlers or wildcard behavior.
-  - B-11c removes remaining root execution ownership and leaves the final
-    explicit supported `nodes.py` compatibility shim.
+    guarded, idempotent `easyuse_anima.bootstrap` owner. PR #293 / `f2a2ec0`
+    implements this unit without changing route handlers or wildcard behavior.
+  - The B-11c readiness audit found that one cutover would combine 41 residual
+    functions, 2 classes, 33 globals, and 28 runtime binders. B-11c therefore
+    first moves residual owners one vertical family at a time, then migrates
+    binder/resolver seams by family, and only then performs the final shim
+    cutover.
+  - B-11c1 moves `_AnyType`, `_FlexibleOptionalInputType`, and `_ANY_TYPE` to
+    side-effect-free `easyuse_anima.nodes.input_types`, while retaining direct
+    root aliases and the existing Regional, Prompt Advanced, and LoRA binder
+    calls. PR #294 owns this Move-only unit.
+  - The final B-11c cutover removes remaining root execution ownership and
+    leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no
   file I/O, route registration, capability discovery, service construction, or
   cache creation.

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `20c8b4d57243cc4b2c0423f43c9f0a2069707187`
+  `f2a2ec0198119caa9680ca86a8c5d4d068ab4ba8`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a is integrated in PR #292. B-11b PR #293 moves route and
-  wildcard startup to guarded `easyuse_anima.bootstrap` ownership; B-11c final
-  root shim remains a separate Move.
+- Current state: B-11a is integrated in PR #292 and B-11b in PR #293. B-11c is
+  split into residual-owner and binder Moves before the final root shim;
+  B-11c1 input-type ownership is tracked by PR #294.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,8 +75,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 258 at the
-  integrated B-10b20 baseline, with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 261 after
+  B-11c1 (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -84,8 +84,8 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 41 functions, 2 classes, and 33 assigned
-  globals.
+- root-owned residual implementation: 41 functions, 0 classes, and 32 assigned
+  globals after B-11c1 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 256, including
   literal lookups and binder-owned helper-name/default collections;
@@ -148,6 +148,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
   handlers once per shared ComfyUI route table, and guards successful wildcard
   startup through `easyuse_anima.bootstrap`. Handler bodies, URL/order,
   correlation wrappers, and wildcard implementation remain unchanged.
+
+### B-11c1 private input-type aliases
+
+- Canonical owner: `easyuse_anima.nodes.input_types`.
+- `_FlexibleOptionalInputType` and `_ANY_TYPE` remain transitional direct root
+  aliases because the Regional, Prompt Advanced, and LoRA runtime binders load
+  them during root composition. Their signatures and call timing are unchanged.
+- `_AnyType` has no remaining root production load after `_ANY_TYPE` moves, so
+  the machine-readable audit correctly classifies its retained direct alias as
+  unsupported/test-only rather than public support. It remains in PR #294 only
+  to keep this Move rollback-safe; removal requires a separate compatibility
+  review.
+- LoRA, Prompt Advanced, Regional, and Wildcard adapters import the shared
+  owner instead of retaining duplicate local definitions. Socket values,
+  workflow payloads, and mapped node-class identity do not change.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/nodes/input_types.py
+++ b/easyuse_anima/nodes/input_types.py
@@ -1,0 +1,24 @@
+"""Shared private ComfyUI input type helpers."""
+
+from __future__ import annotations
+
+__all__ = ()
+
+
+class _AnyType(str):
+    def __ne__(self, __value: object) -> bool:
+        return False
+
+
+class _FlexibleOptionalInputType(dict):
+    def __init__(self, input_type):
+        self.input_type = input_type
+
+    def __getitem__(self, key):
+        return (self.input_type,)
+
+    def __contains__(self, key):
+        return True
+
+
+_ANY_TYPE = _AnyType("*")

--- a/easyuse_anima/nodes/lora_nodes.py
+++ b/easyuse_anima/nodes/lora_nodes.py
@@ -16,25 +16,7 @@ from ..lora.metadata import (
     _raise_missing_loras,
 )
 from ..lora.preset import _correct_style_prompt, _format_strength, _select_profile_values
-
-
-class _AnyType(str):
-    def __ne__(self, __value: object) -> bool:
-        return False
-
-
-class _FlexibleOptionalInputType(dict):
-    def __init__(self, input_type):
-        self.input_type = input_type
-
-    def __getitem__(self, key):
-        return (self.input_type,)
-
-    def __contains__(self, key):
-        return True
-
-
-_ANY_TYPE = _AnyType("*")
+from .input_types import _ANY_TYPE, _FlexibleOptionalInputType
 
 
 def _bind_lora_node_runtime(*, resolve_helper, flexible_optional_input_type, any_type) -> None:

--- a/easyuse_anima/nodes/prompt_advanced_nodes.py
+++ b/easyuse_anima/nodes/prompt_advanced_nodes.py
@@ -30,6 +30,7 @@ from ..prompt.artist_mix import (
     ARTIST_MIX_STUDIO_MODES,
 )
 from ..prompt.data import PROMPT_DATA_TYPE
+from .input_types import _FlexibleOptionalInputType
 
 WILDCARD_MODE_SEQUENTIAL = "sequential"
 PROMPT_STUDIO_WILDCARD_MODE_LABELS = ("일반", "순차")
@@ -53,17 +54,6 @@ WILDCARD_SEED_RANGE_NOTE = (
     "legacy value; increment, decrement, and randomize return the next seed to the "
     "public range."
 )
-
-
-class _FlexibleOptionalInputType(dict):
-    def __init__(self, input_type):
-        self.input_type = input_type
-
-    def __getitem__(self, key):
-        return (self.input_type,)
-
-    def __contains__(self, key):
-        return True
 
 
 def _unbound_runtime(*_args, **_kwargs) -> Any:

--- a/easyuse_anima/nodes/regional_nodes.py
+++ b/easyuse_anima/nodes/regional_nodes.py
@@ -13,6 +13,7 @@ from ..prompt.regional import (
     REGIONAL_FIELDS_WORKFLOW_PROPERTY,
     REGIONAL_PROMPT_DATA_TYPE,
 )
+from .input_types import _FlexibleOptionalInputType
 
 
 WILDCARD_MODE_SEQUENTIAL = "sequential"
@@ -37,17 +38,6 @@ WILDCARD_SEED_RANGE_NOTE = (
     "legacy value; increment, decrement, and randomize return the next seed to the "
     "public range."
 )
-
-
-class _FlexibleOptionalInputType(dict):
-    def __init__(self, input_type):
-        self.input_type = input_type
-
-    def __getitem__(self, key):
-        return (self.input_type,)
-
-    def __contains__(self, key):
-        return True
 
 
 def _unbound_runtime(*_args, **_kwargs):

--- a/easyuse_anima/nodes/wildcard_nodes.py
+++ b/easyuse_anima/nodes/wildcard_nodes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ..common.serialization import _stable_change_key
 from ..common.values import _single_value
+from .input_types import _FlexibleOptionalInputType
 
 try:
     from ...wildcard_engine import (
@@ -50,22 +51,13 @@ WILDCARD_MODE_DISPLAY_LABELS = {
 }
 
 
-class _FlexibleOptionalInputType(dict):
-    def __init__(self, input_type):
-        self.input_type = input_type
-
-    def __getitem__(self, key):
-        return (self.input_type,)
-
-    def __contains__(self, key):
-        return True
-
-
 def _unbound_runtime(*_args, **_kwargs):
     raise RuntimeError("Wildcard node runtime dependencies are not bound.")
 
 
 _get_workflow_node = _unbound_runtime
+
+
 def _bind_wildcard_node_runtime(*, get_workflow_node, expand, normalize_seed_value, normalize_mode, sources_signature) -> None:
     global _get_workflow_node
     global expand_wildcards

--- a/nodes.py
+++ b/nodes.py
@@ -317,6 +317,11 @@ try:
         EasyUseAnimaPromptDataUnpack as EasyUseAnimaPromptDataUnpack,
         _bind_prompt_data_node_runtime as _bind_prompt_data_node_runtime,
     )
+    from .easyuse_anima.nodes.input_types import (
+        _ANY_TYPE as _ANY_TYPE,
+        _AnyType as _AnyType,
+        _FlexibleOptionalInputType as _FlexibleOptionalInputType,
+    )
     from .easyuse_anima.nodes.prompt_advanced_nodes import (
         EasyUseAnimaPromptStudioAdvanced as EasyUseAnimaPromptStudioAdvanced,
         EasyUseAnimaPromptStudioAdvancedV2 as EasyUseAnimaPromptStudioAdvancedV2,
@@ -829,6 +834,11 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         EasyUseAnimaPromptDataConditioning as EasyUseAnimaPromptDataConditioning,
         EasyUseAnimaPromptDataUnpack as EasyUseAnimaPromptDataUnpack,
         _bind_prompt_data_node_runtime as _bind_prompt_data_node_runtime,
+    )
+    from easyuse_anima.nodes.input_types import (
+        _ANY_TYPE as _ANY_TYPE,
+        _AnyType as _AnyType,
+        _FlexibleOptionalInputType as _FlexibleOptionalInputType,
     )
     from easyuse_anima.nodes.prompt_advanced_nodes import (
         EasyUseAnimaPromptStudioAdvanced as EasyUseAnimaPromptStudioAdvanced,
@@ -1535,23 +1545,6 @@ AIO_RESHIFT_DTYPES = ("bf16", "fp32")
 
 
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
-class _AnyType(str):
-    def __ne__(self, __value: object) -> bool:
-        return False
-
-
-class _FlexibleOptionalInputType(dict):
-    def __init__(self, input_type):
-        self.input_type = input_type
-
-    def __getitem__(self, key):
-        return (self.input_type,)
-
-    def __contains__(self, key):
-        return True
-
-
-_ANY_TYPE = _AnyType("*")
 
 
 def _normalize_aio_seed(value, default: int = AIO_SPECIAL_SEED_RANDOM) -> int:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -8759,6 +8759,23 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/nodes/lora_nodes.py"
       },
       {
@@ -8993,6 +9010,42 @@
         "scope": "<module>",
         "source": "easyuse_anima/nodes/lora_nodes.py",
         "target": "easyuse_anima/lora/preset.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_ANY_TYPE",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_types:_ANY_TYPE",
+        "kind": "static_from",
+        "line": 19,
+        "name": "_ANY_TYPE",
+        "optional": false,
+        "requested": ".input_types",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/lora_nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_FlexibleOptionalInputType",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_types:_FlexibleOptionalInputType",
+        "kind": "static_from",
+        "line": 19,
+        "name": "_FlexibleOptionalInputType",
+        "optional": false,
+        "requested": ".input_types",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/lora_nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
       },
       {
         "alias": null,
@@ -9670,6 +9723,24 @@
         "scope": "<module>",
         "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
         "target": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_FlexibleOptionalInputType",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_types:_FlexibleOptionalInputType",
+        "kind": "static_from",
+        "line": 33,
+        "name": "_FlexibleOptionalInputType",
+        "optional": false,
+        "requested": ".input_types",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
       },
       {
         "alias": null,
@@ -10943,6 +11014,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_FlexibleOptionalInputType",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_types:_FlexibleOptionalInputType",
+        "kind": "static_from",
+        "line": 16,
+        "name": "_FlexibleOptionalInputType",
+        "optional": false,
+        "requested": ".input_types",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
         "classification": "external",
@@ -11263,6 +11352,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_FlexibleOptionalInputType",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_types:_FlexibleOptionalInputType",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_FlexibleOptionalInputType",
+        "optional": false,
+        "requested": ".input_types",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "alias": null,
         "bound_name": "MAX_SEED",
         "branch_context": [
           {
@@ -11270,7 +11377,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -11278,12 +11385,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "...wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -11301,7 +11408,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -11309,12 +11416,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "...wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -11332,7 +11439,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -11340,12 +11447,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "...wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -11363,7 +11470,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -11371,12 +11478,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "...wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -11394,7 +11501,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -11402,12 +11509,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "...wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -11425,7 +11532,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -11433,12 +11540,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_REPRODUCE",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "...wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -11456,7 +11563,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -11464,12 +11571,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "...wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -11487,7 +11594,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -11495,12 +11602,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "...wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -11518,7 +11625,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -11526,12 +11633,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "...wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "normalize_seed",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -11549,7 +11656,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -11557,12 +11664,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "...wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -11580,7 +11687,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -11588,12 +11695,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "...wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -11612,9 +11719,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -11622,12 +11729,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -11646,9 +11753,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -11656,12 +11763,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -11680,9 +11787,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -11690,12 +11797,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -11714,9 +11821,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -11724,12 +11831,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -11748,9 +11855,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -11758,12 +11865,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -11782,9 +11889,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -11792,12 +11899,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_REPRODUCE",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -11816,9 +11923,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -11826,12 +11933,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -11850,9 +11957,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -11860,12 +11967,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -11884,9 +11991,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -11894,12 +12001,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -11918,9 +12025,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -11928,12 +12035,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -11952,9 +12059,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -11962,12 +12069,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -19477,6 +19584,99 @@
         "target": "easyuse_anima/nodes/prompt_data_nodes.py"
       },
       {
+        "alias": "_ANY_TYPE",
+        "bound_name": "_ANY_TYPE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_ANY_TYPE",
+          "target": "easyuse_anima/nodes/input_types.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
+        "kind": "static_from",
+        "line": 320,
+        "name": "_ANY_TYPE",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.input_types",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "alias": "_AnyType",
+        "bound_name": "_AnyType",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_AnyType",
+          "target": "easyuse_anima/nodes/input_types.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.input_types:_AnyType",
+        "kind": "static_from",
+        "line": 320,
+        "name": "_AnyType",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.input_types",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "alias": "_FlexibleOptionalInputType",
+        "bound_name": "_FlexibleOptionalInputType",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_FlexibleOptionalInputType",
+          "target": "easyuse_anima/nodes/input_types.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
+        "kind": "static_from",
+        "line": 320,
+        "name": "_FlexibleOptionalInputType",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.input_types",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
         "alias": "EasyUseAnimaPromptStudioAdvanced",
         "bound_name": "EasyUseAnimaPromptStudioAdvanced",
         "branch_context": [
@@ -19498,7 +19698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 320,
+        "line": 325,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19529,7 +19729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 320,
+        "line": 325,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19560,7 +19760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 320,
+        "line": 325,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19591,7 +19791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 326,
+        "line": 331,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19622,7 +19822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 326,
+        "line": 331,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19653,7 +19853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 326,
+        "line": 331,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19684,7 +19884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 326,
+        "line": 331,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19715,7 +19915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 326,
+        "line": 331,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19746,7 +19946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 333,
+        "line": 338,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -19777,7 +19977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 333,
+        "line": 338,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -19808,7 +20008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 343,
+        "line": 348,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -19839,7 +20039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 343,
+        "line": 348,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -19870,7 +20070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 343,
+        "line": 348,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -19901,7 +20101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 343,
+        "line": 348,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -19932,7 +20132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 356,
+        "line": 361,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -19963,7 +20163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 356,
+        "line": 361,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -19994,7 +20194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 364,
+        "line": 369,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20025,7 +20225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 364,
+        "line": 369,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20056,7 +20256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 364,
+        "line": 369,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20087,7 +20287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 364,
+        "line": 369,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20118,7 +20318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 364,
+        "line": 369,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20149,7 +20349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 364,
+        "line": 369,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20180,7 +20380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 364,
+        "line": 369,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20211,7 +20411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 364,
+        "line": 369,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20242,7 +20442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 375,
+        "line": 380,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20273,7 +20473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 375,
+        "line": 380,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20304,7 +20504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 375,
+        "line": 380,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20335,7 +20535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 375,
+        "line": 380,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20366,7 +20566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 381,
+        "line": 386,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20397,7 +20597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 381,
+        "line": 386,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20428,7 +20628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 381,
+        "line": 386,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20459,7 +20659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 381,
+        "line": 386,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20490,7 +20690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 381,
+        "line": 386,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20521,7 +20721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 389,
+        "line": 394,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20552,7 +20752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 389,
+        "line": 394,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20583,7 +20783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 393,
+        "line": 398,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -20614,7 +20814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 397,
+        "line": 402,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -20645,7 +20845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 397,
+        "line": 402,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -20676,7 +20876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 397,
+        "line": 402,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -20707,7 +20907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 402,
+        "line": 407,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -20738,7 +20938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 402,
+        "line": 407,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -20769,7 +20969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 402,
+        "line": 407,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -20800,7 +21000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 402,
+        "line": 407,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -20831,7 +21031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 402,
+        "line": 407,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -20862,7 +21062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 409,
+        "line": 414,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -20893,7 +21093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 409,
+        "line": 414,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -20924,7 +21124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 409,
+        "line": 414,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -20955,7 +21155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 414,
+        "line": 419,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -20986,7 +21186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 414,
+        "line": 419,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21017,7 +21217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 414,
+        "line": 419,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21048,7 +21248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 432,
+        "line": 437,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21079,7 +21279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 432,
+        "line": 437,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21110,7 +21310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 432,
+        "line": 437,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21141,7 +21341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 432,
+        "line": 437,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21172,7 +21372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 432,
+        "line": 437,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21203,7 +21403,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 455,
+        "line": 460,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21234,7 +21434,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 455,
+        "line": 460,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21265,7 +21465,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 459,
+        "line": 464,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21296,7 +21496,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 459,
+        "line": 464,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21327,7 +21527,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21358,7 +21558,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21389,7 +21589,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21420,7 +21620,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21451,7 +21651,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21482,7 +21682,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21513,7 +21713,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21544,7 +21744,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21575,7 +21775,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21606,7 +21806,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21637,7 +21837,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21668,7 +21868,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21699,7 +21899,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21730,7 +21930,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21761,7 +21961,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 464,
+        "line": 469,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21792,7 +21992,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 481,
+        "line": 486,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -21823,7 +22023,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 481,
+        "line": 486,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -21854,7 +22054,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 481,
+        "line": 486,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -21885,7 +22085,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 481,
+        "line": 486,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -21916,7 +22116,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 481,
+        "line": 486,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -21947,7 +22147,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 481,
+        "line": 486,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -21978,7 +22178,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 481,
+        "line": 486,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22009,7 +22209,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 481,
+        "line": 486,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22040,7 +22240,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 491,
+        "line": 496,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22071,7 +22271,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 491,
+        "line": 496,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22102,7 +22302,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 495,
+        "line": 500,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22133,7 +22333,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 495,
+        "line": 500,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22164,7 +22364,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 496,
+        "line": 501,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -22195,7 +22395,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 497,
+        "line": 502,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -22226,7 +22426,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 497,
+        "line": 502,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -22257,7 +22457,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 497,
+        "line": 502,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -22288,7 +22488,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 502,
+        "line": 507,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22319,7 +22519,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 502,
+        "line": 507,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22350,7 +22550,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22381,7 +22581,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22412,7 +22612,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22443,7 +22643,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22474,7 +22674,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22505,7 +22705,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22536,7 +22736,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22567,7 +22767,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22598,7 +22798,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22629,7 +22829,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22660,7 +22860,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22691,7 +22891,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22722,7 +22922,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22753,7 +22953,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22784,7 +22984,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22815,7 +23015,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22846,7 +23046,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22877,7 +23077,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22908,7 +23108,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 503,
+        "line": 508,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22927,7 +23127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -22942,7 +23142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -22961,7 +23161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -22976,7 +23176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -22995,7 +23195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23010,7 +23210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23029,7 +23229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23044,7 +23244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23063,7 +23263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23078,7 +23278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23097,7 +23297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23112,7 +23312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23131,7 +23331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23146,7 +23346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23165,7 +23365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23180,7 +23380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23199,7 +23399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23214,7 +23414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 536,
+        "line": 541,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23233,7 +23433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23248,7 +23448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 536,
+        "line": 541,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23267,7 +23467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23282,7 +23482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23301,7 +23501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23316,7 +23516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23335,7 +23535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23350,7 +23550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23369,7 +23569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23384,7 +23584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 545,
+        "line": 550,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -23403,7 +23603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23418,7 +23618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 548,
+        "line": 553,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23437,7 +23637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23452,7 +23652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 548,
+        "line": 553,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23471,7 +23671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23486,7 +23686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 548,
+        "line": 553,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23505,7 +23705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23520,7 +23720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 548,
+        "line": 553,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23539,7 +23739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23554,7 +23754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23573,7 +23773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23588,7 +23788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23607,7 +23807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23622,7 +23822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23641,7 +23841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23656,7 +23856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23675,7 +23875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23690,7 +23890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23709,7 +23909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23724,7 +23924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23743,7 +23943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23758,7 +23958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23777,7 +23977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23792,7 +23992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23811,7 +24011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23826,7 +24026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23845,7 +24045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23860,7 +24060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23879,7 +24079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23894,7 +24094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23913,7 +24113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23928,7 +24128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23947,7 +24147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23962,7 +24162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -23981,7 +24181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -23996,7 +24196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24015,7 +24215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24030,7 +24230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24049,7 +24249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24064,7 +24264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24083,7 +24283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24098,7 +24298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24117,7 +24317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24132,7 +24332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24151,7 +24351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24166,7 +24366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24185,7 +24385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24200,7 +24400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24219,7 +24419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24234,7 +24434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24253,7 +24453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24268,7 +24468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24287,7 +24487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24302,7 +24502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24321,7 +24521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24336,7 +24536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24355,7 +24555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24370,7 +24570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24389,7 +24589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24404,7 +24604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24423,7 +24623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24438,7 +24638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24457,7 +24657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24472,7 +24672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24491,7 +24691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24506,7 +24706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24525,7 +24725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24540,7 +24740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24559,7 +24759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24574,7 +24774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24593,7 +24793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24608,7 +24808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24627,7 +24827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24642,7 +24842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24661,7 +24861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24676,7 +24876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24695,7 +24895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24710,7 +24910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24729,7 +24929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24744,7 +24944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24763,7 +24963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24778,7 +24978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24797,7 +24997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24812,7 +25012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24831,7 +25031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24846,7 +25046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24865,7 +25065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24880,7 +25080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24899,7 +25099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24914,7 +25114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24933,7 +25133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24948,7 +25148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24967,7 +25167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -24982,7 +25182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25001,7 +25201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25016,7 +25216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25035,7 +25235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25050,7 +25250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25069,7 +25269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25084,7 +25284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25103,7 +25303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25118,7 +25318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25137,7 +25337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25152,7 +25352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25171,7 +25371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25186,7 +25386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25205,7 +25405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25220,7 +25420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25239,7 +25439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25254,7 +25454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25273,7 +25473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25288,7 +25488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25307,7 +25507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25322,7 +25522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25341,7 +25541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25356,7 +25556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 617,
+        "line": 622,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25375,7 +25575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25390,7 +25590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 617,
+        "line": 622,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25409,7 +25609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25424,7 +25624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 617,
+        "line": 622,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25443,7 +25643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25458,7 +25658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 622,
+        "line": 627,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25477,7 +25677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25492,7 +25692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 622,
+        "line": 627,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25511,7 +25711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25526,7 +25726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 622,
+        "line": 627,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25545,7 +25745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25560,7 +25760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 622,
+        "line": 627,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25579,7 +25779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25594,7 +25794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 622,
+        "line": 627,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25613,7 +25813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25628,7 +25828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 629,
+        "line": 634,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -25647,7 +25847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25662,7 +25862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 629,
+        "line": 634,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -25681,7 +25881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25696,7 +25896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 629,
+        "line": 634,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -25715,7 +25915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25730,7 +25930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 629,
+        "line": 634,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -25749,7 +25949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25764,7 +25964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -25783,7 +25983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25798,7 +25998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -25817,7 +26017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25832,7 +26032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -25851,7 +26051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25866,7 +26066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -25885,7 +26085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25900,7 +26100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -25919,7 +26119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25934,7 +26134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -25953,7 +26153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -25968,7 +26168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -25987,7 +26187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26002,7 +26202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26021,7 +26221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26036,7 +26236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26055,7 +26255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26070,7 +26270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26089,7 +26289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26104,7 +26304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26123,7 +26323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26138,7 +26338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26157,7 +26357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26172,7 +26372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26191,7 +26391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26206,7 +26406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26225,7 +26425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26240,7 +26440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26259,7 +26459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26274,7 +26474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26293,7 +26493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26308,7 +26508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26327,7 +26527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26342,7 +26542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26361,7 +26561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26376,7 +26576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26395,7 +26595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26410,7 +26610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26429,7 +26629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26444,7 +26644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26463,7 +26663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26478,7 +26678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26497,7 +26697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26512,7 +26712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26531,7 +26731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26546,7 +26746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26565,7 +26765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26580,7 +26780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26599,7 +26799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26614,7 +26814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26633,7 +26833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26648,7 +26848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26667,7 +26867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26682,7 +26882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26701,7 +26901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26716,7 +26916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26735,7 +26935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26750,7 +26950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26769,7 +26969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26784,7 +26984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26803,7 +27003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26818,7 +27018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26837,7 +27037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26852,7 +27052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26871,7 +27071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26886,7 +27086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26905,7 +27105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26920,7 +27120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26939,7 +27139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26954,7 +27154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26973,7 +27173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -26988,7 +27188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27007,7 +27207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27022,7 +27222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27041,7 +27241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27056,7 +27256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27075,7 +27275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27090,7 +27290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27109,7 +27309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27124,7 +27324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27143,7 +27343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27158,7 +27358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27177,7 +27377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27192,7 +27392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27211,7 +27411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27226,7 +27426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27245,7 +27445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27260,7 +27460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27279,7 +27479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27294,7 +27494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27313,7 +27513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27328,7 +27528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27347,7 +27547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27362,7 +27562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27381,7 +27581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27396,7 +27596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27415,7 +27615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27430,7 +27630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27449,7 +27649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27464,7 +27664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27483,7 +27683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27498,7 +27698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27517,7 +27717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27532,7 +27732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27551,7 +27751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27566,7 +27766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27585,7 +27785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27600,7 +27800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27619,7 +27819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27634,7 +27834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27653,7 +27853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27668,7 +27868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27687,7 +27887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27702,7 +27902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27721,7 +27921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27736,7 +27936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27755,7 +27955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27770,7 +27970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27789,7 +27989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27804,7 +28004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27823,7 +28023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27838,7 +28038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27857,7 +28057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27872,7 +28072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -27891,7 +28091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27906,7 +28106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -27925,7 +28125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27940,7 +28140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -27959,7 +28159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -27974,7 +28174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -27993,7 +28193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28008,7 +28208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28027,7 +28227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28042,7 +28242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28061,7 +28261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28076,7 +28276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28095,7 +28295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28110,7 +28310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28129,7 +28329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28144,7 +28344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28163,7 +28363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28178,7 +28378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28197,7 +28397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28212,7 +28412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28231,7 +28431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28246,7 +28446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28265,7 +28465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28280,7 +28480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28299,7 +28499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28314,7 +28514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28333,7 +28533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28348,7 +28548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28367,7 +28567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28382,7 +28582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28401,7 +28601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28416,7 +28616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28435,7 +28635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28450,7 +28650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28469,7 +28669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28484,7 +28684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28503,7 +28703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28518,7 +28718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28537,7 +28737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28552,7 +28752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28571,7 +28771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28586,7 +28786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28605,7 +28805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28620,7 +28820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28639,7 +28839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28654,7 +28854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28673,7 +28873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28688,7 +28888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28707,7 +28907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28722,7 +28922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 827,
+        "line": 832,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -28741,7 +28941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28756,7 +28956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 827,
+        "line": 832,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -28775,7 +28975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28790,7 +28990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 827,
+        "line": 832,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -28809,7 +29009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28824,7 +29024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 827,
+        "line": 832,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -28832,6 +29032,108 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/prompt_data_nodes.py"
+      },
+      {
+        "alias": "_ANY_TYPE",
+        "bound_name": "_ANY_TYPE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 529,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_ANY_TYPE",
+          "target": "easyuse_anima/nodes/input_types.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
+        "kind": "static_from",
+        "line": 838,
+        "name": "_ANY_TYPE",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.input_types",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "alias": "_AnyType",
+        "bound_name": "_AnyType",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 529,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_AnyType",
+          "target": "easyuse_anima/nodes/input_types.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.input_types:_AnyType",
+        "kind": "static_from",
+        "line": 838,
+        "name": "_AnyType",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.input_types",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "alias": "_FlexibleOptionalInputType",
+        "bound_name": "_FlexibleOptionalInputType",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 529,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_FlexibleOptionalInputType",
+          "target": "easyuse_anima/nodes/input_types.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
+        "kind": "static_from",
+        "line": 838,
+        "name": "_FlexibleOptionalInputType",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.input_types",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
       },
       {
         "alias": "EasyUseAnimaPromptStudioAdvanced",
@@ -28843,7 +29145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28858,7 +29160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 833,
+        "line": 843,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -28877,7 +29179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28892,7 +29194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 833,
+        "line": 843,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -28911,7 +29213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28926,7 +29228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 833,
+        "line": 843,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -28945,7 +29247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28960,7 +29262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 839,
+        "line": 849,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -28979,7 +29281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -28994,7 +29296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 839,
+        "line": 849,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29013,7 +29315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29028,7 +29330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 839,
+        "line": 849,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29047,7 +29349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29062,7 +29364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 839,
+        "line": 849,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29081,7 +29383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29096,7 +29398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 839,
+        "line": 849,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29115,7 +29417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29130,7 +29432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 846,
+        "line": 856,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29149,7 +29451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29164,7 +29466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 846,
+        "line": 856,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29183,7 +29485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29198,7 +29500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 856,
+        "line": 866,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29217,7 +29519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29232,7 +29534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 856,
+        "line": 866,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29251,7 +29553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29266,7 +29568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 856,
+        "line": 866,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29285,7 +29587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29300,7 +29602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 856,
+        "line": 866,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29319,7 +29621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29334,7 +29636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 869,
+        "line": 879,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -29353,7 +29655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29368,7 +29670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 869,
+        "line": 879,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -29387,7 +29689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29402,7 +29704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29421,7 +29723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29436,7 +29738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29455,7 +29757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29470,7 +29772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29489,7 +29791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29504,7 +29806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29523,7 +29825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29538,7 +29840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29557,7 +29859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29572,7 +29874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29591,7 +29893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29606,7 +29908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29625,7 +29927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29640,7 +29942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29659,7 +29961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29674,7 +29976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 888,
+        "line": 898,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -29693,7 +29995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29708,7 +30010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 888,
+        "line": 898,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -29727,7 +30029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29742,7 +30044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 888,
+        "line": 898,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -29761,7 +30063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29776,7 +30078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 888,
+        "line": 898,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -29795,7 +30097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29810,7 +30112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -29829,7 +30131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29844,7 +30146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -29863,7 +30165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29878,7 +30180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -29897,7 +30199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29912,7 +30214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -29931,7 +30233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29946,7 +30248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -29965,7 +30267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -29980,7 +30282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 902,
+        "line": 912,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -29999,7 +30301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30014,7 +30316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 902,
+        "line": 912,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30033,7 +30335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30048,7 +30350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 906,
+        "line": 916,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -30067,7 +30369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30082,7 +30384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 910,
+        "line": 920,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30101,7 +30403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30116,7 +30418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 910,
+        "line": 920,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30135,7 +30437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30150,7 +30452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 910,
+        "line": 920,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30169,7 +30471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30184,7 +30486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 915,
+        "line": 925,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30203,7 +30505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30218,7 +30520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 915,
+        "line": 925,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30237,7 +30539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30252,7 +30554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 915,
+        "line": 925,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30271,7 +30573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30286,7 +30588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 915,
+        "line": 925,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30305,7 +30607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30320,7 +30622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 915,
+        "line": 925,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30339,7 +30641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30354,7 +30656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 922,
+        "line": 932,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30373,7 +30675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30388,7 +30690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 922,
+        "line": 932,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30407,7 +30709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30422,7 +30724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 922,
+        "line": 932,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30441,7 +30743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30456,7 +30758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 927,
+        "line": 937,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -30475,7 +30777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30490,7 +30792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 927,
+        "line": 937,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -30509,7 +30811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30524,7 +30826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 927,
+        "line": 937,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -30543,7 +30845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30558,7 +30860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 945,
+        "line": 955,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -30577,7 +30879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30592,7 +30894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 945,
+        "line": 955,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -30611,7 +30913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30626,7 +30928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 945,
+        "line": 955,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -30645,7 +30947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30660,7 +30962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 945,
+        "line": 955,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -30679,7 +30981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30694,7 +30996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 945,
+        "line": 955,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -30713,7 +31015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30728,7 +31030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 968,
+        "line": 978,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -30747,7 +31049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30762,7 +31064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 968,
+        "line": 978,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -30781,7 +31083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30796,7 +31098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 972,
+        "line": 982,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -30815,7 +31117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30830,7 +31132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 972,
+        "line": 982,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -30849,7 +31151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30864,7 +31166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -30883,7 +31185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30898,7 +31200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -30917,7 +31219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30932,7 +31234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -30951,7 +31253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -30966,7 +31268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -30985,7 +31287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31000,7 +31302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31019,7 +31321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31034,7 +31336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31053,7 +31355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31068,7 +31370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31087,7 +31389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31102,7 +31404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31121,7 +31423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31136,7 +31438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31155,7 +31457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31170,7 +31472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31189,7 +31491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31204,7 +31506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31223,7 +31525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31238,7 +31540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31257,7 +31559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31272,7 +31574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31291,7 +31593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31306,7 +31608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31325,7 +31627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31340,7 +31642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31359,7 +31661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31374,7 +31676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31393,7 +31695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31408,7 +31710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31427,7 +31729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31442,7 +31744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31461,7 +31763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31476,7 +31778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31495,7 +31797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31510,7 +31812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31529,7 +31831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31544,7 +31846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31563,7 +31865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31578,7 +31880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31597,7 +31899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31612,7 +31914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31631,7 +31933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31646,7 +31948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1014,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -31665,7 +31967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31680,7 +31982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1014,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -31699,7 +32001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31714,7 +32016,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1018,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -31733,7 +32035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31748,7 +32050,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1018,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -31767,7 +32069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31782,7 +32084,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1019,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -31801,7 +32103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31816,7 +32118,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1020,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -31835,7 +32137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31850,7 +32152,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1020,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -31869,7 +32171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31884,7 +32186,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1020,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -31903,7 +32205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31918,7 +32220,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1025,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -31937,7 +32239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31952,7 +32254,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1025,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -31971,7 +32273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -31986,7 +32288,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32005,7 +32307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32020,7 +32322,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32039,7 +32341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32054,7 +32356,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32073,7 +32375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32088,7 +32390,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32107,7 +32409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32122,7 +32424,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32141,7 +32443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32156,7 +32458,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32175,7 +32477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32190,7 +32492,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32209,7 +32511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32224,7 +32526,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32243,7 +32545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32258,7 +32560,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32277,7 +32579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32292,7 +32594,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32311,7 +32613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32326,7 +32628,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32345,7 +32647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32360,7 +32662,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32379,7 +32681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32394,7 +32696,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32413,7 +32715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32428,7 +32730,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32447,7 +32749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32462,7 +32764,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32481,7 +32783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32496,7 +32798,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32515,7 +32817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32530,7 +32832,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32549,7 +32851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32564,7 +32866,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32583,7 +32885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -32598,7 +32900,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32616,7 +32918,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1769
+            "line": 1762
           }
         ],
         "classification": "external",
@@ -32624,7 +32926,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1770,
+        "line": 1763,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -32641,7 +32943,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1806
+            "line": 1799
           }
         ],
         "classification": "external",
@@ -32649,7 +32951,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1807,
+        "line": 1800,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -32666,7 +32968,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1814
+            "line": 1807
           }
         ],
         "classification": "external",
@@ -32674,7 +32976,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1815,
+        "line": 1808,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -34416,6 +34718,10 @@
         "to": "easyuse_anima/lora/preset.py"
       },
       {
+        "from": "easyuse_anima/nodes/lora_nodes.py",
+        "to": "easyuse_anima/nodes/input_types.py"
+      },
+      {
         "from": "easyuse_anima/nodes/naia_nodes.py",
         "to": "easyuse_anima/common/serialization.py"
       },
@@ -34430,6 +34736,10 @@
       {
         "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
         "to": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "to": "easyuse_anima/nodes/input_types.py"
       },
       {
         "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
@@ -34493,6 +34803,10 @@
       },
       {
         "from": "easyuse_anima/nodes/regional_nodes.py",
+        "to": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/regional_nodes.py",
         "to": "easyuse_anima/prompt/regional.py"
       },
       {
@@ -34522,6 +34836,10 @@
       {
         "from": "easyuse_anima/nodes/wildcard_nodes.py",
         "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/wildcard_nodes.py",
+        "to": "easyuse_anima/nodes/input_types.py"
       },
       {
         "from": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -34722,6 +35040,10 @@
       {
         "from": "nodes.py",
         "to": "easyuse_anima/nodes/impact_detailer_nodes.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/nodes/input_types.py"
       },
       {
         "from": "nodes.py",
@@ -35156,6 +35478,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/nodes/input_types.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/nodes/lora_nodes.py"
         ]
       },
@@ -35306,7 +35634,7 @@
     ]
   },
   "inventory": {
-    "module_count": 79,
+    "module_count": 80,
     "modules": [
       {
         "is_package": true,
@@ -35958,14 +36286,26 @@
       },
       {
         "is_package": false,
-        "loc": 232,
+        "loc": 24,
+        "module": "easyuse_anima.nodes.input_types",
+        "normalized_git_blob_sha1": "88b7cf460cf4e4440b472493c56ed3dcb5bf65dd",
+        "path": "easyuse_anima/nodes/input_types.py",
+        "top_level": {
+          "class_count": 2,
+          "function_count": 0,
+          "global_count": 2
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 214,
         "module": "easyuse_anima.nodes.lora_nodes",
-        "normalized_git_blob_sha1": "e2b53041ed96aa9f48ad8a4479d93deb4747098d",
+        "normalized_git_blob_sha1": "1c870ccf56ea9a6338c1acdd256ab981b697db95",
         "path": "easyuse_anima/nodes/lora_nodes.py",
         "top_level": {
-          "class_count": 3,
+          "class_count": 1,
           "function_count": 1,
-          "global_count": 2
+          "global_count": 1
         }
       },
       {
@@ -35982,12 +36322,12 @@
       },
       {
         "is_package": false,
-        "loc": 1157,
+        "loc": 1147,
         "module": "easyuse_anima.nodes.prompt_advanced_nodes",
-        "normalized_git_blob_sha1": "b2452a94d3642e62da1ef3811c401ddbb1134737",
+        "normalized_git_blob_sha1": "b6211be12fb6e0c5153be777717df204a562e1d9",
         "path": "easyuse_anima/nodes/prompt_advanced_nodes.py",
         "top_level": {
-          "class_count": 4,
+          "class_count": 3,
           "function_count": 3,
           "global_count": 50
         }
@@ -36018,12 +36358,12 @@
       },
       {
         "is_package": false,
-        "loc": 569,
+        "loc": 559,
         "module": "easyuse_anima.nodes.regional_nodes",
-        "normalized_git_blob_sha1": "e471ddb34eddaf21afad4921cfb59799d038f9f4",
+        "normalized_git_blob_sha1": "3bcc21c4f3b5e554286f476b9c8eb9f6e9b0df85",
         "path": "easyuse_anima/nodes/regional_nodes.py",
         "top_level": {
-          "class_count": 3,
+          "class_count": 2,
           "function_count": 2,
           "global_count": 42
         }
@@ -36042,12 +36382,12 @@
       },
       {
         "is_package": false,
-        "loc": 280,
+        "loc": 272,
         "module": "easyuse_anima.nodes.wildcard_nodes",
-        "normalized_git_blob_sha1": "5b4ba8f919348b276764ef15502a4d9ded78d74d",
+        "normalized_git_blob_sha1": "f4d70f01713c109700bfebecf0cc44f85cf7240e",
         "path": "easyuse_anima/nodes/wildcard_nodes.py",
         "top_level": {
-          "class_count": 2,
+          "class_count": 1,
           "function_count": 2,
           "global_count": 4
         }
@@ -36198,14 +36538,14 @@
       },
       {
         "is_package": false,
-        "loc": 2712,
+        "loc": 2705,
         "module": "nodes",
-        "normalized_git_blob_sha1": "bb1344cd0e436e823a428e3f3f41ee77cd71b982",
+        "normalized_git_blob_sha1": "c4bda09b51453509e63f8ffe9676c88c3ae05184",
         "path": "nodes.py",
         "top_level": {
-          "class_count": 2,
+          "class_count": 0,
           "function_count": 41,
-          "global_count": 33
+          "global_count": 32
         }
       },
       {
@@ -37173,16 +37513,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -37196,16 +37536,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -37219,16 +37559,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -37242,16 +37582,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -37265,16 +37605,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -37288,16 +37628,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -37311,16 +37651,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -37334,16 +37674,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -37357,16 +37697,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -37380,16 +37720,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -37403,16 +37743,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 22,
+            "handler_line": 23,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 23,
+        "line": 24,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -37564,7 +37904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37573,7 +37913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37587,7 +37927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37596,7 +37936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37610,7 +37950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37619,7 +37959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37633,7 +37973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37642,7 +37982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37656,7 +37996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37665,7 +38005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37679,7 +38019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37688,7 +38028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37702,7 +38042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37711,7 +38051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37725,7 +38065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37734,7 +38074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 525,
+        "line": 530,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37748,7 +38088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37757,7 +38097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 536,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37771,7 +38111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37780,7 +38120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 536,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37794,7 +38134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37803,7 +38143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37817,7 +38157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37826,7 +38166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37840,7 +38180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37849,7 +38189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37863,7 +38203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37872,7 +38212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 545,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37886,7 +38226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37895,7 +38235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 548,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37909,7 +38249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37918,7 +38258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 548,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37932,7 +38272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37941,7 +38281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 548,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37955,7 +38295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37964,7 +38304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 548,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37978,7 +38318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -37987,7 +38327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38001,7 +38341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38010,7 +38350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38024,7 +38364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38033,7 +38373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38047,7 +38387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38056,7 +38396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38070,7 +38410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38079,7 +38419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38093,7 +38433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38102,7 +38442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38116,7 +38456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38125,7 +38465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38139,7 +38479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38148,7 +38488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38162,7 +38502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38171,7 +38511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38185,7 +38525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38194,7 +38534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38208,7 +38548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38217,7 +38557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38231,7 +38571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38240,7 +38580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 554,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38254,7 +38594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38263,7 +38603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38277,7 +38617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38286,7 +38626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38300,7 +38640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38309,7 +38649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38323,7 +38663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38332,7 +38672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38346,7 +38686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38355,7 +38695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38369,7 +38709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38378,7 +38718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38392,7 +38732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38401,7 +38741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38415,7 +38755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38424,7 +38764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38438,7 +38778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38447,7 +38787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38461,7 +38801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38470,7 +38810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 568,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38484,7 +38824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38493,7 +38833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38507,7 +38847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38516,7 +38856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38530,7 +38870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38539,7 +38879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38553,7 +38893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38562,7 +38902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38576,7 +38916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38585,7 +38925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38599,7 +38939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38608,7 +38948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38622,7 +38962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38631,7 +38971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38645,7 +38985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38654,7 +38994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38668,7 +39008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38677,7 +39017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38691,7 +39031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38700,7 +39040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 580,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38714,7 +39054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38723,7 +39063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38737,7 +39077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38746,7 +39086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38760,7 +39100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38769,7 +39109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38783,7 +39123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38792,7 +39132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38806,7 +39146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38815,7 +39155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38829,7 +39169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38838,7 +39178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38852,7 +39192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38861,7 +39201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38875,7 +39215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38884,7 +39224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38898,7 +39238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38907,7 +39247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38921,7 +39261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38930,7 +39270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 592,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38944,7 +39284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38953,7 +39293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38967,7 +39307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38976,7 +39316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38990,7 +39330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -38999,7 +39339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39013,7 +39353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39022,7 +39362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39036,7 +39376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39045,7 +39385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39059,7 +39399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39068,7 +39408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39082,7 +39422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39091,7 +39431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39105,7 +39445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39114,7 +39454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39128,7 +39468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39137,7 +39477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39151,7 +39491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39160,7 +39500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39174,7 +39514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39183,7 +39523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 604,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39197,7 +39537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39206,7 +39546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 617,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39220,7 +39560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39229,7 +39569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 617,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39243,7 +39583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39252,7 +39592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 617,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39266,7 +39606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39275,7 +39615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 622,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39289,7 +39629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39298,7 +39638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 622,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39312,7 +39652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39321,7 +39661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 622,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39335,7 +39675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39344,7 +39684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 622,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39358,7 +39698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39367,7 +39707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 622,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39381,7 +39721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39390,7 +39730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 629,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39404,7 +39744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39413,7 +39753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 629,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39427,7 +39767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39436,7 +39776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 629,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39450,7 +39790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39459,7 +39799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 629,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39473,7 +39813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39482,7 +39822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39496,7 +39836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39505,7 +39845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39519,7 +39859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39528,7 +39868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39542,7 +39882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39551,7 +39891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39565,7 +39905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39574,7 +39914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39588,7 +39928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39597,7 +39937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39611,7 +39951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39620,7 +39960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39634,7 +39974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39643,7 +39983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39657,7 +39997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39666,7 +40006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39680,7 +40020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39689,7 +40029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 635,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39703,7 +40043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39712,7 +40052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39726,7 +40066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39735,7 +40075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39749,7 +40089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39758,7 +40098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39772,7 +40112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39781,7 +40121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39795,7 +40135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39804,7 +40144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39818,7 +40158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39827,7 +40167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39841,7 +40181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39850,7 +40190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 649,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39864,7 +40204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39873,7 +40213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39887,7 +40227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39896,7 +40236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39910,7 +40250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39919,7 +40259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39933,7 +40273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39942,7 +40282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39956,7 +40296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39965,7 +40305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39979,7 +40319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -39988,7 +40328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40002,7 +40342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40011,7 +40351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40025,7 +40365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40034,7 +40374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40048,7 +40388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40057,7 +40397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40071,7 +40411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40080,7 +40420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40094,7 +40434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40103,7 +40443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40117,7 +40457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40126,7 +40466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40140,7 +40480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40149,7 +40489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40163,7 +40503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40172,7 +40512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40186,7 +40526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40195,7 +40535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40209,7 +40549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40218,7 +40558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40232,7 +40572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40241,7 +40581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40255,7 +40595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40264,7 +40604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40278,7 +40618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40287,7 +40627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40301,7 +40641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40310,7 +40650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40324,7 +40664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40333,7 +40673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40347,7 +40687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40356,7 +40696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 667,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40370,7 +40710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40379,7 +40719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40393,7 +40733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40402,7 +40742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40416,7 +40756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40425,7 +40765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40439,7 +40779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40448,7 +40788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40462,7 +40802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40471,7 +40811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40485,7 +40825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40494,7 +40834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40508,7 +40848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40517,7 +40857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40531,7 +40871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40540,7 +40880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40554,7 +40894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40563,7 +40903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40577,7 +40917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40586,7 +40926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40600,7 +40940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40609,7 +40949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40623,7 +40963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40632,7 +40972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40646,7 +40986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40655,7 +40995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40669,7 +41009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40678,7 +41018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 703,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40692,7 +41032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40701,7 +41041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40715,7 +41055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40724,7 +41064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40738,7 +41078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40747,7 +41087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40761,7 +41101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40770,7 +41110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40784,7 +41124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40793,7 +41133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40807,7 +41147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40816,7 +41156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40830,7 +41170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40839,7 +41179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40853,7 +41193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40862,7 +41202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40876,7 +41216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40885,7 +41225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40899,7 +41239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40908,7 +41248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40922,7 +41262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40931,7 +41271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40945,7 +41285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40954,7 +41294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40968,7 +41308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -40977,7 +41317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40991,7 +41331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41000,7 +41340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41014,7 +41354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41023,7 +41363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41037,7 +41377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41046,7 +41386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41060,7 +41400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41069,7 +41409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41083,7 +41423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41092,7 +41432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41106,7 +41446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41115,7 +41455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41129,7 +41469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41138,7 +41478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41152,7 +41492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41161,7 +41501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41175,7 +41515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41184,7 +41524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41198,7 +41538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41207,7 +41547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41221,7 +41561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41230,7 +41570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41244,7 +41584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41253,7 +41593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41267,7 +41607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41276,7 +41616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41290,7 +41630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41299,7 +41639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41313,7 +41653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41322,7 +41662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41336,7 +41676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41345,7 +41685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41359,7 +41699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41368,7 +41708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41382,7 +41722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41391,7 +41731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41405,7 +41745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41414,7 +41754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41428,7 +41768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41437,7 +41777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41451,7 +41791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41460,7 +41800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 747,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41474,7 +41814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41483,7 +41823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 827,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41497,7 +41837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41506,7 +41846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 827,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41520,7 +41860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41529,7 +41869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 827,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41543,7 +41883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41552,7 +41892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 827,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41566,7 +41906,76 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
+        "kind": "static_from",
+        "line": 838,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 529,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.input_types:_AnyType",
+        "kind": "static_from",
+        "line": 838,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 529,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
+        "kind": "static_from",
+        "line": 838,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41575,7 +41984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 833,
+        "line": 843,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41589,7 +41998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41598,7 +42007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 833,
+        "line": 843,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41612,7 +42021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41621,7 +42030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 833,
+        "line": 843,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41635,7 +42044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41644,7 +42053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 839,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41658,7 +42067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41667,7 +42076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 839,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41681,7 +42090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41690,7 +42099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 839,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41704,7 +42113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41713,7 +42122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 839,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41727,7 +42136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41736,7 +42145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 839,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41750,7 +42159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41759,7 +42168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 846,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41773,7 +42182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41782,7 +42191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 846,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41796,7 +42205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41805,7 +42214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 856,
+        "line": 866,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41819,7 +42228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41828,7 +42237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 856,
+        "line": 866,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41842,7 +42251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41851,7 +42260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 856,
+        "line": 866,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41865,7 +42274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41874,7 +42283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 856,
+        "line": 866,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41888,7 +42297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41897,7 +42306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 869,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41911,7 +42320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41920,7 +42329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 869,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41934,7 +42343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41943,7 +42352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41957,7 +42366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41966,7 +42375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41980,7 +42389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -41989,7 +42398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42003,7 +42412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42012,7 +42421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42026,7 +42435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42035,7 +42444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42049,7 +42458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42058,7 +42467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42072,7 +42481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42081,7 +42490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42095,7 +42504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42104,7 +42513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 877,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42118,7 +42527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42127,7 +42536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 888,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42141,7 +42550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42150,7 +42559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 888,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42164,7 +42573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42173,7 +42582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 888,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42187,7 +42596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42196,7 +42605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 888,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42210,7 +42619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42219,7 +42628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42233,7 +42642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42242,7 +42651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42256,7 +42665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42265,7 +42674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42279,7 +42688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42288,7 +42697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42302,7 +42711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42311,7 +42720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42325,7 +42734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42334,7 +42743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 902,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42348,7 +42757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42357,7 +42766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 902,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42371,7 +42780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42380,7 +42789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 906,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42394,7 +42803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42403,7 +42812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 910,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42417,7 +42826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42426,7 +42835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 910,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42440,7 +42849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42449,7 +42858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 910,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42463,7 +42872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42472,7 +42881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 915,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42486,7 +42895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42495,7 +42904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 915,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42509,7 +42918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42518,7 +42927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 915,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42532,7 +42941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42541,7 +42950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 915,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42555,7 +42964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42564,7 +42973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 915,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42578,7 +42987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42587,7 +42996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 922,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42601,7 +43010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42610,7 +43019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 922,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42624,7 +43033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42633,7 +43042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 922,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42647,7 +43056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42656,7 +43065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 927,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42670,7 +43079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42679,7 +43088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 927,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42693,7 +43102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42702,7 +43111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 927,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42716,7 +43125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42725,7 +43134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 945,
+        "line": 955,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42739,7 +43148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42748,7 +43157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 945,
+        "line": 955,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42762,7 +43171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42771,7 +43180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 945,
+        "line": 955,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42785,7 +43194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42794,7 +43203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 945,
+        "line": 955,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42808,7 +43217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42817,7 +43226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 945,
+        "line": 955,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42831,7 +43240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42840,7 +43249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 968,
+        "line": 978,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42854,7 +43263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42863,7 +43272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 968,
+        "line": 978,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42877,7 +43286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42886,7 +43295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 972,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42900,7 +43309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42909,7 +43318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 972,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42923,7 +43332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42932,7 +43341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42946,7 +43355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42955,7 +43364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42969,7 +43378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -42978,7 +43387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42992,7 +43401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43001,7 +43410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43015,7 +43424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43024,7 +43433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43038,7 +43447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43047,7 +43456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43061,7 +43470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43070,7 +43479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43084,7 +43493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43093,7 +43502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43107,7 +43516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43116,7 +43525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43130,7 +43539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43139,7 +43548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43153,7 +43562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43162,7 +43571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43176,7 +43585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43185,7 +43594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43199,7 +43608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43208,7 +43617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43222,7 +43631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43231,7 +43640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43245,7 +43654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43254,7 +43663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 977,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43268,7 +43677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43277,7 +43686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43291,7 +43700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43300,7 +43709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43314,7 +43723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43323,7 +43732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43337,7 +43746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43346,7 +43755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43360,7 +43769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43369,7 +43778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43383,7 +43792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43392,7 +43801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43406,7 +43815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43415,7 +43824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43429,7 +43838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43438,7 +43847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43452,7 +43861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43461,7 +43870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43475,7 +43884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43484,7 +43893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43498,7 +43907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43507,7 +43916,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43521,7 +43930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43530,7 +43939,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43544,7 +43953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43553,7 +43962,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1019,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43567,7 +43976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43576,7 +43985,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43590,7 +43999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43599,7 +44008,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43613,7 +44022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43622,7 +44031,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43636,7 +44045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43645,7 +44054,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1025,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43659,7 +44068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43668,7 +44077,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1025,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43682,7 +44091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43691,7 +44100,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43705,7 +44114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43714,7 +44123,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43728,7 +44137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43737,7 +44146,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43751,7 +44160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43760,7 +44169,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43774,7 +44183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43783,7 +44192,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43797,7 +44206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43806,7 +44215,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43820,7 +44229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43829,7 +44238,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43843,7 +44252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43852,7 +44261,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43866,7 +44275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43875,7 +44284,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43889,7 +44298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43898,7 +44307,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43912,7 +44321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43921,7 +44330,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43935,7 +44344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43944,7 +44353,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43958,7 +44367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43967,7 +44376,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43981,7 +44390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -43990,7 +44399,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44004,7 +44413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -44013,7 +44422,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44027,7 +44436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -44036,7 +44445,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44050,7 +44459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -44059,7 +44468,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44073,7 +44482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -44082,7 +44491,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44096,7 +44505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 524,
+            "handler_line": 529,
             "kind": "try",
             "line": 11
           }
@@ -44105,7 +44514,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47020,6 +47429,17 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/nodes/lora_nodes.py"
       },
       {
@@ -47822,14 +48242,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1769
+            "line": 1762
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1770,
+        "line": 1763,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -47841,14 +48261,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1806
+            "line": 1799
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1807,
+        "line": 1800,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -47860,14 +48280,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1814
+            "line": 1807
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1815,
+        "line": 1808,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49242,14 +49662,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1769
+            "line": 1762
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1770,
+        "line": 1763,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49261,14 +49681,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1806
+            "line": 1799
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1807,
+        "line": 1800,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49280,14 +49700,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1814
+            "line": 1807
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1815,
+        "line": 1808,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49444,6 +49864,7 @@
       "easyuse_anima/nodes/aio_nodes.py",
       "easyuse_anima/nodes/image_nodes.py",
       "easyuse_anima/nodes/impact_detailer_nodes.py",
+      "easyuse_anima/nodes/input_types.py",
       "easyuse_anima/nodes/lora_nodes.py",
       "easyuse_anima/nodes/naia_nodes.py",
       "easyuse_anima/nodes/prompt_advanced_nodes.py",
@@ -49525,6 +49946,7 @@
       "easyuse_anima/nodes/aio_nodes.py",
       "easyuse_anima/nodes/image_nodes.py",
       "easyuse_anima/nodes/impact_detailer_nodes.py",
+      "easyuse_anima/nodes/input_types.py",
       "easyuse_anima/nodes/lora_nodes.py",
       "easyuse_anima/nodes/naia_nodes.py",
       "easyuse_anima/nodes/prompt_advanced_nodes.py",
@@ -50398,8 +50820,8 @@
         "column": 12,
         "context": "assign:_ANY_TYPE",
         "kind": "import_time_call",
-        "line": 37,
-        "module": "easyuse_anima/nodes/lora_nodes.py",
+        "line": 24,
+        "module": "easyuse_anima/nodes/input_types.py",
         "scope": "<module>"
       },
       {
@@ -50731,16 +51153,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1038,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_AnyType",
-        "column": 12,
-        "context": "assign:_ANY_TYPE",
-        "kind": "import_time_call",
-        "line": 1554,
+        "line": 1048,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50749,7 +51162,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1720,
+        "line": 1713,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50758,7 +51171,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2614,
+        "line": 2607,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50767,7 +51180,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2617,
+        "line": 2610,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50776,7 +51189,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2620,
+        "line": 2613,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50785,7 +51198,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2623,
+        "line": 2616,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50794,7 +51207,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2626,
+        "line": 2619,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50803,7 +51216,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2629,
+        "line": 2622,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50812,7 +51225,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2632,
+        "line": 2625,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50821,7 +51234,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2635,
+        "line": 2628,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50830,7 +51243,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2638,
+        "line": 2631,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50839,7 +51252,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2641,
+        "line": 2634,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50848,7 +51261,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2644,
+        "line": 2637,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50857,7 +51270,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2647,
+        "line": 2640,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50866,7 +51279,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2650,
+        "line": 2643,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50875,7 +51288,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2653,
+        "line": 2646,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50884,7 +51297,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2657,
+        "line": 2650,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50893,7 +51306,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2660,
+        "line": 2653,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50902,7 +51315,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2664,
+        "line": 2657,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50911,7 +51324,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2667,
+        "line": 2660,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50920,7 +51333,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2671,
+        "line": 2664,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50929,7 +51342,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2674,
+        "line": 2667,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50938,7 +51351,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2677,
+        "line": 2670,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50947,7 +51360,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2680,
+        "line": 2673,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50956,7 +51369,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2683,
+        "line": 2676,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50965,7 +51378,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2686,
+        "line": 2679,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50974,7 +51387,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2693,
+        "line": 2686,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50983,7 +51396,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2699,
+        "line": 2692,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -50992,7 +51405,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2704,
+        "line": 2697,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51001,7 +51414,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2708,
+        "line": 2701,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51407,7 +51820,7 @@
       },
       {
         "kind": "dict",
-        "line": 45,
+        "line": 46,
         "module": "easyuse_anima/nodes/wildcard_nodes.py",
         "name": "WILDCARD_MODE_DISPLAY_LABELS"
       },
@@ -51503,25 +51916,25 @@
       },
       {
         "kind": "dict",
-        "line": 1108,
+        "line": 1118,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1097,
+        "line": 1107,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1092,
+        "line": 1102,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "set",
-        "line": 1719,
+        "line": 1712,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "20c8b4d57243cc4b2c0423f43c9f0a2069707187",
+    "base_commit": "f2a2ec0198119caa9680ca86a8c5d4d068ab4ba8",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -29,7 +29,8 @@
       "B-10b19",
       "B-10b20",
       "B-11a",
-      "B-11b"
+      "B-11b",
+      "B-11c1"
     ]
   },
   "enums": {
@@ -64,13 +65,13 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 258,
+    "nodes_canonical_bindings": 261,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 41,
-    "root_residual_classes": 2,
-    "root_residual_globals": 33,
+    "root_residual_classes": 0,
+    "root_residual_globals": 32,
     "runtime_binders": 28,
     "direct_nodes_import_test_files": 21
   },
@@ -2771,6 +2772,64 @@
       "lifecycle_state": "transitional"
     },
     {
+      "id": "nodes_canonical_bindings:easyuse_anima.nodes.input_types:transitional_private_seam",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_ANY_TYPE": "_ANY_TYPE",
+        "_FlexibleOptionalInputType": "_FlexibleOptionalInputType"
+      },
+      "classification": "transitional_private_seam",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.nodes.input_types",
+      "target_state": "canonical",
+      "identity_requirement": "required",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.nodes.input_types",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "nodes.py residual runtime"
+      ],
+      "evidence": [
+        "AST:nodes.py direct runtime load"
+      ],
+      "removal_gates": [
+        "canonical production consumer migration",
+        "focused monkeypatch and identity contract review",
+        "separate B-10b or B-11 rollback unit"
+      ],
+      "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.nodes.input_types:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_AnyType": "_AnyType"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.nodes.input_types",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.nodes.input_types",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.lora_nodes:supported_public_reexport",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -3785,10 +3844,7 @@
       "id": "nodes_root_residuals:classes",
       "surface": "nodes_root_residuals",
       "kind": "classes",
-      "symbols": {
-        "_AnyType": "_AnyType",
-        "_FlexibleOptionalInputType": "_FlexibleOptionalInputType"
-      },
+      "symbols": {},
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
       "canonical_target": null,
@@ -3915,7 +3971,6 @@
         "WILDCARD_RESERVED_NEXT_SEED_INPUT": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "_AIO_DETAILER_CUSTOM_RE": "_AIO_DETAILER_CUSTOM_RE",
         "_AIO_DETAILER_RESERVED_KEYS": "_AIO_DETAILER_RESERVED_KEYS",
-        "_ANY_TYPE": "_ANY_TYPE",
         "_TRIGGER_WORD_KEYS": "_TRIGGER_WORD_KEYS",
         "logger": "logger"
       },

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -33,6 +33,7 @@ from easyuse_anima.naia import resolution as naia_resolution
 from easyuse_anima.nodes import (
     image_nodes,
     impact_detailer_nodes,
+    input_types,
     lora_nodes,
     naia_nodes,
     prompt_advanced_nodes,
@@ -944,6 +945,74 @@ class WildcardNaiaMoveContractTests(unittest.TestCase):
                 package_naia_nodes.EasyUseAnimaNAIARandomPrompt,
             )
             self.assertFalse(hasattr(package_nodes, "WILDCARD_SEED_RANGE_NOTE"))
+
+
+class InputTypeMoveContractTests(unittest.TestCase):
+    def test_shared_input_type_behavior_and_flat_root_identity(self):
+        wildcard_type = input_types._AnyType("*")
+        self.assertFalse(wildcard_type != "IMAGE")
+
+        optional_inputs = input_types._FlexibleOptionalInputType(
+            input_types._ANY_TYPE
+        )
+        self.assertIn("arbitrary_name", optional_inputs)
+        self.assertIs(
+            optional_inputs["arbitrary_name"][0],
+            input_types._ANY_TYPE,
+        )
+
+        self.assertIs(nodes._AnyType, input_types._AnyType)
+        self.assertIs(
+            nodes._FlexibleOptionalInputType,
+            input_types._FlexibleOptionalInputType,
+        )
+        self.assertIs(nodes._ANY_TYPE, input_types._ANY_TYPE)
+        self.assertIs(lora_nodes._ANY_TYPE, input_types._ANY_TYPE)
+        for adapter in (
+            lora_nodes,
+            prompt_advanced_nodes,
+            regional_nodes,
+            wildcard_nodes,
+        ):
+            with self.subTest(adapter=adapter.__name__):
+                self.assertIs(
+                    adapter._FlexibleOptionalInputType,
+                    input_types._FlexibleOptionalInputType,
+                )
+
+    def test_package_root_and_adapters_share_the_canonical_input_types(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_input_types = sys.modules[
+                f"{package_name}.easyuse_anima.nodes.input_types"
+            ]
+            package_adapters = (
+                sys.modules[f"{package_name}.easyuse_anima.nodes.lora_nodes"],
+                sys.modules[
+                    f"{package_name}.easyuse_anima.nodes.prompt_advanced_nodes"
+                ],
+                sys.modules[
+                    f"{package_name}.easyuse_anima.nodes.regional_nodes"
+                ],
+                sys.modules[f"{package_name}.easyuse_anima.nodes.wildcard_nodes"],
+            )
+
+            self.assertIs(package_nodes._AnyType, package_input_types._AnyType)
+            self.assertIs(
+                package_nodes._FlexibleOptionalInputType,
+                package_input_types._FlexibleOptionalInputType,
+            )
+            self.assertIs(package_nodes._ANY_TYPE, package_input_types._ANY_TYPE)
+            self.assertIs(
+                package_adapters[0]._ANY_TYPE,
+                package_input_types._ANY_TYPE,
+            )
+            for adapter in package_adapters:
+                with self.subTest(adapter=adapter.__name__):
+                    self.assertIs(
+                        adapter._FlexibleOptionalInputType,
+                        package_input_types._FlexibleOptionalInputType,
+                    )
 
 
 class LoraPresetMoveContractTests(unittest.TestCase):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "bb1344cd0e436e823a428e3f3f41ee77cd71b982")
-        # Issue #184 B-10b20 retires the final 21 unsupported Artist Mix
-        # conditioning aliases while preserving tensor and metadata behavior.
+        self.assertEqual(report["git_blob_sha1"], "c4bda09b51453509e63f8ffe9676c88c3ae05184")
+        # Issue #184 B-11c1 moves the final root-owned input type classes while
+        # preserving direct aliases and binder identity.
         self.assertEqual(report["top_level"]["function_count"], 41)
-        self.assertEqual(report["top_level"]["class_count"], 2)
-        self.assertEqual(report["line_count"], 2_712)
+        self.assertEqual(report["top_level"]["class_count"], 0)
+        self.assertEqual(report["line_count"], 2_705)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 79)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 79)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 79)
+        self.assertEqual(report["inventory"]["module_count"], 80)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 80)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 80)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
         self.assertTrue(

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "20c8b4d57243cc4b2c0423f43c9f0a2069707187"
+BASE_COMMIT = "f2a2ec0198119caa9680ca86a8c5d4d068ab4ba8"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1303,6 +1303,7 @@ def _build_document() -> dict[str, Any]:
                 "B-10b20",
                 "B-11a",
                 "B-11b",
+                "B-11c1",
             ],
         },
         "enums": {
@@ -1315,13 +1316,13 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 258,
+            "nodes_canonical_bindings": 261,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 41,
-            "root_residual_classes": 2,
-            "root_residual_globals": 33,
+            "root_residual_classes": 0,
+            "root_residual_globals": 32,
             "runtime_binders": 28,
             "direct_nodes_import_test_files": 21,
         },
@@ -1409,7 +1410,14 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             self.assertTrue(group["known_consumers"])
             self.assertTrue(group["evidence"])
             self.assertTrue(group["removal_gates"])
-            self.assertTrue(group["symbols"])
+            if not group["symbols"]:
+                self.assertEqual(group["surface"], "nodes_root_residuals")
+                self.assertEqual(
+                    self.document["expected_counts"][
+                        f"root_residual_{group['kind']}"
+                    ],
+                    0,
+                )
             if group["binding_shape"] == "direct_import":
                 self.assertTrue(group["import_target"])
             else:

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -43,6 +43,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.naia",
     "easyuse_anima.nodes",
     "easyuse_anima.nodes.aio_nodes",
+    "easyuse_anima.nodes.input_types",
     "easyuse_anima.nodes.impact_detailer_nodes",
     "easyuse_anima.nodes.prompt_advanced_nodes",
     "easyuse_anima.nodes.prompt_data_nodes",

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -56,6 +56,7 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/nodes/aio_nodes.py",
     "easyuse_anima/nodes/image_nodes.py",
     "easyuse_anima/nodes/impact_detailer_nodes.py",
+    "easyuse_anima/nodes/input_types.py",
     "easyuse_anima/nodes/lora_nodes.py",
     "easyuse_anima/nodes/naia_nodes.py",
     "easyuse_anima/nodes/prompt_data_nodes.py",


### PR DESCRIPTION
## 변경 전 inventory

- 기준: `dev` / `f2a2ec0198119caa9680ca86a8c5d4d068ab4ba8`
- 유형: Move-only (`B-11c1 input-type residual`)
- B-11c split 근거:
  - root `nodes.py`에는 41 functions, 2 classes, 33 globals, 28 runtime binders가 남아 있음.
  - 최종 shim cutover를 한 PR로 수행하면 256개 resolver seam과 21개 direct-root test consumer를 함께 변경해야 하므로 rollback 가능한 Move 경계를 넘음.
  - 이 PR은 최종 shim이나 binder 제거를 시도하지 않고, 독립적인 두 class와 singleton만 먼저 canonical owner로 이동함.
- symbol/caller:
  - `_AnyType`: `str` subclass이며 `__ne__`가 항상 `False`인 wildcard socket type helper.
  - `_FlexibleOptionalInputType`: 임의 key를 `(input_type,)`로 제공하는 optional-input mapping helper.
  - `_ANY_TYPE`: `_AnyType("*")` singleton.
  - root binder caller는 `_bind_regional_node_runtime`, `_bind_prompt_advanced_node_runtime`, `_bind_lora_node_runtime`이며 마지막 binder만 `_ANY_TYPE`도 전달함.
  - canonical Regional/Prompt Advanced/LoRA adapter의 binder signature와 call order는 유지함.
  - canonical 실제 소비자는 LoRA, Prompt Advanced, Regional, Wildcard 네 adapter이며, 현재 각 adapter에 동일한 local fallback class가 중복되어 있음.
- alias/compatibility:
  - 세 root name은 새 canonical object의 explicit direct identity alias로 유지함.
  - existing root monkeypatch/binder behavior, mapped class identity, socket shape와 `INPUT_TYPES` order/default는 변경하지 않음.
  - 네 adapter의 local fallback 정의만 제거하고 같은 canonical object를 import함. Wildcard는 binder 대상이 아니므로 direct owner import만 사용함.
  - legacy Wildcard/SAM3 compatibility surface는 이 PR에서 건드리지 않음.
- global state:
  - 새 owner는 immutable class definitions와 `_ANY_TYPE` singleton만 소유함.
  - file I/O, network, route, cache, lock, lifecycle, random/seed state는 없음.

## 허용 경계

- production: root `nodes.py`, new `easyuse_anima/nodes/input_types.py`, `easyuse_anima/nodes/lora_nodes.py`, `prompt_advanced_nodes.py`, `regional_nodes.py`, `wildcard_nodes.py`
- focused contracts: input-type identity/behavior, affected node socket contracts, node/public compatibility
- package/analyzer contracts: package skeleton, Registry scanner closure, backend analyzer baseline, compatibility surface test/fixture
- status docs: backend execution roadmap, compatibility shim registry

## 금지 경계

- binder signature/call order 또는 resolver/monkeypatch 동작 변경
- Regional/Prompt Advanced/LoRA/Wildcard의 input type owner import 외 node implementation 변경
- root `nodes.py`의 다른 residual function/global/alias 제거
- legacy Wildcard/SAM3 compatibility decision
- schema/default/socket/workflow/frontend/seed/cache/API behavior
- B-11c final shim cutover, Phase D root consolidation, Phase E RuntimeServices

## 변경 요약

- 세 symbol을 side-effect-free `easyuse_anima.nodes.input_types` owner로 동일 구현 그대로 이동함.
- root `nodes.py`의 relative/flat compatibility branch가 canonical object를 explicit alias로 re-export함.
- 네 consumer module의 중복 정의를 owner import로 바꾸고, 기존 binder 인자·재할당·호출 시점은 그대로 두어 monkeypatch seam과 object identity를 보존함.
- analyzer/compatibility fixture는 실제 새 module과 alias target만 반영함.

## 주요 파일

- `easyuse_anima/nodes/input_types.py`: side-effect-free canonical owner
- `nodes.py`: relative/flat direct compatibility aliases; 기존 binder 호출 유지
- `easyuse_anima/nodes/{lora,prompt_advanced,regional,wildcard}_nodes.py`: 중복 local owner 제거
- `tests/test_node_contracts.py`: flat/package root와 네 adapter의 identity/동작 계약
- compatibility/analyzer/package/scanner fixture와 status docs

## 검증 결과

- focused `unittest`: input-type flat/package identity와 public node/workflow contract 8개 통과
- compatibility/scanner/analyzer 재검증 14개 통과; 독립 리뷰 지적 수정 후 compatibility 12개 통과
- `git diff --check`: 통과
- 독립 diff review: runtime finding 없음; fixture topology와 문서 수치 지적 2건 수정 완료
- 첫 공식 full: Python 885개 중 stale `nodes.py` analyzer baseline 1건만 실패; 실제 shape `41 functions / 0 classes / 32 globals / 2705 lines`로 기대값 갱신 후 해당 focused test 통과
- 최종 head `cc419129c3bcfc5a33fa640e0e46e087e0b59473` 공식 `Profile full`: 통과
  - Python `unittest`: 885 passed
  - frontend: 114 JavaScript files passed (TypeScript 6.0.3)
  - Pyright baseline: 63 files / existing 60 errors / 0 warnings, ratchet 통과
  - import boundary: 6 completed groups / 0 violations
  - Ruff G-01 report-only: existing 105 findings, 증가 없음
- 테스트 표면: ComfyUI Codex test instance runner; live ComfyUI/browser 미실행

## 남은 위험 / 미확인

- 이 PR 뒤에도 root `nodes.py`의 41 functions/32 globals/28 binders 중 이 lane과 무관한 residual이 남으므로 B-11c와 Phase B는 완료되지 않음.
- 최종 shim 전에 workflow/wildcard reservation, AiO normalization/seed/Comfy boundary/postprocess, binder cutover를 별도 Move로 진행해야 함.
- live ComfyUI/browser 및 package/pack exit 검증은 Phase B exit checkpoint에 남김.
