### PR TITLE
refactor(backend): move workflow lookup residual (B-11c2)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -56,7 +56,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   owner in PR #292. B-11b moved route-table registration and wildcard startup
   to guarded `easyuse_anima.bootstrap` ownership in PR #293 / `f2a2ec0`.
   B-11c is split into residual-owner Moves before the final `nodes.py` shim;
-  B-11c1 starts with shared private input types in PR #294.
+  B-11c1 moved shared private input types in PR #294 / `ebeee89`, and B-11c2
+  moves the read-only workflow lookup owner in PR #295.
 
 ### Current quality baseline
 
@@ -298,7 +299,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 input types PR #294 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 workflow lookup PR #295 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -794,7 +795,11 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
   - B-11c1 moves `_AnyType`, `_FlexibleOptionalInputType`, and `_ANY_TYPE` to
     side-effect-free `easyuse_anima.nodes.input_types`, while retaining direct
     root aliases and the existing Regional, Prompt Advanced, and LoRA binder
-    calls. PR #294 owns this Move-only unit.
+    calls. PR #294 / `ebeee89` completes this Move-only unit.
+  - B-11c2 moves only `_get_workflow_node` to side-effect-free
+    `easyuse_anima.workflow`. PR #295 retains the root direct alias and the
+    existing Wildcard, NAIA, Prompt Advanced, and Regional binder/resolver
+    calls. Reserved wildcard seed consumption remains separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `f2a2ec0198119caa9680ca86a8c5d4d068ab4ba8`
+  `ebeee894e537c0edb4c7ec7aed34cefd212151f4`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a is integrated in PR #292 and B-11b in PR #293. B-11c is
+- Current state: B-11a through B-11c1 are integrated through PR #294. B-11c is
   split into residual-owner and binder Moves before the final root shim;
-  B-11c1 input-type ownership is tracked by PR #294.
+  B-11c2 workflow lookup ownership is tracked by PR #295.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,8 +75,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 261 after
-  B-11c1 (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 262 after
+  B-11c2 (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -84,8 +84,8 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 41 functions, 0 classes, and 32 assigned
-  globals after B-11c1 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 40 functions, 0 classes, and 32 assigned
+  globals after B-11c2 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 256, including
   literal lookups and binder-owned helper-name/default collections;
@@ -163,6 +163,19 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - LoRA, Prompt Advanced, Regional, and Wildcard adapters import the shared
   owner instead of retaining duplicate local definitions. Socket values,
   workflow payloads, and mapped node-class identity do not change.
+
+### B-11c2 workflow lookup alias
+
+- Canonical owner: `easyuse_anima.workflow._get_workflow_node`.
+- The private root name remains a transitional direct alias. Existing Wildcard
+  and NAIA callback binders plus Prompt Advanced and Regional string resolvers
+  still resolve through the root at call time, preserving monkeypatch seams.
+- The owner reads top-level and nested subgraph workflow metadata without
+  mutation or global state. Traversal order, return values, and adapter binder
+  signatures do not change in PR #295.
+- Reserved wildcard next-seed consumption remains root-owned because moving it
+  before D-12 would require a new dependency contract, canonical-to-legacy
+  import, or duplicated seed behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/workflow.py
+++ b/easyuse_anima/workflow.py
@@ -1,0 +1,50 @@
+"""Read-only helpers for locating nodes in ComfyUI workflow metadata."""
+
+from __future__ import annotations
+
+from .common.values import _single_value
+
+__all__ = ()
+
+
+def _get_workflow_node(extra_pnginfo, node_id: str):
+    pnginfo = _single_value(extra_pnginfo)
+    if not isinstance(pnginfo, dict):
+        return None
+    workflow = pnginfo.get("workflow")
+    if not isinstance(workflow, dict):
+        return None
+
+    node_ids = str(node_id).split(":")
+    nodes_list = workflow.get("nodes", [])
+    definitions = workflow.get("definitions", {})
+    if not isinstance(definitions, dict):
+        definitions = {}
+    subgraphs = definitions.get("subgraphs", [])
+    if not isinstance(subgraphs, list):
+        subgraphs = []
+
+    found = None
+    for individual_node_id in node_ids:
+        if not isinstance(nodes_list, list):
+            return None
+        found = next(
+            (
+                node
+                for node in nodes_list
+                if isinstance(node, dict) and str(node.get("id")) == individual_node_id
+            ),
+            None,
+        )
+        if isinstance(found, dict):
+            subgraph = next(
+                (
+                    graph
+                    for graph in subgraphs
+                    if isinstance(graph, dict) and str(graph.get("id")) == str(found.get("type"))
+                ),
+                None,
+            )
+            if isinstance(subgraph, dict) and isinstance(subgraph.get("nodes"), list):
+                nodes_list = subgraph["nodes"]
+    return found

--- a/nodes.py
+++ b/nodes.py
@@ -113,6 +113,7 @@ try:
         _choice as _choice,
         _single_value as _single_value,
     )
+    from .easyuse_anima.workflow import _get_workflow_node as _get_workflow_node
     from .easyuse_anima.prompt.correction import (
         _bind_prompt_correction_runtime as _bind_prompt_correction_runtime,
         _prompt_translation_change_key as _prompt_translation_change_key,
@@ -631,6 +632,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _choice as _choice,
         _single_value as _single_value,
     )
+    from easyuse_anima.workflow import _get_workflow_node as _get_workflow_node
     from easyuse_anima.prompt.correction import (
         _bind_prompt_correction_runtime as _bind_prompt_correction_runtime,
         _prompt_translation_change_key as _prompt_translation_change_key,
@@ -2478,49 +2480,6 @@ def _aio_detailer_has_enabled_targets(detailer_settings: dict[str, Any]) -> bool
         and _as_bool(detailer_settings[name].get("enabled"), False)
         for name in _aio_detailer_target_order(detailer_settings)
     )
-
-
-def _get_workflow_node(extra_pnginfo, node_id: str):
-    pnginfo = _single_value(extra_pnginfo)
-    if not isinstance(pnginfo, dict):
-        return None
-    workflow = pnginfo.get("workflow")
-    if not isinstance(workflow, dict):
-        return None
-
-    node_ids = str(node_id).split(":")
-    nodes_list = workflow.get("nodes", [])
-    definitions = workflow.get("definitions", {})
-    if not isinstance(definitions, dict):
-        definitions = {}
-    subgraphs = definitions.get("subgraphs", [])
-    if not isinstance(subgraphs, list):
-        subgraphs = []
-
-    found = None
-    for individual_node_id in node_ids:
-        if not isinstance(nodes_list, list):
-            return None
-        found = next(
-            (
-                node
-                for node in nodes_list
-                if isinstance(node, dict) and str(node.get("id")) == individual_node_id
-            ),
-            None,
-        )
-        if isinstance(found, dict):
-            subgraph = next(
-                (
-                    graph
-                    for graph in subgraphs
-                    if isinstance(graph, dict) and str(graph.get("id")) == str(found.get("type"))
-                ),
-                None,
-            )
-            if isinstance(subgraph, dict) and isinstance(subgraph.get("nodes"), list):
-                nodes_list = subgraph["nodes"]
-    return found
 
 
 def _consume_reserved_wildcard_next_seed(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14062,6 +14062,41 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/workflow.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_single_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".common.values:_single_value",
+        "kind": "static_from",
+        "line": 5,
+        "name": "_single_value",
+        "optional": false,
+        "requested": ".common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/workflow.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
         "line": 2,
         "name": "annotations",
         "optional": false,
@@ -16639,6 +16674,37 @@
         "target": "easyuse_anima/common/values.py"
       },
       {
+        "alias": "_get_workflow_node",
+        "bound_name": "_get_workflow_node",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_get_workflow_node",
+          "target": "easyuse_anima/workflow.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.workflow:_get_workflow_node",
+        "kind": "static_from",
+        "line": 116,
+        "name": "_get_workflow_node",
+        "optional": false,
+        "requested": ".easyuse_anima.workflow",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/workflow.py"
+      },
+      {
         "alias": "_bind_prompt_correction_runtime",
         "bound_name": "_bind_prompt_correction_runtime",
         "branch_context": [
@@ -16660,7 +16726,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16691,7 +16757,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16722,7 +16788,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16753,7 +16819,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16784,7 +16850,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16815,7 +16881,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16846,7 +16912,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16877,7 +16943,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16908,7 +16974,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16939,7 +17005,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16970,7 +17036,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17001,7 +17067,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17032,7 +17098,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17063,7 +17129,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17094,7 +17160,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17125,7 +17191,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17156,7 +17222,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17187,7 +17253,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17218,7 +17284,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17249,7 +17315,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17280,7 +17346,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17311,7 +17377,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17342,7 +17408,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17373,7 +17439,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17404,7 +17470,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17435,7 +17501,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17466,7 +17532,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17497,7 +17563,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17528,7 +17594,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17559,7 +17625,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17590,7 +17656,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17621,7 +17687,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17652,7 +17718,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17683,7 +17749,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17714,7 +17780,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17745,7 +17811,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17776,7 +17842,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17807,7 +17873,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17838,7 +17904,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17869,7 +17935,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17900,7 +17966,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17931,7 +17997,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17962,7 +18028,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17993,7 +18059,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18024,7 +18090,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18055,7 +18121,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18086,7 +18152,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18117,7 +18183,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18148,7 +18214,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18179,7 +18245,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18210,7 +18276,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18241,7 +18307,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18272,7 +18338,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18303,7 +18369,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18334,7 +18400,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18365,7 +18431,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18396,7 +18462,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18427,7 +18493,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18458,7 +18524,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18489,7 +18555,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18520,7 +18586,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18551,7 +18617,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18582,7 +18648,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18613,7 +18679,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18644,7 +18710,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18675,7 +18741,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18706,7 +18772,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18737,7 +18803,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18768,7 +18834,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18799,7 +18865,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18830,7 +18896,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18861,7 +18927,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18892,7 +18958,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18923,7 +18989,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18954,7 +19020,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18985,7 +19051,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19016,7 +19082,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19047,7 +19113,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19078,7 +19144,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19109,7 +19175,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19140,7 +19206,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19171,7 +19237,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19202,7 +19268,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19233,7 +19299,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19264,7 +19330,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19295,7 +19361,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19326,7 +19392,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19357,7 +19423,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19388,7 +19454,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19419,7 +19485,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19450,7 +19516,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 234,
+        "line": 235,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19481,7 +19547,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 314,
+        "line": 315,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19512,7 +19578,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 314,
+        "line": 315,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19543,7 +19609,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 314,
+        "line": 315,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19574,7 +19640,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 314,
+        "line": 315,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19605,7 +19671,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 320,
+        "line": 321,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19636,7 +19702,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 320,
+        "line": 321,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19667,7 +19733,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 320,
+        "line": 321,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19698,7 +19764,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 325,
+        "line": 326,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19729,7 +19795,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 325,
+        "line": 326,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19760,7 +19826,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 325,
+        "line": 326,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19791,7 +19857,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 331,
+        "line": 332,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19822,7 +19888,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 331,
+        "line": 332,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19853,7 +19919,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 331,
+        "line": 332,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19884,7 +19950,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 331,
+        "line": 332,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19915,7 +19981,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 331,
+        "line": 332,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19946,7 +20012,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 338,
+        "line": 339,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -19977,7 +20043,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 338,
+        "line": 339,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20008,7 +20074,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 348,
+        "line": 349,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20039,7 +20105,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 348,
+        "line": 349,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20070,7 +20136,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 348,
+        "line": 349,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20101,7 +20167,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 348,
+        "line": 349,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20132,7 +20198,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 361,
+        "line": 362,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20163,7 +20229,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 361,
+        "line": 362,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20194,7 +20260,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20225,7 +20291,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20256,7 +20322,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20287,7 +20353,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20318,7 +20384,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20349,7 +20415,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20380,7 +20446,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20411,7 +20477,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20442,7 +20508,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 380,
+        "line": 381,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20473,7 +20539,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 380,
+        "line": 381,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20504,7 +20570,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 380,
+        "line": 381,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20535,7 +20601,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 380,
+        "line": 381,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20566,7 +20632,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 386,
+        "line": 387,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20597,7 +20663,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 386,
+        "line": 387,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20628,7 +20694,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 386,
+        "line": 387,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20659,7 +20725,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 386,
+        "line": 387,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20690,7 +20756,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 386,
+        "line": 387,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20721,7 +20787,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20752,7 +20818,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20783,7 +20849,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -20814,7 +20880,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -20845,7 +20911,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -20876,7 +20942,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -20907,7 +20973,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -20938,7 +21004,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -20969,7 +21035,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21000,7 +21066,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21031,7 +21097,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21062,7 +21128,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 414,
+        "line": 415,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21093,7 +21159,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 414,
+        "line": 415,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21124,7 +21190,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 414,
+        "line": 415,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21155,7 +21221,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 419,
+        "line": 420,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21186,7 +21252,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 419,
+        "line": 420,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21217,7 +21283,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 419,
+        "line": 420,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21248,7 +21314,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21279,7 +21345,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21310,7 +21376,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21341,7 +21407,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21372,7 +21438,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21403,7 +21469,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 460,
+        "line": 461,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21434,7 +21500,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 460,
+        "line": 461,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21465,7 +21531,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 464,
+        "line": 465,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21496,7 +21562,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 464,
+        "line": 465,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21527,7 +21593,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21558,7 +21624,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21589,7 +21655,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21620,7 +21686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21651,7 +21717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21682,7 +21748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21713,7 +21779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21744,7 +21810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21775,7 +21841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21806,7 +21872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21837,7 +21903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21868,7 +21934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21899,7 +21965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21930,7 +21996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21961,7 +22027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21992,7 +22058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 486,
+        "line": 487,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22023,7 +22089,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 486,
+        "line": 487,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22054,7 +22120,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 486,
+        "line": 487,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22085,7 +22151,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 486,
+        "line": 487,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22116,7 +22182,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 486,
+        "line": 487,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22147,7 +22213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 486,
+        "line": 487,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22178,7 +22244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 486,
+        "line": 487,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22209,7 +22275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 486,
+        "line": 487,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22240,7 +22306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 496,
+        "line": 497,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22271,7 +22337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 496,
+        "line": 497,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22302,7 +22368,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22333,7 +22399,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22364,7 +22430,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -22395,7 +22461,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -22426,7 +22492,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -22457,7 +22523,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -22488,7 +22554,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22519,7 +22585,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22550,7 +22616,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22581,7 +22647,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22612,7 +22678,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22643,7 +22709,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22674,7 +22740,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22705,7 +22771,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22736,7 +22802,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22767,7 +22833,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22798,7 +22864,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22829,7 +22895,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22860,7 +22926,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22891,7 +22957,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22922,7 +22988,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22953,7 +23019,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22984,7 +23050,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23015,7 +23081,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23046,7 +23112,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23077,7 +23143,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23108,7 +23174,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23127,7 +23193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23142,7 +23208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23161,7 +23227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23176,7 +23242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23195,7 +23261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23210,7 +23276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23229,7 +23295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23244,7 +23310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23263,7 +23329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23278,7 +23344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23297,7 +23363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23312,7 +23378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23331,7 +23397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23346,7 +23412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23365,7 +23431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23380,7 +23446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23399,7 +23465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23414,7 +23480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23433,7 +23499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23448,7 +23514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23467,7 +23533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23482,7 +23548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23501,7 +23567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23516,7 +23582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23535,7 +23601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23550,7 +23616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23569,7 +23635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23584,7 +23650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 550,
+        "line": 551,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -23603,7 +23669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23618,7 +23684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 553,
+        "line": 554,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23637,7 +23703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23652,7 +23718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 553,
+        "line": 554,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23671,7 +23737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23686,7 +23752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 553,
+        "line": 554,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23705,7 +23771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23720,7 +23786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 553,
+        "line": 554,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23739,7 +23805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23754,7 +23820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23773,7 +23839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23788,7 +23854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23807,7 +23873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23822,7 +23888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23841,7 +23907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23856,7 +23922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23875,7 +23941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23890,7 +23956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23909,7 +23975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23924,7 +23990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23943,7 +24009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23958,7 +24024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23977,7 +24043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -23992,7 +24058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24011,7 +24077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24026,7 +24092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24045,7 +24111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24060,7 +24126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24079,7 +24145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24094,7 +24160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24113,7 +24179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24128,7 +24194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24147,7 +24213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24162,7 +24228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24181,7 +24247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24196,7 +24262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24215,7 +24281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24230,7 +24296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24249,7 +24315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24264,7 +24330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24283,7 +24349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24298,7 +24364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24317,7 +24383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24332,7 +24398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24351,7 +24417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24366,7 +24432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24385,7 +24451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24400,7 +24466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24419,7 +24485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24434,7 +24500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24453,7 +24519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24468,7 +24534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24487,7 +24553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24502,7 +24568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24521,7 +24587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24536,7 +24602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24555,7 +24621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24570,7 +24636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24589,7 +24655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24604,7 +24670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24623,7 +24689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24638,7 +24704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24657,7 +24723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24672,7 +24738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24691,7 +24757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24706,7 +24772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24725,7 +24791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24740,7 +24806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24759,7 +24825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24774,7 +24840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24793,7 +24859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24808,7 +24874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24827,7 +24893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24842,7 +24908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24861,7 +24927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24876,7 +24942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24895,7 +24961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24910,7 +24976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24929,7 +24995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24944,7 +25010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24963,7 +25029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -24978,7 +25044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24997,7 +25063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25012,7 +25078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25031,7 +25097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25046,7 +25112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25065,7 +25131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25080,7 +25146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25099,7 +25165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25114,7 +25180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25133,7 +25199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25148,7 +25214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25167,7 +25233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25182,7 +25248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25201,7 +25267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25216,7 +25282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25235,7 +25301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25250,7 +25316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25269,7 +25335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25284,7 +25350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25303,7 +25369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25318,7 +25384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25337,7 +25403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25352,7 +25418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25371,7 +25437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25386,7 +25452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25405,7 +25471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25420,7 +25486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25439,7 +25505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25454,7 +25520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25473,7 +25539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25488,7 +25554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25507,7 +25573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25522,7 +25588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25541,7 +25607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25556,7 +25622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 622,
+        "line": 623,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25575,7 +25641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25590,7 +25656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 622,
+        "line": 623,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25609,7 +25675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25624,7 +25690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 622,
+        "line": 623,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25643,7 +25709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25658,7 +25724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25677,7 +25743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25692,7 +25758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25711,7 +25777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25726,7 +25792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25745,7 +25811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25760,7 +25826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25779,7 +25845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25794,7 +25860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25802,6 +25868,40 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": "_get_workflow_node",
+        "bound_name": "_get_workflow_node",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 530,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_get_workflow_node",
+          "target": "easyuse_anima/workflow.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.workflow:_get_workflow_node",
+        "kind": "static_from",
+        "line": 635,
+        "name": "_get_workflow_node",
+        "optional": false,
+        "requested": "easyuse_anima.workflow",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/workflow.py"
       },
       {
         "alias": "_bind_prompt_correction_runtime",
@@ -25813,7 +25913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25828,7 +25928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 634,
+        "line": 636,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -25847,7 +25947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25862,7 +25962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 634,
+        "line": 636,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -25881,7 +25981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25896,7 +25996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 634,
+        "line": 636,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -25915,7 +26015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25930,7 +26030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 634,
+        "line": 636,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -25949,7 +26049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25964,7 +26064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -25983,7 +26083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -25998,7 +26098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26017,7 +26117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26032,7 +26132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26051,7 +26151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26066,7 +26166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26085,7 +26185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26100,7 +26200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26119,7 +26219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26134,7 +26234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26153,7 +26253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26168,7 +26268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26187,7 +26287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26202,7 +26302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26221,7 +26321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26236,7 +26336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26255,7 +26355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26270,7 +26370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26289,7 +26389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26304,7 +26404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26323,7 +26423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26338,7 +26438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26357,7 +26457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26372,7 +26472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26391,7 +26491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26406,7 +26506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26425,7 +26525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26440,7 +26540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26459,7 +26559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26474,7 +26574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26493,7 +26593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26508,7 +26608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26527,7 +26627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26542,7 +26642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26561,7 +26661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26576,7 +26676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26595,7 +26695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26610,7 +26710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26629,7 +26729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26644,7 +26744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26663,7 +26763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26678,7 +26778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26697,7 +26797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26712,7 +26812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26731,7 +26831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26746,7 +26846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26765,7 +26865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26780,7 +26880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26799,7 +26899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26814,7 +26914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26833,7 +26933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26848,7 +26948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26867,7 +26967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26882,7 +26982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26901,7 +27001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26916,7 +27016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26935,7 +27035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26950,7 +27050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26969,7 +27069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -26984,7 +27084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27003,7 +27103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27018,7 +27118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27037,7 +27137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27052,7 +27152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27071,7 +27171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27086,7 +27186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27105,7 +27205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27120,7 +27220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27139,7 +27239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27154,7 +27254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27173,7 +27273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27188,7 +27288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27207,7 +27307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27222,7 +27322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27241,7 +27341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27256,7 +27356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27275,7 +27375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27290,7 +27390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27309,7 +27409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27324,7 +27424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27343,7 +27443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27358,7 +27458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27377,7 +27477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27392,7 +27492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27411,7 +27511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27426,7 +27526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27445,7 +27545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27460,7 +27560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27479,7 +27579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27494,7 +27594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27513,7 +27613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27528,7 +27628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27547,7 +27647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27562,7 +27662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27581,7 +27681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27596,7 +27696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27615,7 +27715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27630,7 +27730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27649,7 +27749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27664,7 +27764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27683,7 +27783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27698,7 +27798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27717,7 +27817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27732,7 +27832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27751,7 +27851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27766,7 +27866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27785,7 +27885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27800,7 +27900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27819,7 +27919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27834,7 +27934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27853,7 +27953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27868,7 +27968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27887,7 +27987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27902,7 +28002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27921,7 +28021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27936,7 +28036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27955,7 +28055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -27970,7 +28070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27989,7 +28089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28004,7 +28104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28023,7 +28123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28038,7 +28138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28057,7 +28157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28072,7 +28172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28091,7 +28191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28106,7 +28206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28125,7 +28225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28140,7 +28240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28159,7 +28259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28174,7 +28274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28193,7 +28293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28208,7 +28308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28227,7 +28327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28242,7 +28342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28261,7 +28361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28276,7 +28376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28295,7 +28395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28310,7 +28410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28329,7 +28429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28344,7 +28444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28363,7 +28463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28378,7 +28478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28397,7 +28497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28412,7 +28512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28431,7 +28531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28446,7 +28546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28465,7 +28565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28480,7 +28580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28499,7 +28599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28514,7 +28614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28533,7 +28633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28548,7 +28648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28567,7 +28667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28582,7 +28682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28601,7 +28701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28616,7 +28716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28635,7 +28735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28650,7 +28750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28669,7 +28769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28684,7 +28784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28703,7 +28803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28718,7 +28818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28737,7 +28837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28752,7 +28852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28771,7 +28871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28786,7 +28886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28805,7 +28905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28820,7 +28920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28839,7 +28939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28854,7 +28954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28873,7 +28973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28888,7 +28988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28907,7 +29007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28922,7 +29022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -28941,7 +29041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28956,7 +29056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -28975,7 +29075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -28990,7 +29090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29009,7 +29109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29024,7 +29124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29043,7 +29143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29058,7 +29158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 838,
+        "line": 840,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29077,7 +29177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29092,7 +29192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 838,
+        "line": 840,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29111,7 +29211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29126,7 +29226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 838,
+        "line": 840,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29145,7 +29245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29160,7 +29260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 843,
+        "line": 845,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29179,7 +29279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29194,7 +29294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 843,
+        "line": 845,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29213,7 +29313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29228,7 +29328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 843,
+        "line": 845,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29247,7 +29347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29262,7 +29362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 849,
+        "line": 851,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29281,7 +29381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29296,7 +29396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 849,
+        "line": 851,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29315,7 +29415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29330,7 +29430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 849,
+        "line": 851,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29349,7 +29449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29364,7 +29464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 849,
+        "line": 851,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29383,7 +29483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29398,7 +29498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 849,
+        "line": 851,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29417,7 +29517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29432,7 +29532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29451,7 +29551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29466,7 +29566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29485,7 +29585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29500,7 +29600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29519,7 +29619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29534,7 +29634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29553,7 +29653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29568,7 +29668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29587,7 +29687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29602,7 +29702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29621,7 +29721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29636,7 +29736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 879,
+        "line": 881,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -29655,7 +29755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29670,7 +29770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 879,
+        "line": 881,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -29689,7 +29789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29704,7 +29804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29723,7 +29823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29738,7 +29838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29757,7 +29857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29772,7 +29872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29791,7 +29891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29806,7 +29906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29825,7 +29925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29840,7 +29940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29859,7 +29959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29874,7 +29974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29893,7 +29993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29908,7 +30008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29927,7 +30027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29942,7 +30042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29961,7 +30061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -29976,7 +30076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -29995,7 +30095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30010,7 +30110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30029,7 +30129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30044,7 +30144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30063,7 +30163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30078,7 +30178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30097,7 +30197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30112,7 +30212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30131,7 +30231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30146,7 +30246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30165,7 +30265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30180,7 +30280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30199,7 +30299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30214,7 +30314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30233,7 +30333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30248,7 +30348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30267,7 +30367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30282,7 +30382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30301,7 +30401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30316,7 +30416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30335,7 +30435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30350,7 +30450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -30369,7 +30469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30384,7 +30484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30403,7 +30503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30418,7 +30518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30437,7 +30537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30452,7 +30552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30471,7 +30571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30486,7 +30586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30505,7 +30605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30520,7 +30620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30539,7 +30639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30554,7 +30654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30573,7 +30673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30588,7 +30688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30607,7 +30707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30622,7 +30722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30641,7 +30741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30656,7 +30756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30675,7 +30775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30690,7 +30790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30709,7 +30809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30724,7 +30824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30743,7 +30843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30758,7 +30858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -30777,7 +30877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30792,7 +30892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -30811,7 +30911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30826,7 +30926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -30845,7 +30945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30860,7 +30960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 955,
+        "line": 957,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -30879,7 +30979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30894,7 +30994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 955,
+        "line": 957,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -30913,7 +31013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30928,7 +31028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 955,
+        "line": 957,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -30947,7 +31047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30962,7 +31062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 955,
+        "line": 957,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -30981,7 +31081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -30996,7 +31096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 955,
+        "line": 957,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31015,7 +31115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31030,7 +31130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 978,
+        "line": 980,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31049,7 +31149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31064,7 +31164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 978,
+        "line": 980,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31083,7 +31183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31098,7 +31198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 982,
+        "line": 984,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31117,7 +31217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31132,7 +31232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 982,
+        "line": 984,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31151,7 +31251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31166,7 +31266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31185,7 +31285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31200,7 +31300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31219,7 +31319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31234,7 +31334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31253,7 +31353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31268,7 +31368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31287,7 +31387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31302,7 +31402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31321,7 +31421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31336,7 +31436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31355,7 +31455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31370,7 +31470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31389,7 +31489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31404,7 +31504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31423,7 +31523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31438,7 +31538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31457,7 +31557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31472,7 +31572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31491,7 +31591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31506,7 +31606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31525,7 +31625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31540,7 +31640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31559,7 +31659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31574,7 +31674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31593,7 +31693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31608,7 +31708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31627,7 +31727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31642,7 +31742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31661,7 +31761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31676,7 +31776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31695,7 +31795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31710,7 +31810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31729,7 +31829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31744,7 +31844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31763,7 +31863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31778,7 +31878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31797,7 +31897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31812,7 +31912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31831,7 +31931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31846,7 +31946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31865,7 +31965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31880,7 +31980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31899,7 +31999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31914,7 +32014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31933,7 +32033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31948,7 +32048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -31967,7 +32067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -31982,7 +32082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32001,7 +32101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32016,7 +32116,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -32035,7 +32135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32050,7 +32150,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -32069,7 +32169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32084,7 +32184,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1021,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -32103,7 +32203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32118,7 +32218,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -32137,7 +32237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32152,7 +32252,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -32171,7 +32271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32186,7 +32286,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -32205,7 +32305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32220,7 +32320,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1027,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32239,7 +32339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32254,7 +32354,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1027,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32273,7 +32373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32288,7 +32388,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32307,7 +32407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32322,7 +32422,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32341,7 +32441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32356,7 +32456,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32375,7 +32475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32390,7 +32490,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32409,7 +32509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32424,7 +32524,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32443,7 +32543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32458,7 +32558,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32477,7 +32577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32492,7 +32592,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32511,7 +32611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32526,7 +32626,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32545,7 +32645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32560,7 +32660,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32579,7 +32679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32594,7 +32694,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32613,7 +32713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32628,7 +32728,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32647,7 +32747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32662,7 +32762,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32681,7 +32781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32696,7 +32796,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32715,7 +32815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32730,7 +32830,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32749,7 +32849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32764,7 +32864,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32783,7 +32883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32798,7 +32898,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32817,7 +32917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32832,7 +32932,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32851,7 +32951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32866,7 +32966,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32885,7 +32985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -32900,7 +33000,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32918,7 +33018,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1762
+            "line": 1764
           }
         ],
         "classification": "external",
@@ -32926,7 +33026,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1763,
+        "line": 1765,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -32943,7 +33043,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1799
+            "line": 1801
           }
         ],
         "classification": "external",
@@ -32951,7 +33051,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1800,
+        "line": 1802,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -32968,7 +33068,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1807
+            "line": 1809
           }
         ],
         "classification": "external",
@@ -32976,7 +33076,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1808,
+        "line": 1810,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -34934,6 +35034,10 @@
         "to": "easyuse_anima/nodes/wildcard_nodes.py"
       },
       {
+        "from": "easyuse_anima/workflow.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
         "from": "nodes.py",
         "to": "anima_prompt/__init__.py"
       },
@@ -35104,6 +35208,10 @@
       {
         "from": "nodes.py",
         "to": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/workflow.py"
       },
       {
         "from": "nodes.py",
@@ -35604,6 +35712,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/workflow.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "nodes.py"
         ]
       },
@@ -35634,7 +35748,7 @@
     ]
   },
   "inventory": {
-    "module_count": 80,
+    "module_count": 81,
     "modules": [
       {
         "is_package": true,
@@ -36538,13 +36652,25 @@
       },
       {
         "is_package": false,
-        "loc": 2705,
+        "loc": 50,
+        "module": "easyuse_anima.workflow",
+        "normalized_git_blob_sha1": "8247d94d4e33a9fd0a7a9563b5333e28588ab8eb",
+        "path": "easyuse_anima/workflow.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 1,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 2664,
         "module": "nodes",
-        "normalized_git_blob_sha1": "c4bda09b51453509e63f8ffe9676c88c3ae05184",
+        "normalized_git_blob_sha1": "50ee288154fdaf73816e2884d7fe1d41e4fc20dc",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 41,
+          "function_count": 40,
           "global_count": 32
         }
       },
@@ -37904,7 +38030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -37913,7 +38039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37927,7 +38053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -37936,7 +38062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37950,7 +38076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -37959,7 +38085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37973,7 +38099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -37982,7 +38108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37996,7 +38122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38005,7 +38131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38019,7 +38145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38028,7 +38154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38042,7 +38168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38051,7 +38177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38065,7 +38191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38074,7 +38200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38088,7 +38214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38097,7 +38223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38111,7 +38237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38120,7 +38246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38134,7 +38260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38143,7 +38269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38157,7 +38283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38166,7 +38292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38180,7 +38306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38189,7 +38315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38203,7 +38329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38212,7 +38338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 550,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38226,7 +38352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38235,7 +38361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 553,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38249,7 +38375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38258,7 +38384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 553,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38272,7 +38398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38281,7 +38407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 553,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38295,7 +38421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38304,7 +38430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 553,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38318,7 +38444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38327,7 +38453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38341,7 +38467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38350,7 +38476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38364,7 +38490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38373,7 +38499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38387,7 +38513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38396,7 +38522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38410,7 +38536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38419,7 +38545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38433,7 +38559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38442,7 +38568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38456,7 +38582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38465,7 +38591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38479,7 +38605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38488,7 +38614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38502,7 +38628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38511,7 +38637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38525,7 +38651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38534,7 +38660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38548,7 +38674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38557,7 +38683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38571,7 +38697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38580,7 +38706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38594,7 +38720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38603,7 +38729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38617,7 +38743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38626,7 +38752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38640,7 +38766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38649,7 +38775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38663,7 +38789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38672,7 +38798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38686,7 +38812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38695,7 +38821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38709,7 +38835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38718,7 +38844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38732,7 +38858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38741,7 +38867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38755,7 +38881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38764,7 +38890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38778,7 +38904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38787,7 +38913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38801,7 +38927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38810,7 +38936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38824,7 +38950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38833,7 +38959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38847,7 +38973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38856,7 +38982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38870,7 +38996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38879,7 +39005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38893,7 +39019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38902,7 +39028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38916,7 +39042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38925,7 +39051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38939,7 +39065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38948,7 +39074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38962,7 +39088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38971,7 +39097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38985,7 +39111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -38994,7 +39120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39008,7 +39134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39017,7 +39143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39031,7 +39157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39040,7 +39166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 585,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39054,7 +39180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39063,7 +39189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39077,7 +39203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39086,7 +39212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39100,7 +39226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39109,7 +39235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39123,7 +39249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39132,7 +39258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39146,7 +39272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39155,7 +39281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39169,7 +39295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39178,7 +39304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39192,7 +39318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39201,7 +39327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39215,7 +39341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39224,7 +39350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39238,7 +39364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39247,7 +39373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39261,7 +39387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39270,7 +39396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39284,7 +39410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39293,7 +39419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39307,7 +39433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39316,7 +39442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39330,7 +39456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39339,7 +39465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39353,7 +39479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39362,7 +39488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39376,7 +39502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39385,7 +39511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39399,7 +39525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39408,7 +39534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39422,7 +39548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39431,7 +39557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39445,7 +39571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39454,7 +39580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39468,7 +39594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39477,7 +39603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39491,7 +39617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39500,7 +39626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39514,7 +39640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39523,7 +39649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39537,7 +39663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39546,7 +39672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 622,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39560,7 +39686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39569,7 +39695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 622,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39583,7 +39709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39592,7 +39718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 622,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39606,7 +39732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39615,7 +39741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39629,7 +39755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39638,7 +39764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39652,7 +39778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39661,7 +39787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39675,7 +39801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39684,7 +39810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39698,7 +39824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39707,7 +39833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39721,7 +39847,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.workflow:_get_workflow_node",
+        "kind": "static_from",
+        "line": 635,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/workflow.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39730,7 +39879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 634,
+        "line": 636,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39744,7 +39893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39753,7 +39902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 634,
+        "line": 636,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39767,7 +39916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39776,7 +39925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 634,
+        "line": 636,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39790,7 +39939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39799,7 +39948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 634,
+        "line": 636,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39813,7 +39962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39822,7 +39971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39836,7 +39985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39845,7 +39994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39859,7 +40008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39868,7 +40017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39882,7 +40031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39891,7 +40040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39905,7 +40054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39914,7 +40063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39928,7 +40077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39937,7 +40086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39951,7 +40100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39960,7 +40109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39974,7 +40123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -39983,7 +40132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39997,7 +40146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40006,7 +40155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40020,7 +40169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40029,7 +40178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40043,7 +40192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40052,7 +40201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40066,7 +40215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40075,7 +40224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40089,7 +40238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40098,7 +40247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40112,7 +40261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40121,7 +40270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40135,7 +40284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40144,7 +40293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40158,7 +40307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40167,7 +40316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40181,7 +40330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40190,7 +40339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 654,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40204,7 +40353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40213,7 +40362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40227,7 +40376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40236,7 +40385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40250,7 +40399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40259,7 +40408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40273,7 +40422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40282,7 +40431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40296,7 +40445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40305,7 +40454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40319,7 +40468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40328,7 +40477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40342,7 +40491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40351,7 +40500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40365,7 +40514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40374,7 +40523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40388,7 +40537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40397,7 +40546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40411,7 +40560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40420,7 +40569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40434,7 +40583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40443,7 +40592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40457,7 +40606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40466,7 +40615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40480,7 +40629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40489,7 +40638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40503,7 +40652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40512,7 +40661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40526,7 +40675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40535,7 +40684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40549,7 +40698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40558,7 +40707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40572,7 +40721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40581,7 +40730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40595,7 +40744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40604,7 +40753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40618,7 +40767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40627,7 +40776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40641,7 +40790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40650,7 +40799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40664,7 +40813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40673,7 +40822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40687,7 +40836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40696,7 +40845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 672,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40710,7 +40859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40719,7 +40868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40733,7 +40882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40742,7 +40891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40756,7 +40905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40765,7 +40914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40779,7 +40928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40788,7 +40937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40802,7 +40951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40811,7 +40960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40825,7 +40974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40834,7 +40983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40848,7 +40997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40857,7 +41006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40871,7 +41020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40880,7 +41029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40894,7 +41043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40903,7 +41052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40917,7 +41066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40926,7 +41075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40940,7 +41089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40949,7 +41098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40963,7 +41112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40972,7 +41121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40986,7 +41135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -40995,7 +41144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41009,7 +41158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41018,7 +41167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41032,7 +41181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41041,7 +41190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41055,7 +41204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41064,7 +41213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41078,7 +41227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41087,7 +41236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41101,7 +41250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41110,7 +41259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41124,7 +41273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41133,7 +41282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41147,7 +41296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41156,7 +41305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41170,7 +41319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41179,7 +41328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41193,7 +41342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41202,7 +41351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41216,7 +41365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41225,7 +41374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41239,7 +41388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41248,7 +41397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41262,7 +41411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41271,7 +41420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41285,7 +41434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41294,7 +41443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41308,7 +41457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41317,7 +41466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41331,7 +41480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41340,7 +41489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41354,7 +41503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41363,7 +41512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41377,7 +41526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41386,7 +41535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41400,7 +41549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41409,7 +41558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41423,7 +41572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41432,7 +41581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41446,7 +41595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41455,7 +41604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41469,7 +41618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41478,7 +41627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41492,7 +41641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41501,7 +41650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41515,7 +41664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41524,7 +41673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41538,7 +41687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41547,7 +41696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41561,7 +41710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41570,7 +41719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41584,7 +41733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41593,7 +41742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41607,7 +41756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41616,7 +41765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41630,7 +41779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41639,7 +41788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41653,7 +41802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41662,7 +41811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41676,7 +41825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41685,7 +41834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41699,7 +41848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41708,7 +41857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41722,7 +41871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41731,7 +41880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41745,7 +41894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41754,7 +41903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41768,7 +41917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41777,7 +41926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41791,7 +41940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41800,7 +41949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41814,7 +41963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41823,7 +41972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41837,7 +41986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41846,7 +41995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41860,7 +42009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41869,7 +42018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41883,7 +42032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41892,7 +42041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41906,7 +42055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41915,7 +42064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 838,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41929,7 +42078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41938,7 +42087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 838,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41952,7 +42101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41961,7 +42110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 838,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41975,7 +42124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -41984,7 +42133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 843,
+        "line": 845,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41998,7 +42147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42007,7 +42156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 843,
+        "line": 845,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42021,7 +42170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42030,7 +42179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 843,
+        "line": 845,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42044,7 +42193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42053,7 +42202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 849,
+        "line": 851,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42067,7 +42216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42076,7 +42225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 849,
+        "line": 851,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42090,7 +42239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42099,7 +42248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 849,
+        "line": 851,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42113,7 +42262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42122,7 +42271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 849,
+        "line": 851,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42136,7 +42285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42145,7 +42294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 849,
+        "line": 851,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42159,7 +42308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42168,7 +42317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42182,7 +42331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42191,7 +42340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42205,7 +42354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42214,7 +42363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42228,7 +42377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42237,7 +42386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42251,7 +42400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42260,7 +42409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42274,7 +42423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42283,7 +42432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42297,7 +42446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42306,7 +42455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 879,
+        "line": 881,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42320,7 +42469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42329,7 +42478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 879,
+        "line": 881,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42343,7 +42492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42352,7 +42501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42366,7 +42515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42375,7 +42524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42389,7 +42538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42398,7 +42547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42412,7 +42561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42421,7 +42570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42435,7 +42584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42444,7 +42593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42458,7 +42607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42467,7 +42616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42481,7 +42630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42490,7 +42639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42504,7 +42653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42513,7 +42662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42527,7 +42676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42536,7 +42685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42550,7 +42699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42559,7 +42708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42573,7 +42722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42582,7 +42731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42596,7 +42745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42605,7 +42754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42619,7 +42768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42628,7 +42777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42642,7 +42791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42651,7 +42800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42665,7 +42814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42674,7 +42823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42688,7 +42837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42697,7 +42846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42711,7 +42860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42720,7 +42869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42734,7 +42883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42743,7 +42892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42757,7 +42906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42766,7 +42915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42780,7 +42929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42789,7 +42938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42803,7 +42952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42812,7 +42961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42826,7 +42975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42835,7 +42984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42849,7 +42998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42858,7 +43007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42872,7 +43021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42881,7 +43030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42895,7 +43044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42904,7 +43053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42918,7 +43067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42927,7 +43076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42941,7 +43090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42950,7 +43099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42964,7 +43113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42973,7 +43122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42987,7 +43136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -42996,7 +43145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43010,7 +43159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43019,7 +43168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43033,7 +43182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43042,7 +43191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43056,7 +43205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43065,7 +43214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43079,7 +43228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43088,7 +43237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43102,7 +43251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43111,7 +43260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43125,7 +43274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43134,7 +43283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 955,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43148,7 +43297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43157,7 +43306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 955,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43171,7 +43320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43180,7 +43329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 955,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43194,7 +43343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43203,7 +43352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 955,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43217,7 +43366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43226,7 +43375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 955,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43240,7 +43389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43249,7 +43398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 978,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43263,7 +43412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43272,7 +43421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 978,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43286,7 +43435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43295,7 +43444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 982,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43309,7 +43458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43318,7 +43467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 982,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43332,7 +43481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43341,7 +43490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43355,7 +43504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43364,7 +43513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43378,7 +43527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43387,7 +43536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43401,7 +43550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43410,7 +43559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43424,7 +43573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43433,7 +43582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43447,7 +43596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43456,7 +43605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43470,7 +43619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43479,7 +43628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43493,7 +43642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43502,7 +43651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43516,7 +43665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43525,7 +43674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43539,7 +43688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43548,7 +43697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43562,7 +43711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43571,7 +43720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43585,7 +43734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43594,7 +43743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43608,7 +43757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43617,7 +43766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43631,7 +43780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43640,7 +43789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43654,7 +43803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43663,7 +43812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43677,7 +43826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43686,7 +43835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43700,7 +43849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43709,7 +43858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43723,7 +43872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43732,7 +43881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43746,7 +43895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43755,7 +43904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43769,7 +43918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43778,7 +43927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43792,7 +43941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43801,7 +43950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43815,7 +43964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43824,7 +43973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43838,7 +43987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43847,7 +43996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43861,7 +44010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43870,7 +44019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43884,7 +44033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43893,7 +44042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43907,7 +44056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43916,7 +44065,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43930,7 +44079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43939,7 +44088,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43953,7 +44102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43962,7 +44111,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1021,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43976,7 +44125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -43985,7 +44134,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43999,7 +44148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44008,7 +44157,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44022,7 +44171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44031,7 +44180,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44045,7 +44194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44054,7 +44203,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1027,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44068,7 +44217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44077,7 +44226,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1027,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44091,7 +44240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44100,7 +44249,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44114,7 +44263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44123,7 +44272,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44137,7 +44286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44146,7 +44295,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44160,7 +44309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44169,7 +44318,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44183,7 +44332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44192,7 +44341,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44206,7 +44355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44215,7 +44364,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44229,7 +44378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44238,7 +44387,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44252,7 +44401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44261,7 +44410,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44275,7 +44424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44284,7 +44433,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44298,7 +44447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44307,7 +44456,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44321,7 +44470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44330,7 +44479,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44344,7 +44493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44353,7 +44502,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44367,7 +44516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44376,7 +44525,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44390,7 +44539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44399,7 +44548,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44413,7 +44562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44422,7 +44571,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44436,7 +44585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44445,7 +44594,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44459,7 +44608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44468,7 +44617,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44482,7 +44631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44491,7 +44640,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44505,7 +44654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 529,
+            "handler_line": 530,
             "kind": "try",
             "line": 11
           }
@@ -44514,7 +44663,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48153,6 +48302,17 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/workflow.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
         "line": 2,
         "optional": false,
         "role": "ordinary",
@@ -48242,14 +48402,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1762
+            "line": 1764
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1763,
+        "line": 1765,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -48261,14 +48421,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1799
+            "line": 1801
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1800,
+        "line": 1802,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -48280,14 +48440,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1807
+            "line": 1809
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1808,
+        "line": 1810,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49662,14 +49822,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1762
+            "line": 1764
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1763,
+        "line": 1765,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49681,14 +49841,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1799
+            "line": 1801
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1800,
+        "line": 1802,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49700,14 +49860,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1807
+            "line": 1809
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1808,
+        "line": 1810,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49885,6 +50045,7 @@
       "easyuse_anima/prompt/fields.py",
       "easyuse_anima/prompt/regional.py",
       "easyuse_anima/registration.py",
+      "easyuse_anima/workflow.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
@@ -49967,6 +50128,7 @@
       "easyuse_anima/prompt/fields.py",
       "easyuse_anima/prompt/regional.py",
       "easyuse_anima/registration.py",
+      "easyuse_anima/workflow.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
@@ -51153,7 +51315,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1048,
+        "line": 1050,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51162,7 +51324,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1713,
+        "line": 1715,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51171,7 +51333,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2607,
+        "line": 2566,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51180,7 +51342,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2610,
+        "line": 2569,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51189,7 +51351,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2613,
+        "line": 2572,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51198,7 +51360,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2616,
+        "line": 2575,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51207,7 +51369,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2619,
+        "line": 2578,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51216,7 +51378,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2622,
+        "line": 2581,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51225,7 +51387,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2625,
+        "line": 2584,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51234,7 +51396,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2628,
+        "line": 2587,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51243,7 +51405,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2631,
+        "line": 2590,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51252,7 +51414,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2634,
+        "line": 2593,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51261,7 +51423,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2637,
+        "line": 2596,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51270,7 +51432,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2640,
+        "line": 2599,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51279,7 +51441,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2643,
+        "line": 2602,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51288,7 +51450,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2646,
+        "line": 2605,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51297,7 +51459,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2650,
+        "line": 2609,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51306,7 +51468,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2653,
+        "line": 2612,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51315,7 +51477,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2657,
+        "line": 2616,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51324,7 +51486,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2660,
+        "line": 2619,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51333,7 +51495,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2664,
+        "line": 2623,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51342,7 +51504,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2667,
+        "line": 2626,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51351,7 +51513,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2670,
+        "line": 2629,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51360,7 +51522,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2673,
+        "line": 2632,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51369,7 +51531,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2676,
+        "line": 2635,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51378,7 +51540,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2679,
+        "line": 2638,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51387,7 +51549,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2686,
+        "line": 2645,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51396,7 +51558,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2692,
+        "line": 2651,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51405,7 +51567,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2697,
+        "line": 2656,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51414,7 +51576,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2701,
+        "line": 2660,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51916,25 +52078,25 @@
       },
       {
         "kind": "dict",
-        "line": 1118,
+        "line": 1120,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1107,
+        "line": 1109,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1102,
+        "line": 1104,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "set",
-        "line": 1712,
+        "line": 1714,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "f2a2ec0198119caa9680ca86a8c5d4d068ab4ba8",
+    "base_commit": "ebeee894e537c0edb4c7ec7aed34cefd212151f4",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -30,7 +30,8 @@
       "B-10b20",
       "B-11a",
       "B-11b",
-      "B-11c1"
+      "B-11c1",
+      "B-11c2"
     ]
   },
   "enums": {
@@ -65,11 +66,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 261,
+    "nodes_canonical_bindings": 262,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 41,
+    "root_residual_functions": 40,
     "root_residual_classes": 0,
     "root_residual_globals": 32,
     "runtime_binders": 28,
@@ -3625,6 +3626,38 @@
       "lifecycle_state": "transitional"
     },
     {
+      "id": "nodes_canonical_bindings:easyuse_anima.workflow:transitional_private_seam",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_get_workflow_node": "_get_workflow_node"
+      },
+      "classification": "transitional_private_seam",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.workflow",
+      "target_state": "canonical",
+      "identity_requirement": "required",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.workflow",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
+        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
+      ],
+      "evidence": [
+        "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
+        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
+      ],
+      "removal_gates": [
+        "canonical production consumer migration",
+        "focused monkeypatch and identity contract review",
+        "separate B-10b or B-11 rollback unit"
+      ],
+      "lifecycle_state": "transitional"
+    },
+    {
       "id": "nodes_legacy_bindings:anima_prompt.parser:transitional_private_seam",
       "surface": "nodes_legacy_bindings",
       "symbols": {
@@ -3893,7 +3926,6 @@
         "_find_comfy_node_class": "_find_comfy_node_class",
         "_find_comfy_node_mapping_class": "_find_comfy_node_mapping_class",
         "_find_loaded_node_class": "_find_loaded_node_class",
-        "_get_workflow_node": "_get_workflow_node",
         "_image_tensor_size": "_image_tensor_size",
         "_is_aio_detailer_target_name": "_is_aio_detailer_target_name",
         "_new_aio_random_seed": "_new_aio_random_seed",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -18,6 +18,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 import nodes
+from easyuse_anima import workflow
 from easyuse_anima.common import serialization as common_serialization
 from easyuse_anima.common import values as common_values
 from easyuse_anima.image import detailer as image_detailer
@@ -945,6 +946,64 @@ class WildcardNaiaMoveContractTests(unittest.TestCase):
                 package_naia_nodes.EasyUseAnimaNAIARandomPrompt,
             )
             self.assertFalse(hasattr(package_nodes, "WILDCARD_SEED_RANGE_NOTE"))
+
+
+class WorkflowLookupMoveContractTests(unittest.TestCase):
+    def test_canonical_workflow_lookup_preserves_top_level_and_subgraph_behavior(self):
+        inner_node = {"id": 7, "title": "inner"}
+        extra_pnginfo = {
+            "workflow": {
+                "nodes": [{"id": 3, "type": "nested-graph", "title": "outer"}],
+                "definitions": {
+                    "subgraphs": [
+                        {"id": "nested-graph", "nodes": [inner_node]},
+                    ],
+                },
+            },
+        }
+        original = json.loads(json.dumps(extra_pnginfo))
+
+        self.assertEqual(
+            workflow._get_workflow_node(extra_pnginfo, "3")["title"],
+            "outer",
+        )
+        self.assertIs(
+            workflow._get_workflow_node([extra_pnginfo], "3:7"),
+            inner_node,
+        )
+        self.assertIsNone(workflow._get_workflow_node(extra_pnginfo, "missing"))
+        self.assertIsNone(workflow._get_workflow_node(None, "3"))
+        self.assertEqual(extra_pnginfo, original)
+
+    def test_flat_and_package_roots_reexport_the_canonical_workflow_lookup(self):
+        self.assertIs(nodes._get_workflow_node, workflow._get_workflow_node)
+
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_workflow = sys.modules[f"{package_name}.easyuse_anima.workflow"]
+            self.assertIs(
+                package_nodes._get_workflow_node,
+                package_workflow._get_workflow_node,
+            )
+
+    def test_existing_binders_keep_the_call_time_root_patch_seam(self):
+        patched_result = object()
+        with patch.object(
+            nodes,
+            "_get_workflow_node",
+            return_value=patched_result,
+        ):
+            for adapter in (
+                wildcard_nodes,
+                naia_nodes,
+                prompt_advanced_nodes,
+                regional_nodes,
+            ):
+                with self.subTest(adapter=adapter.__name__):
+                    self.assertIs(
+                        adapter._get_workflow_node(None, "3"),
+                        patched_result,
+                    )
 
 
 class InputTypeMoveContractTests(unittest.TestCase):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "c4bda09b51453509e63f8ffe9676c88c3ae05184")
-        # Issue #184 B-11c1 moves the final root-owned input type classes while
-        # preserving direct aliases and binder identity.
-        self.assertEqual(report["top_level"]["function_count"], 41)
+        self.assertEqual(report["git_blob_sha1"], "50ee288154fdaf73816e2884d7fe1d41e4fc20dc")
+        # Issue #184 B-11c2 moves the read-only workflow lookup while
+        # preserving the root alias and existing binder/resolver seams.
+        self.assertEqual(report["top_level"]["function_count"], 40)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_705)
+        self.assertEqual(report["line_count"], 2_664)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 80)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 80)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 80)
+        self.assertEqual(report["inventory"]["module_count"], 81)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 81)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 81)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
         self.assertTrue(

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "f2a2ec0198119caa9680ca86a8c5d4d068ab4ba8"
+BASE_COMMIT = "ebeee894e537c0edb4c7ec7aed34cefd212151f4"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1304,6 +1304,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11a",
                 "B-11b",
                 "B-11c1",
+                "B-11c2",
             ],
         },
         "enums": {
@@ -1316,11 +1317,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 261,
+            "nodes_canonical_bindings": 262,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 41,
+            "root_residual_functions": 40,
             "root_residual_classes": 0,
             "root_residual_globals": 32,
             "runtime_binders": 28,

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -11,6 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_MODULES = (
     "easyuse_anima",
     "easyuse_anima.bootstrap",
+    "easyuse_anima.workflow",
     "easyuse_anima.aio",
     "easyuse_anima.aio.conditioning",
     "easyuse_anima.aio.first_pass_cache",

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -33,6 +33,7 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/aio/resources.py",
     "easyuse_anima/aio/sampling.py",
     "easyuse_anima/bootstrap.py",
+    "easyuse_anima/workflow.py",
     "easyuse_anima/common/__init__.py",
     "easyuse_anima/common/serialization.py",
     "easyuse_anima/common/values.py",


### PR DESCRIPTION
## 변경 전 inventory

- 기준: `dev` / `ebeee894e537c0edb4c7ec7aed34cefd212151f4`
- 유형: Move-only (`B-11c2 workflow lookup residual`)
- 선택 근거:
  - B-11c1 뒤 root `nodes.py`에는 41 functions, 0 classes, 32 globals, 28 runtime binders가 남아 있음.
  - `_get_workflow_node`는 module global/mutable state가 없는 단일 읽기 함수이며 canonical 의존성은 `_single_value` 하나뿐임.
  - `_consume_reserved_wildcard_next_seed`는 JSON 검증, prompt token 삭제, wildcard mode/seed 상수까지 소유하므로 별도 residual-owner Move로 보류함.
- symbol/caller:
  - `_get_workflow_node(extra_pnginfo, node_id)`는 `workflow.nodes`와 `definitions.subgraphs`를 colon-separated node id 순서로 읽고, 일치 node 또는 `None`을 반환함.
  - Wildcard와 NAIA adapter는 explicit binder lambda로 호출함.
  - Prompt Advanced와 Regional adapter는 existing string runtime resolver로 호출함.
  - canonical 실행 caller는 Wildcard 1곳, NAIA 1곳, Prompt Advanced 2곳, Regional 1곳임.
- alias/compatibility:
  - root `_get_workflow_node`는 새 canonical object의 relative/flat direct identity alias로 유지함.
  - 네 adapter 파일, binder signature/call order/lambda, resolver/monkeypatch seam은 변경하지 않음.
  - private transitional seam이며 `nodes.__all__` 또는 공개 API로 승격하지 않음.
- global state:
  - 입력 workflow mapping을 읽기만 하며 module global, cache, lock, file/network I/O, mutation을 소유하지 않음.

## 허용 경계

- production: new `easyuse_anima/workflow.py`, root `nodes.py`
- focused contracts: top-level/subgraph/not-found behavior, flat/package root direct identity
- package/analyzer contracts: package skeleton, Registry scanner closure, backend/nodes analyzer baseline, compatibility surface test/fixture
- status docs: backend execution roadmap, compatibility shim registry

## 금지 경계

- `_consume_reserved_wildcard_next_seed`, `WILDCARD_RESERVED_NEXT_SEED_INPUT`, `WILDCARD_QUEUE_MAX_SAFE_SEED`
- Wildcard/NAIA/Prompt Advanced/Regional adapter 또는 binder/resolver 변경
- workflow schema, traversal order, input mutation, node/socket/workflow payload behavior
- root `nodes.py`의 다른 residual function/global/alias 제거
- B-11c final shim cutover, Phase D root consolidation, Phase E RuntimeServices

## 변경 요약

- 기존 함수 본문을 side-effect-free `easyuse_anima.workflow` owner로 그대로 이동함.
- 새 owner는 `easyuse_anima.common.values._single_value`를 직접 사용함.
- root `nodes.py` relative/flat branch가 canonical function을 explicit alias로 re-export하고 기존 binder 호출은 그대로 둠.
- analyzer/compatibility fixture는 실제 module/alias target만 반영함.

## 주요 파일

- `easyuse_anima/workflow.py`: `_get_workflow_node` canonical owner
- `nodes.py`: relative/flat direct identity alias와 기존 runtime binding 유지
- `tests/test_node_contracts.py`: lookup parity, alias identity, 네 adapter의 call-time root patch seam
- `tests/test_python_compatibility_surface.py` 및 analyzer fixtures: 실제 root residual/module 상태 반영
- `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`: B-11c2 상태와 잔여 범위 기록

## 검증 결과

- focused `unittest`: 67 tests passed
  - lookup parity, root/canonical flat·package identity
  - affected public node contracts
  - package skeleton, Registry scanner, backend/nodes analyzer, compatibility surface, import boundary
- call-time root patch seam focused `unittest`: 3 tests passed
  - Wildcard, NAIA, Prompt Advanced, Regional adapter 경로 확인
- 독립 diff review: actionable finding 없음
- 정확한 PR head `c05e3c8e25c67037fa91566f88a69934c59144ed` 공식 `Profile full`: passed
  - Python `unittest`: 888 passed
  - frontend: 114 JavaScript files, TypeScript 6.0.3
  - Pyright: 64 files, 기존 60 errors / 0 warnings
  - import boundary: 6 groups / 0 violations
  - Ruff report-only: 기존 105 findings, 증가 없음
  - `git diff --check`: passed
- ComfyUI Codex test runner: repository-owned static/unit/full validation
- Live ComfyUI/browser smoke: not run (Phase B exit checkpoint 대상)

## 남은 위험 / 미확인

- 이 PR은 함수 한 개의 owner만 이동하므로 B-11c와 Phase B를 완료하지 않음.
- reserved wildcard seed consumption, AiO values/normalization, Comfy boundary/postprocess와 28 binders는 후속 rollback unit으로 남음.
- 저장소 외부 코드가 문서화되지 않은 private `nodes._single_value` monkeypatch로 lookup 동작을 바꾸는 경우에는 새 canonical owner에 반영되지 않음. 저장소 내부 consumer 증거는 없고, 공개 API나 adapter patch seam은 유지됨.
- live ComfyUI/browser 및 package/pack exit 검증은 Phase B exit checkpoint에 남김.
- 병합 후 예상 root residual: 40 functions, 0 classes, 32 globals, 28 runtime binders.
