### PR TITLE
refactor(backend): move AiO image size residual (B-11c3)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `20c8b4d57243cc4b2c0423f43c9f0a2069707187`
+- Integrated `dev` snapshot commit: `47fef1deebc32644d19caa22add5fee0aa94edbe`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11a; B-11b guarded bootstrap Move in PR #293 | Integrate B-11b, then complete the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c2; B-11c3 image-size Move in PR #296 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,712
-  lines after B-09b2.
-- The mechanical extraction has removed 9,951
-  lines, approximately 78.6% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,664
+  lines after B-11c2.
+- The mechanical extraction has removed 9,999
+  lines, approximately 79.0% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -56,8 +56,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   owner in PR #292. B-11b moved route-table registration and wildcard startup
   to guarded `easyuse_anima.bootstrap` ownership in PR #293 / `f2a2ec0`.
   B-11c is split into residual-owner Moves before the final `nodes.py` shim;
-  B-11c1 moved shared private input types in PR #294 / `ebeee89`, and B-11c2
-  moves the read-only workflow lookup owner in PR #295.
+  B-11c1 moved shared private input types in PR #294 / `ebeee89`, B-11c2 moved
+  the read-only workflow lookup owner in PR #295 / `47fef1d`, and B-11c3 moves
+  only the dependency-free image tensor size helper in PR #296.
 
 ### Current quality baseline
 
@@ -299,7 +300,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 workflow lookup PR #295 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 image-size PR #296 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -800,6 +801,10 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     `easyuse_anima.workflow`. PR #295 retains the root direct alias and the
     existing Wildcard, NAIA, Prompt Advanced, and Regional binder/resolver
     calls. Reserved wildcard seed consumption remains separate.
+  - B-11c3 moves only `_image_tensor_size` to the existing side-effect-free
+    `easyuse_anima.image.geometry` owner. PR #296 retains the root direct alias,
+    all root stage callers, and the existing AiO preview/legacy-generation
+    runtime resolvers; resize and postprocess execution remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `ebeee894e537c0edb4c7ec7aed34cefd212151f4`
+  `47fef1deebc32644d19caa22add5fee0aa94edbe`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c1 are integrated through PR #294. B-11c is
+- Current state: B-11a through B-11c2 are integrated through PR #295. B-11c is
   split into residual-owner and binder Moves before the final root shim;
-  B-11c2 workflow lookup ownership is tracked by PR #295.
+  B-11c3 image tensor size ownership is tracked by PR #296.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,8 +75,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 262 after
-  B-11c2 (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 263 after
+  B-11c3 (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -84,8 +84,8 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 40 functions, 0 classes, and 32 assigned
-  globals after B-11c2 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 39 functions, 0 classes, and 32 assigned
+  globals after B-11c3 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 256, including
   literal lookups and binder-owned helper-name/default collections;
@@ -176,6 +176,19 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - Reserved wildcard next-seed consumption remains root-owned because moving it
   before D-12 would require a new dependency contract, canonical-to-legacy
   import, or duplicated seed behavior.
+
+### B-11c3 image tensor size alias
+
+- Canonical owner: `easyuse_anima.image.geometry._image_tensor_size`.
+- The private root name remains a transitional direct alias. Root AiO resize,
+  tile, fit, postprocess, and upscale callers continue to resolve the same root
+  binding, while the existing legacy-generation and preview resolvers preserve
+  call-time monkeypatch behavior.
+- The owner reads BHWC shape width/height and falls back to the supplied integer
+  dimensions on the same broad exception boundary. It has no module state,
+  mutation, Comfy provider, cache, or I/O dependency.
+- `_resize_image_to_size_if_needed` and all stage/postprocess execution remain
+  root-owned so this PR does not alter their internal patch seams or behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/image/geometry.py
+++ b/easyuse_anima/image/geometry.py
@@ -38,6 +38,13 @@ def _align_down(value: int, alignment: int) -> int:
     return max(1, (value // alignment) * alignment)
 
 
+def _image_tensor_size(image, fallback_width: int, fallback_height: int) -> tuple[int, int]:
+    try:
+        return int(image.shape[2]), int(image.shape[1])
+    except Exception:
+        return int(fallback_width), int(fallback_height)
+
+
 def _aligned_size_near_scale(
     source_width: int,
     source_height: int,

--- a/nodes.py
+++ b/nodes.py
@@ -339,6 +339,7 @@ try:
     from .easyuse_anima.image.geometry import (
         _align_down as _align_down,
         _align_nearest as _align_nearest,
+        _image_tensor_size as _image_tensor_size,
         # B-10b5 retires three root image-geometry aliases.
         # Canonical image/scaling/detailer consumers import geometry directly.
         # _align_nearest/_align_down stay for root residual runtime.
@@ -858,6 +859,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.image.geometry import (
         _align_down as _align_down,
         _align_nearest as _align_nearest,
+        _image_tensor_size as _image_tensor_size,
         # B-10b5 retires three root image-geometry aliases.
         # Canonical image/scaling/detailer consumers import geometry directly.
         # _align_nearest/_align_down stay for root residual runtime.
@@ -1851,13 +1853,6 @@ def _aio_lora_stack_signature(lora_stack) -> list[dict[str, Any]]:
         }
         for name, model_strength, clip_strength in _normalize_aio_lora_stack(lora_stack)
     ]
-
-
-def _image_tensor_size(image, fallback_width: int, fallback_height: int) -> tuple[int, int]:
-    try:
-        return int(image.shape[2]), int(image.shape[1])
-    except Exception:
-        return int(fallback_width), int(fallback_height)
 
 
 def _resize_image_to_size_if_needed(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -20053,6 +20053,37 @@
         "target": "easyuse_anima/image/geometry.py"
       },
       {
+        "alias": "_image_tensor_size",
+        "bound_name": "_image_tensor_size",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_image_tensor_size",
+          "target": "easyuse_anima/image/geometry.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
+        "kind": "static_from",
+        "line": 339,
+        "name": "_image_tensor_size",
+        "optional": false,
+        "requested": ".easyuse_anima.image.geometry",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/image/geometry.py"
+      },
+      {
         "alias": "_bind_sam3_runtime",
         "bound_name": "_bind_sam3_runtime",
         "branch_context": [
@@ -20074,7 +20105,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 349,
+        "line": 350,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20105,7 +20136,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 349,
+        "line": 350,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20136,7 +20167,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 349,
+        "line": 350,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20167,7 +20198,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 349,
+        "line": 350,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20198,7 +20229,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20229,7 +20260,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20260,7 +20291,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 370,
+        "line": 371,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20291,7 +20322,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 370,
+        "line": 371,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20322,7 +20353,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 370,
+        "line": 371,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20353,7 +20384,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 370,
+        "line": 371,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20384,7 +20415,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 370,
+        "line": 371,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20415,7 +20446,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 370,
+        "line": 371,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20446,7 +20477,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 370,
+        "line": 371,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20477,7 +20508,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 370,
+        "line": 371,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20508,7 +20539,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 381,
+        "line": 382,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20539,7 +20570,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 381,
+        "line": 382,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20570,7 +20601,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 381,
+        "line": 382,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20601,7 +20632,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 381,
+        "line": 382,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20632,7 +20663,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 387,
+        "line": 388,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20663,7 +20694,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 387,
+        "line": 388,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20694,7 +20725,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 387,
+        "line": 388,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20725,7 +20756,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 387,
+        "line": 388,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20756,7 +20787,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 387,
+        "line": 388,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20787,7 +20818,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 395,
+        "line": 396,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20818,7 +20849,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 395,
+        "line": 396,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20849,7 +20880,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 399,
+        "line": 400,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -20880,7 +20911,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 403,
+        "line": 404,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -20911,7 +20942,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 403,
+        "line": 404,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -20942,7 +20973,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 403,
+        "line": 404,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -20973,7 +21004,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21004,7 +21035,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21035,7 +21066,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21066,7 +21097,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21097,7 +21128,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21128,7 +21159,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 415,
+        "line": 416,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21159,7 +21190,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 415,
+        "line": 416,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21190,7 +21221,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 415,
+        "line": 416,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21221,7 +21252,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21252,7 +21283,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21283,7 +21314,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21314,7 +21345,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21345,7 +21376,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21376,7 +21407,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21407,7 +21438,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21438,7 +21469,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21469,7 +21500,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 461,
+        "line": 462,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21500,7 +21531,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 461,
+        "line": 462,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21531,7 +21562,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 465,
+        "line": 466,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21562,7 +21593,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 465,
+        "line": 466,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21593,7 +21624,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21624,7 +21655,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21655,7 +21686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21686,7 +21717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21717,7 +21748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21748,7 +21779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21779,7 +21810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21810,7 +21841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21841,7 +21872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21872,7 +21903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21903,7 +21934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21934,7 +21965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21965,7 +21996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21996,7 +22027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22027,7 +22058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22058,7 +22089,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 487,
+        "line": 488,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22089,7 +22120,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 487,
+        "line": 488,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22120,7 +22151,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 487,
+        "line": 488,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22151,7 +22182,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 487,
+        "line": 488,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22182,7 +22213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 487,
+        "line": 488,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22213,7 +22244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 487,
+        "line": 488,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22244,7 +22275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 487,
+        "line": 488,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22275,7 +22306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 487,
+        "line": 488,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22306,7 +22337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 497,
+        "line": 498,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22337,7 +22368,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 497,
+        "line": 498,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22368,7 +22399,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22399,7 +22430,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22430,7 +22461,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -22461,7 +22492,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -22492,7 +22523,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -22523,7 +22554,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -22554,7 +22585,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22585,7 +22616,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22616,7 +22647,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22647,7 +22678,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22678,7 +22709,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22709,7 +22740,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22740,7 +22771,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22771,7 +22802,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22802,7 +22833,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22833,7 +22864,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22864,7 +22895,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22895,7 +22926,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22926,7 +22957,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22957,7 +22988,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22988,7 +23019,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23019,7 +23050,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23050,7 +23081,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23081,7 +23112,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23112,7 +23143,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23143,7 +23174,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23174,7 +23205,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23193,7 +23224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23208,7 +23239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23227,7 +23258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23242,7 +23273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23261,7 +23292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23276,7 +23307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23295,7 +23326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23329,7 +23360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23344,7 +23375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23363,7 +23394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23378,7 +23409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23397,7 +23428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23412,7 +23443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23431,7 +23462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23446,7 +23477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23465,7 +23496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23480,7 +23511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23499,7 +23530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23514,7 +23545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23533,7 +23564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23548,7 +23579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23567,7 +23598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23582,7 +23613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23601,7 +23632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23616,7 +23647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23635,7 +23666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23650,7 +23681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 551,
+        "line": 552,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -23669,7 +23700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23684,7 +23715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 554,
+        "line": 555,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23703,7 +23734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23718,7 +23749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 554,
+        "line": 555,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23737,7 +23768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23752,7 +23783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 554,
+        "line": 555,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23771,7 +23802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23786,7 +23817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 554,
+        "line": 555,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23805,7 +23836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23820,7 +23851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23839,7 +23870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23854,7 +23885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23873,7 +23904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23888,7 +23919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23907,7 +23938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23922,7 +23953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23941,7 +23972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23956,7 +23987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23975,7 +24006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -23990,7 +24021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24009,7 +24040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24024,7 +24055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24043,7 +24074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24058,7 +24089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24077,7 +24108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24092,7 +24123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24111,7 +24142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24126,7 +24157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24145,7 +24176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24160,7 +24191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24179,7 +24210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24194,7 +24225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24213,7 +24244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24228,7 +24259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24247,7 +24278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24262,7 +24293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24281,7 +24312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24296,7 +24327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24315,7 +24346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24330,7 +24361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24349,7 +24380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24364,7 +24395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24383,7 +24414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24398,7 +24429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24417,7 +24448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24432,7 +24463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24451,7 +24482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24466,7 +24497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24485,7 +24516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24500,7 +24531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24519,7 +24550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24534,7 +24565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24553,7 +24584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24568,7 +24599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24587,7 +24618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24602,7 +24633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24621,7 +24652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24636,7 +24667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24655,7 +24686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24670,7 +24701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24689,7 +24720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24704,7 +24735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24723,7 +24754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24738,7 +24769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24757,7 +24788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24772,7 +24803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24791,7 +24822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24806,7 +24837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24825,7 +24856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24840,7 +24871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24859,7 +24890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24874,7 +24905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24893,7 +24924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24908,7 +24939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24927,7 +24958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24942,7 +24973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24961,7 +24992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -24976,7 +25007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24995,7 +25026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25010,7 +25041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25029,7 +25060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25044,7 +25075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25063,7 +25094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25078,7 +25109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25097,7 +25128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25112,7 +25143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25131,7 +25162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25146,7 +25177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25165,7 +25196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25180,7 +25211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25199,7 +25230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25214,7 +25245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25233,7 +25264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25248,7 +25279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25267,7 +25298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25282,7 +25313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25301,7 +25332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25316,7 +25347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25335,7 +25366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25350,7 +25381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25369,7 +25400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25384,7 +25415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25403,7 +25434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25418,7 +25449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25437,7 +25468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25452,7 +25483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25471,7 +25502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25486,7 +25517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25505,7 +25536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25520,7 +25551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25539,7 +25570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25554,7 +25585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25573,7 +25604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25588,7 +25619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25607,7 +25638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25622,7 +25653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 623,
+        "line": 624,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25641,7 +25672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25656,7 +25687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 623,
+        "line": 624,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25675,7 +25706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25690,7 +25721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 623,
+        "line": 624,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25709,7 +25740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25724,7 +25755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25743,7 +25774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25758,7 +25789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25777,7 +25808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25792,7 +25823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25811,7 +25842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25826,7 +25857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25845,7 +25876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25860,7 +25891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25879,7 +25910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25894,7 +25925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 635,
+        "line": 636,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -25913,7 +25944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25928,7 +25959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 636,
+        "line": 637,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -25947,7 +25978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25962,7 +25993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 636,
+        "line": 637,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -25981,7 +26012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -25996,7 +26027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 636,
+        "line": 637,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26015,7 +26046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26030,7 +26061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 636,
+        "line": 637,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26049,7 +26080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26064,7 +26095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26083,7 +26114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26098,7 +26129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26117,7 +26148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26132,7 +26163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26151,7 +26182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26166,7 +26197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26185,7 +26216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26200,7 +26231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26219,7 +26250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26234,7 +26265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26253,7 +26284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26268,7 +26299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26287,7 +26318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26302,7 +26333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26321,7 +26352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26336,7 +26367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26355,7 +26386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26370,7 +26401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26389,7 +26420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26404,7 +26435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26423,7 +26454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26438,7 +26469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26457,7 +26488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26472,7 +26503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26491,7 +26522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26506,7 +26537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26525,7 +26556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26540,7 +26571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26559,7 +26590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26574,7 +26605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26593,7 +26624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26608,7 +26639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26627,7 +26658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26642,7 +26673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26661,7 +26692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26676,7 +26707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26695,7 +26726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26710,7 +26741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26729,7 +26760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26744,7 +26775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26763,7 +26794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26778,7 +26809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26797,7 +26828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26812,7 +26843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26831,7 +26862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26846,7 +26877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26865,7 +26896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26880,7 +26911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26899,7 +26930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26914,7 +26945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26933,7 +26964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26948,7 +26979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26967,7 +26998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -26982,7 +27013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27001,7 +27032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27016,7 +27047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27035,7 +27066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27050,7 +27081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27069,7 +27100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27084,7 +27115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27103,7 +27134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27118,7 +27149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27137,7 +27168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27152,7 +27183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27171,7 +27202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27186,7 +27217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27205,7 +27236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27220,7 +27251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27239,7 +27270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27254,7 +27285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27273,7 +27304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27288,7 +27319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27307,7 +27338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27322,7 +27353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27341,7 +27372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27356,7 +27387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27375,7 +27406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27390,7 +27421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27409,7 +27440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27424,7 +27455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27443,7 +27474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27458,7 +27489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27477,7 +27508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27492,7 +27523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27511,7 +27542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27526,7 +27557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27545,7 +27576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27560,7 +27591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27579,7 +27610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27594,7 +27625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27613,7 +27644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27628,7 +27659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27647,7 +27678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27662,7 +27693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27681,7 +27712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27696,7 +27727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27715,7 +27746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27730,7 +27761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27749,7 +27780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27764,7 +27795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27783,7 +27814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27798,7 +27829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27817,7 +27848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27832,7 +27863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27851,7 +27882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27866,7 +27897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27885,7 +27916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27900,7 +27931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27919,7 +27950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27934,7 +27965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27953,7 +27984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -27968,7 +27999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27987,7 +28018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28002,7 +28033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28021,7 +28052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28036,7 +28067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28055,7 +28086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28070,7 +28101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28089,7 +28120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28104,7 +28135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28123,7 +28154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28138,7 +28169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28157,7 +28188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28172,7 +28203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28191,7 +28222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28206,7 +28237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28225,7 +28256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28240,7 +28271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28259,7 +28290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28274,7 +28305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28293,7 +28324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28308,7 +28339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28327,7 +28358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28342,7 +28373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28361,7 +28392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28376,7 +28407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28395,7 +28426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28410,7 +28441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28429,7 +28460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28444,7 +28475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28463,7 +28494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28478,7 +28509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28497,7 +28528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28512,7 +28543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28531,7 +28562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28546,7 +28577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28565,7 +28596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28580,7 +28611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28599,7 +28630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28614,7 +28645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28633,7 +28664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28648,7 +28679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28667,7 +28698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28682,7 +28713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28701,7 +28732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28716,7 +28747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28735,7 +28766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28750,7 +28781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28769,7 +28800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28784,7 +28815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28803,7 +28834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28818,7 +28849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28837,7 +28868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28852,7 +28883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28871,7 +28902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28886,7 +28917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28905,7 +28936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28920,7 +28951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28939,7 +28970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28954,7 +28985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28973,7 +29004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -28988,7 +29019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29007,7 +29038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29022,7 +29053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 834,
+        "line": 835,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29041,7 +29072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29056,7 +29087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 834,
+        "line": 835,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29075,7 +29106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29090,7 +29121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 834,
+        "line": 835,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29109,7 +29140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29124,7 +29155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 834,
+        "line": 835,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29143,7 +29174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29158,7 +29189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 840,
+        "line": 841,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29177,7 +29208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29192,7 +29223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 840,
+        "line": 841,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29211,7 +29242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29226,7 +29257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 840,
+        "line": 841,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29245,7 +29276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29260,7 +29291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 845,
+        "line": 846,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29279,7 +29310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29294,7 +29325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 845,
+        "line": 846,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29313,7 +29344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29328,7 +29359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 845,
+        "line": 846,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29347,7 +29378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29362,7 +29393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 851,
+        "line": 852,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29381,7 +29412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29396,7 +29427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 851,
+        "line": 852,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29415,7 +29446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29430,7 +29461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 851,
+        "line": 852,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29449,7 +29480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29464,7 +29495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 851,
+        "line": 852,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29483,7 +29514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29498,7 +29529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 851,
+        "line": 852,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29517,7 +29548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29532,7 +29563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 858,
+        "line": 859,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29551,7 +29582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29566,8 +29597,42 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 858,
+        "line": 859,
         "name": "_align_nearest",
+        "optional": false,
+        "requested": "easyuse_anima.image.geometry",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "alias": "_image_tensor_size",
+        "bound_name": "_image_tensor_size",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 531,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_image_tensor_size",
+          "target": "easyuse_anima/image/geometry.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.image.geometry:_image_tensor_size",
+        "kind": "static_from",
+        "line": 859,
+        "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
         "role": "compatibility_fallback",
@@ -29585,7 +29650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29600,7 +29665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29619,7 +29684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29634,7 +29699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29653,7 +29718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29668,7 +29733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29687,7 +29752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29702,7 +29767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29721,7 +29786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29736,7 +29801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 881,
+        "line": 883,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -29755,7 +29820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29770,7 +29835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 881,
+        "line": 883,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -29789,7 +29854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29804,7 +29869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29823,7 +29888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29838,7 +29903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29857,7 +29922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29872,7 +29937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29891,7 +29956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29906,7 +29971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29925,7 +29990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29940,7 +30005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29959,7 +30024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -29974,7 +30039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29993,7 +30058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30008,7 +30073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30027,7 +30092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30042,7 +30107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30061,7 +30126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30076,7 +30141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30095,7 +30160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30110,7 +30175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30129,7 +30194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30144,7 +30209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30163,7 +30228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30178,7 +30243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30197,7 +30262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30212,7 +30277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30231,7 +30296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30246,7 +30311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30265,7 +30330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30280,7 +30345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30299,7 +30364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30314,7 +30379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30333,7 +30398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30348,7 +30413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30367,7 +30432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30382,7 +30447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30401,7 +30466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30416,7 +30481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30435,7 +30500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30450,7 +30515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -30469,7 +30534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30484,7 +30549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30503,7 +30568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30518,7 +30583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30537,7 +30602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30552,7 +30617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30571,7 +30636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30586,7 +30651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30605,7 +30670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30620,7 +30685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30639,7 +30704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30654,7 +30719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30673,7 +30738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30688,7 +30753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30707,7 +30772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30722,7 +30787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30741,7 +30806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30756,7 +30821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 934,
+        "line": 936,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30775,7 +30840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30790,7 +30855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 934,
+        "line": 936,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30809,7 +30874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30824,7 +30889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 934,
+        "line": 936,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30843,7 +30908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30858,7 +30923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -30877,7 +30942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30892,7 +30957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -30911,7 +30976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30926,7 +30991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -30945,7 +31010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30960,7 +31025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -30979,7 +31044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -30994,7 +31059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31013,7 +31078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31028,7 +31093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31047,7 +31112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31062,7 +31127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31081,7 +31146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31096,7 +31161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31115,7 +31180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31130,7 +31195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 980,
+        "line": 982,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31149,7 +31214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31164,7 +31229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 980,
+        "line": 982,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31183,7 +31248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31198,7 +31263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31217,7 +31282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31232,7 +31297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31251,7 +31316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31266,7 +31331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31285,7 +31350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31300,7 +31365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31319,7 +31384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31334,7 +31399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31353,7 +31418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31368,7 +31433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31387,7 +31452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31402,7 +31467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31421,7 +31486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31436,7 +31501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31455,7 +31520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31470,7 +31535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31489,7 +31554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31504,7 +31569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31523,7 +31588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31538,7 +31603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31557,7 +31622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31572,7 +31637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31591,7 +31656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31606,7 +31671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31625,7 +31690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31640,7 +31705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31659,7 +31724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31674,7 +31739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31693,7 +31758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31708,7 +31773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31727,7 +31792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31742,7 +31807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31761,7 +31826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31776,7 +31841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31795,7 +31860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31810,7 +31875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31829,7 +31894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31844,7 +31909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31863,7 +31928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31878,7 +31943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31897,7 +31962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31912,7 +31977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31931,7 +31996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31946,7 +32011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31965,7 +32030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -31980,7 +32045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31999,7 +32064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32014,7 +32079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32033,7 +32098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32048,7 +32113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32067,7 +32132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32082,7 +32147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32101,7 +32166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32116,7 +32181,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -32135,7 +32200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32150,7 +32215,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -32169,7 +32234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32184,7 +32249,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1023,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -32203,7 +32268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32218,7 +32283,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -32237,7 +32302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32252,7 +32317,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -32271,7 +32336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32286,7 +32351,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -32305,7 +32370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32320,7 +32385,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1029,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32339,7 +32404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32354,7 +32419,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1029,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32373,7 +32438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32388,7 +32453,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32407,7 +32472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32422,7 +32487,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32441,7 +32506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32456,7 +32521,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32475,7 +32540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32490,7 +32555,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32509,7 +32574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32524,7 +32589,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32543,7 +32608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32558,7 +32623,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32577,7 +32642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32592,7 +32657,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32611,7 +32676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32626,7 +32691,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32645,7 +32710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32660,7 +32725,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32679,7 +32744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32694,7 +32759,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32713,7 +32778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32728,7 +32793,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32747,7 +32812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32762,7 +32827,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32781,7 +32846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32796,7 +32861,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32815,7 +32880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32830,7 +32895,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32849,7 +32914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32864,7 +32929,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32883,7 +32948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32898,7 +32963,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32917,7 +32982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32932,7 +32997,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32951,7 +33016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -32966,7 +33031,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32985,7 +33050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -33000,7 +33065,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33018,7 +33083,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1764
+            "line": 1766
           }
         ],
         "classification": "external",
@@ -33026,7 +33091,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1765,
+        "line": 1767,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33043,7 +33108,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1801
+            "line": 1803
           }
         ],
         "classification": "external",
@@ -33051,7 +33116,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1802,
+        "line": 1804,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33068,7 +33133,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1809
+            "line": 1811
           }
         ],
         "classification": "external",
@@ -33076,7 +33141,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1810,
+        "line": 1812,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -36184,13 +36249,13 @@
       },
       {
         "is_package": false,
-        "loc": 90,
+        "loc": 97,
         "module": "easyuse_anima.image.geometry",
-        "normalized_git_blob_sha1": "0703690b136041b93bebebe27d90832014d50766",
+        "normalized_git_blob_sha1": "a754b98a8dce7dca3db29f66b9c62f4932f5f64e",
         "path": "easyuse_anima/image/geometry.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 5,
+          "function_count": 6,
           "global_count": 1
         }
       },
@@ -36664,13 +36729,13 @@
       },
       {
         "is_package": false,
-        "loc": 2664,
+        "loc": 2659,
         "module": "nodes",
-        "normalized_git_blob_sha1": "50ee288154fdaf73816e2884d7fe1d41e4fc20dc",
+        "normalized_git_blob_sha1": "0680a8e5e7c605c79a50dd2dde5b463c2694defc",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 40,
+          "function_count": 39,
           "global_count": 32
         }
       },
@@ -38030,7 +38095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38039,7 +38104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38053,7 +38118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38062,7 +38127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38076,7 +38141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38085,7 +38150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38099,7 +38164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38108,7 +38173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38122,7 +38187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38131,7 +38196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38145,7 +38210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38154,7 +38219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38168,7 +38233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38177,7 +38242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38191,7 +38256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38200,7 +38265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38214,7 +38279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38223,7 +38288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38237,7 +38302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38246,7 +38311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38260,7 +38325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38269,7 +38334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38283,7 +38348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38292,7 +38357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38306,7 +38371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38315,7 +38380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38329,7 +38394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38338,7 +38403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 551,
+        "line": 552,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38352,7 +38417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38361,7 +38426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 554,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38375,7 +38440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38384,7 +38449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 554,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38398,7 +38463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38407,7 +38472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 554,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38421,7 +38486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38430,7 +38495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 554,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38444,7 +38509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38453,7 +38518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38467,7 +38532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38476,7 +38541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38490,7 +38555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38499,7 +38564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38513,7 +38578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38522,7 +38587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38536,7 +38601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38545,7 +38610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38559,7 +38624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38568,7 +38633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38582,7 +38647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38591,7 +38656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38605,7 +38670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38614,7 +38679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38628,7 +38693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38637,7 +38702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38651,7 +38716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38660,7 +38725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38674,7 +38739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38683,7 +38748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38697,7 +38762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38706,7 +38771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38720,7 +38785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38729,7 +38794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38743,7 +38808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38752,7 +38817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38766,7 +38831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38775,7 +38840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38789,7 +38854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38798,7 +38863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38812,7 +38877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38821,7 +38886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38835,7 +38900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38844,7 +38909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38858,7 +38923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38867,7 +38932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38881,7 +38946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38890,7 +38955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38904,7 +38969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38913,7 +38978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38927,7 +38992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38936,7 +39001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38950,7 +39015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38959,7 +39024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38973,7 +39038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -38982,7 +39047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38996,7 +39061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39005,7 +39070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39019,7 +39084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39028,7 +39093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39042,7 +39107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39051,7 +39116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39065,7 +39130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39074,7 +39139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39088,7 +39153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39097,7 +39162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39111,7 +39176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39120,7 +39185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39134,7 +39199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39143,7 +39208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39157,7 +39222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39166,7 +39231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 586,
+        "line": 587,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39180,7 +39245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39189,7 +39254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39203,7 +39268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39212,7 +39277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39226,7 +39291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39235,7 +39300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39249,7 +39314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39258,7 +39323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39272,7 +39337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39281,7 +39346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39295,7 +39360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39304,7 +39369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39318,7 +39383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39327,7 +39392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39341,7 +39406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39350,7 +39415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39364,7 +39429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39373,7 +39438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39387,7 +39452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39396,7 +39461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39410,7 +39475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39419,7 +39484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39433,7 +39498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39442,7 +39507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39456,7 +39521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39465,7 +39530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39479,7 +39544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39488,7 +39553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39502,7 +39567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39511,7 +39576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39525,7 +39590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39534,7 +39599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39548,7 +39613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39557,7 +39622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39571,7 +39636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39580,7 +39645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39594,7 +39659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39603,7 +39668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39617,7 +39682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39626,7 +39691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39640,7 +39705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39649,7 +39714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39663,7 +39728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39672,7 +39737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 623,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39686,7 +39751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39695,7 +39760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 623,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39709,7 +39774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39718,7 +39783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 623,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39732,7 +39797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39741,7 +39806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39755,7 +39820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39764,7 +39829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39778,7 +39843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39787,7 +39852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39801,7 +39866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39810,7 +39875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39824,7 +39889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39833,7 +39898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39847,7 +39912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39856,7 +39921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 635,
+        "line": 636,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39870,7 +39935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39879,7 +39944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 636,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39893,7 +39958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39902,7 +39967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 636,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39916,7 +39981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39925,7 +39990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 636,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39939,7 +40004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39948,7 +40013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 636,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39962,7 +40027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39971,7 +40036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39985,7 +40050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -39994,7 +40059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40008,7 +40073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40017,7 +40082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40031,7 +40096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40040,7 +40105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40054,7 +40119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40063,7 +40128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40077,7 +40142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40086,7 +40151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40100,7 +40165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40109,7 +40174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40123,7 +40188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40132,7 +40197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40146,7 +40211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40155,7 +40220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40169,7 +40234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40178,7 +40243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40192,7 +40257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40201,7 +40266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40215,7 +40280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40224,7 +40289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40238,7 +40303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40247,7 +40312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40261,7 +40326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40270,7 +40335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40284,7 +40349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40293,7 +40358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40307,7 +40372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40316,7 +40381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40330,7 +40395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40339,7 +40404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40353,7 +40418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40362,7 +40427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40376,7 +40441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40385,7 +40450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40399,7 +40464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40408,7 +40473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40422,7 +40487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40431,7 +40496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40445,7 +40510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40454,7 +40519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40468,7 +40533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40477,7 +40542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40491,7 +40556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40500,7 +40565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40514,7 +40579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40523,7 +40588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40537,7 +40602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40546,7 +40611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40560,7 +40625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40569,7 +40634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40583,7 +40648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40592,7 +40657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40606,7 +40671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40615,7 +40680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40629,7 +40694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40638,7 +40703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40652,7 +40717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40661,7 +40726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40675,7 +40740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40684,7 +40749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40698,7 +40763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40707,7 +40772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40721,7 +40786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40730,7 +40795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40744,7 +40809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40753,7 +40818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40767,7 +40832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40776,7 +40841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40790,7 +40855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40799,7 +40864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40813,7 +40878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40822,7 +40887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40836,7 +40901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40845,7 +40910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 674,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40859,7 +40924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40868,7 +40933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40882,7 +40947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40891,7 +40956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40905,7 +40970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40914,7 +40979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40928,7 +40993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40937,7 +41002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40951,7 +41016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40960,7 +41025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40974,7 +41039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -40983,7 +41048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40997,7 +41062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41006,7 +41071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41020,7 +41085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41029,7 +41094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41043,7 +41108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41052,7 +41117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41066,7 +41131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41075,7 +41140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41089,7 +41154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41098,7 +41163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41112,7 +41177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41121,7 +41186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41135,7 +41200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41144,7 +41209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41158,7 +41223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41167,7 +41232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 710,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41181,7 +41246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41190,7 +41255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41204,7 +41269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41213,7 +41278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41227,7 +41292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41236,7 +41301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41250,7 +41315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41259,7 +41324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41273,7 +41338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41282,7 +41347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41296,7 +41361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41305,7 +41370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41319,7 +41384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41328,7 +41393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41342,7 +41407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41351,7 +41416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41365,7 +41430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41374,7 +41439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 738,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41388,7 +41453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41397,7 +41462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41411,7 +41476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41420,7 +41485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41434,7 +41499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41443,7 +41508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41457,7 +41522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41466,7 +41531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41480,7 +41545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41489,7 +41554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41503,7 +41568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41512,7 +41577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41526,7 +41591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41535,7 +41600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41549,7 +41614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41558,7 +41623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41572,7 +41637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41581,7 +41646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41595,7 +41660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41604,7 +41669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41618,7 +41683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41627,7 +41692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41641,7 +41706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41650,7 +41715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41664,7 +41729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41673,7 +41738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41687,7 +41752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41696,7 +41761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41710,7 +41775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41719,7 +41784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41733,7 +41798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41742,7 +41807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41756,7 +41821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41765,7 +41830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41779,7 +41844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41788,7 +41853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41802,7 +41867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41811,7 +41876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41825,7 +41890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41834,7 +41899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41848,7 +41913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41857,7 +41922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41871,7 +41936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41880,7 +41945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41894,7 +41959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41903,7 +41968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41917,7 +41982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41926,7 +41991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41940,7 +42005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41949,7 +42014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 754,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41963,7 +42028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41972,7 +42037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 834,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41986,7 +42051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -41995,7 +42060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 834,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42009,7 +42074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42018,7 +42083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 834,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42032,7 +42097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42041,7 +42106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 834,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42055,7 +42120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42064,7 +42129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 840,
+        "line": 841,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42078,7 +42143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42087,7 +42152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 840,
+        "line": 841,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42101,7 +42166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42110,7 +42175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 840,
+        "line": 841,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42124,7 +42189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42133,7 +42198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 845,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42147,7 +42212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42156,7 +42221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 845,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42170,7 +42235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42179,7 +42244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 845,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42193,7 +42258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42202,7 +42267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 851,
+        "line": 852,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42216,7 +42281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42225,7 +42290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 851,
+        "line": 852,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42239,7 +42304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42248,7 +42313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 851,
+        "line": 852,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42262,7 +42327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42271,7 +42336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 851,
+        "line": 852,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42285,7 +42350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42294,7 +42359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 851,
+        "line": 852,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42308,7 +42373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42317,7 +42382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 858,
+        "line": 859,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42331,7 +42396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42340,7 +42405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 858,
+        "line": 859,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42354,7 +42419,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.image.geometry:_image_tensor_size",
+        "kind": "static_from",
+        "line": 859,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42363,7 +42451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42377,7 +42465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42386,7 +42474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42400,7 +42488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42409,7 +42497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42423,7 +42511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42432,7 +42520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42446,7 +42534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42455,7 +42543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 881,
+        "line": 883,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42469,7 +42557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42478,7 +42566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 881,
+        "line": 883,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42492,7 +42580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42501,7 +42589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42515,7 +42603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42524,7 +42612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42538,7 +42626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42547,7 +42635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42561,7 +42649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42570,7 +42658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42584,7 +42672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42593,7 +42681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42607,7 +42695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42616,7 +42704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42630,7 +42718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42639,7 +42727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42653,7 +42741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42662,7 +42750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 889,
+        "line": 891,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42676,7 +42764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42685,7 +42773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42699,7 +42787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42708,7 +42796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42722,7 +42810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42731,7 +42819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42745,7 +42833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42754,7 +42842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42768,7 +42856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42777,7 +42865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42791,7 +42879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42800,7 +42888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42814,7 +42902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42823,7 +42911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42837,7 +42925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42846,7 +42934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42860,7 +42948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42869,7 +42957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42883,7 +42971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42892,7 +42980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42906,7 +42994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42915,7 +43003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42929,7 +43017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42938,7 +43026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42952,7 +43040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42961,7 +43049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42975,7 +43063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -42984,7 +43072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42998,7 +43086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43007,7 +43095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43021,7 +43109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43030,7 +43118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43044,7 +43132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43053,7 +43141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43067,7 +43155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43076,7 +43164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43090,7 +43178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43099,7 +43187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43113,7 +43201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43122,7 +43210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43136,7 +43224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43145,7 +43233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 934,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43159,7 +43247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43168,7 +43256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 934,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43182,7 +43270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43191,7 +43279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 934,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43205,7 +43293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43214,7 +43302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43228,7 +43316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43237,7 +43325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43251,7 +43339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43260,7 +43348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43274,7 +43362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43283,7 +43371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43297,7 +43385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43306,7 +43394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43320,7 +43408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43329,7 +43417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43343,7 +43431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43352,7 +43440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43366,7 +43454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43375,7 +43463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43389,7 +43477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43398,7 +43486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 980,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43412,7 +43500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43421,7 +43509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 980,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43435,7 +43523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43444,7 +43532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43458,7 +43546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43467,7 +43555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43481,7 +43569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43490,7 +43578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43504,7 +43592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43513,7 +43601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43527,7 +43615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43536,7 +43624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43550,7 +43638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43559,7 +43647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43573,7 +43661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43582,7 +43670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43596,7 +43684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43605,7 +43693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43619,7 +43707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43628,7 +43716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43642,7 +43730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43651,7 +43739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43665,7 +43753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43674,7 +43762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43688,7 +43776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43697,7 +43785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43711,7 +43799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43720,7 +43808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43734,7 +43822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43743,7 +43831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43757,7 +43845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43766,7 +43854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43780,7 +43868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43789,7 +43877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43803,7 +43891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43812,7 +43900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43826,7 +43914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43835,7 +43923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43849,7 +43937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43858,7 +43946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43872,7 +43960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43881,7 +43969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43895,7 +43983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43904,7 +43992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43918,7 +44006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43927,7 +44015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43941,7 +44029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43950,7 +44038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43964,7 +44052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43973,7 +44061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43987,7 +44075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -43996,7 +44084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44010,7 +44098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44019,7 +44107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44033,7 +44121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44042,7 +44130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44056,7 +44144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44065,7 +44153,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44079,7 +44167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44088,7 +44176,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44102,7 +44190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44111,7 +44199,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1023,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44125,7 +44213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44134,7 +44222,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44148,7 +44236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44157,7 +44245,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44171,7 +44259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44180,7 +44268,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44194,7 +44282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44203,7 +44291,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1029,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44217,7 +44305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44226,7 +44314,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1029,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44240,7 +44328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44249,7 +44337,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44263,7 +44351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44272,7 +44360,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44286,7 +44374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44295,7 +44383,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44309,7 +44397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44318,7 +44406,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44332,7 +44420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44341,7 +44429,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44355,7 +44443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44364,7 +44452,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44378,7 +44466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44387,7 +44475,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44401,7 +44489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44410,7 +44498,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44424,7 +44512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44433,7 +44521,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44447,7 +44535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44456,7 +44544,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44470,7 +44558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44479,7 +44567,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44493,7 +44581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44502,7 +44590,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44516,7 +44604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44525,7 +44613,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44539,7 +44627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44548,7 +44636,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44562,7 +44650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44571,7 +44659,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44585,7 +44673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44594,7 +44682,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44608,7 +44696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44617,7 +44705,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44631,7 +44719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44640,7 +44728,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44654,7 +44742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 530,
+            "handler_line": 531,
             "kind": "try",
             "line": 11
           }
@@ -44663,7 +44751,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48402,14 +48490,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1764
+            "line": 1766
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1765,
+        "line": 1767,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -48421,14 +48509,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1801
+            "line": 1803
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1802,
+        "line": 1804,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -48440,14 +48528,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1809
+            "line": 1811
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1810,
+        "line": 1812,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49822,14 +49910,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1764
+            "line": 1766
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1765,
+        "line": 1767,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49841,14 +49929,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1801
+            "line": 1803
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1802,
+        "line": 1804,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49860,14 +49948,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1809
+            "line": 1811
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1810,
+        "line": 1812,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51315,7 +51403,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1050,
+        "line": 1052,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51324,7 +51412,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1715,
+        "line": 1717,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51333,7 +51421,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2566,
+        "line": 2561,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51342,7 +51430,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2569,
+        "line": 2564,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51351,7 +51439,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2572,
+        "line": 2567,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51360,7 +51448,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2575,
+        "line": 2570,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51369,7 +51457,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2578,
+        "line": 2573,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51378,7 +51466,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2581,
+        "line": 2576,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51387,7 +51475,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2584,
+        "line": 2579,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51396,7 +51484,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2587,
+        "line": 2582,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51405,7 +51493,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2590,
+        "line": 2585,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51414,7 +51502,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2593,
+        "line": 2588,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51423,7 +51511,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2596,
+        "line": 2591,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51432,7 +51520,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2599,
+        "line": 2594,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51441,7 +51529,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2602,
+        "line": 2597,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51450,7 +51538,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2605,
+        "line": 2600,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51459,7 +51547,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2609,
+        "line": 2604,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51468,7 +51556,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2612,
+        "line": 2607,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51477,7 +51565,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2616,
+        "line": 2611,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51486,7 +51574,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2619,
+        "line": 2614,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51495,7 +51583,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2623,
+        "line": 2618,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51504,7 +51592,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2626,
+        "line": 2621,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51513,7 +51601,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2629,
+        "line": 2624,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51522,7 +51610,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2632,
+        "line": 2627,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51531,7 +51619,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2635,
+        "line": 2630,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51540,7 +51628,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2638,
+        "line": 2633,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51549,7 +51637,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2645,
+        "line": 2640,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51558,7 +51646,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2651,
+        "line": 2646,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51567,7 +51655,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2656,
+        "line": 2651,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51576,7 +51664,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2660,
+        "line": 2655,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52078,25 +52166,25 @@
       },
       {
         "kind": "dict",
-        "line": 1120,
+        "line": 1122,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1109,
+        "line": 1111,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1104,
+        "line": 1106,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "set",
-        "line": 1714,
+        "line": 1716,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "ebeee894e537c0edb4c7ec7aed34cefd212151f4",
+    "base_commit": "47fef1deebc32644d19caa22add5fee0aa94edbe",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -31,7 +31,8 @@
       "B-11a",
       "B-11b",
       "B-11c1",
-      "B-11c2"
+      "B-11c2",
+      "B-11c3"
     ]
   },
   "enums": {
@@ -66,11 +67,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 262,
+    "nodes_canonical_bindings": 263,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 40,
+    "root_residual_functions": 39,
     "root_residual_classes": 0,
     "root_residual_globals": 32,
     "runtime_binders": 28,
@@ -2295,7 +2296,8 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_align_down": "_align_down",
-        "_align_nearest": "_align_nearest"
+        "_align_nearest": "_align_nearest",
+        "_image_tensor_size": "_image_tensor_size"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -2307,10 +2309,14 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime"
+        "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
+        "canonical runtime resolver: easyuse_anima.aio.preview"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load"
+        "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
+        "AST:easyuse_anima.aio.preview string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -3926,7 +3932,6 @@
         "_find_comfy_node_class": "_find_comfy_node_class",
         "_find_comfy_node_mapping_class": "_find_comfy_node_mapping_class",
         "_find_loaded_node_class": "_find_loaded_node_class",
-        "_image_tensor_size": "_image_tensor_size",
         "_is_aio_detailer_target_name": "_is_aio_detailer_target_name",
         "_new_aio_random_seed": "_new_aio_random_seed",
         "_normalize_aio_dit_corrections_settings": "_normalize_aio_dit_corrections_settings",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -466,7 +466,7 @@ class CommonHelperMoveContractTests(unittest.TestCase):
         ),
         (
             image_geometry,
-            ("_align_nearest", "_align_down"),
+            ("_align_nearest", "_align_down", "_image_tensor_size"),
         ),
     )
 
@@ -552,6 +552,18 @@ class CommonHelperMoveContractTests(unittest.TestCase):
         self.assertEqual(nodes._align_nearest(95, 64), 64)
         self.assertEqual(nodes._align_nearest(96, 64), 128)
         self.assertEqual(nodes._align_down(65, 64), 64)
+        self.assertEqual(
+            image_geometry._image_tensor_size(
+                types.SimpleNamespace(shape=(1, 5, 7, 4)),
+                32,
+                48,
+            ),
+            (7, 5),
+        )
+        self.assertEqual(
+            image_geometry._image_tensor_size(object(), "32", "48"),
+            (32, 48),
+        )
         self.assertEqual(
             image_geometry._aligned_size_near_scale(128, 64, 2.0, 64, 0),
             (256, 128, 2.0),

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "50ee288154fdaf73816e2884d7fe1d41e4fc20dc")
-        # Issue #184 B-11c2 moves the read-only workflow lookup while
-        # preserving the root alias and existing binder/resolver seams.
-        self.assertEqual(report["top_level"]["function_count"], 40)
+        self.assertEqual(report["git_blob_sha1"], "0680a8e5e7c605c79a50dd2dde5b463c2694defc")
+        # Issue #184 B-11c3 moves the dependency-free image tensor size helper
+        # while preserving the root alias and existing binder/resolver seams.
+        self.assertEqual(report["top_level"]["function_count"], 39)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_664)
+        self.assertEqual(report["line_count"], 2_659)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "ebeee894e537c0edb4c7ec7aed34cefd212151f4"
+BASE_COMMIT = "47fef1deebc32644d19caa22add5fee0aa94edbe"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1305,6 +1305,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11b",
                 "B-11c1",
                 "B-11c2",
+                "B-11c3",
             ],
         },
         "enums": {
@@ -1317,11 +1318,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 262,
+            "nodes_canonical_bindings": 263,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 40,
+            "root_residual_functions": 39,
             "root_residual_classes": 0,
             "root_residual_globals": 32,
             "runtime_binders": 28,


### PR DESCRIPTION
## 변경 전 inventory

- 기준: `dev` / `47fef1deebc32644d19caa22add5fee0aa94edbe`
- 유형: Move-only (`B-11c3 AiO image tensor size residual`)
- 선택 근거:
  - B-11c2 뒤 root `nodes.py`에는 40 functions, 0 classes, 32 globals, 28 runtime binders가 남아 있음.
  - `_image_tensor_size`는 module global, cache, Comfy provider, mutable state 의존성이 없는 단일 읽기 함수임.
  - AiO seed family는 RNG, mutable special-seed set, `MAX_SEED` runtime seam을 함께 이동해야 하므로 이 단독 Move보다 넓음.
  - Comfy node lookup wrappers는 canonical package의 root `nodes` import 금지 계약 때문에 provider/binder Contract 전에는 Move-only가 아님.
- symbol/caller:
  - `_image_tensor_size(image, fallback_width, fallback_height)`는 `image.shape[2]`, `image.shape[1]`을 `int`로 반환하고, shape 접근/변환 예외 시 두 fallback의 `int` 값을 반환함.
  - root direct callers는 `_resize_image_to_size_if_needed`, `_aio_usdu_tile_plan`, `_apply_aio_final_fit`, `_run_aio_postprocess_stage` 2곳, `_run_aio_usdu_upscale_stage`, `_run_aio_resshift_upscale_stage`임.
  - canonical runtime-resolver callers는 `easyuse_anima.aio.legacy_generation` 3곳과 `easyuse_anima.aio.preview` 1곳임.
- alias/compatibility:
  - 현재는 root definition이며 canonical alias가 없음.
  - 이동 후 root relative/flat import가 같은 canonical function을 direct identity alias로 유지함.
  - `_bind_aio_legacy_generation_runtime`와 `_bind_aio_preview_runtime` 및 호출 순서는 변경하지 않아 call-time `nodes._image_tensor_size` patch seam을 보존함.
  - `_resize_image_to_size_if_needed`를 함께 이동하지 않아 그 함수 내부의 root call-time lookup도 그대로 유지함.
- global state:
  - 입력 image를 읽기만 하며 module global, cache, lock, file/network I/O, mutation을 소유하지 않음.

## 허용 경계

- production: `easyuse_anima/image/geometry.py`, root `nodes.py`
- focused contracts: shape/fallback parity, flat/package root direct identity, legacy-generation/preview call-time root patch seam
- analyzer/compatibility: nodes analyzer baseline, backend analyzer fixture, compatibility surface test/fixture
- status docs: backend execution roadmap, compatibility shim registry

## 금지 경계

- `_resize_image_to_size_if_needed` 및 AiO highres/upscale/postprocess/detailer 실행 함수 이동
- AiO seed, settings, default configuration 또는 wildcard reservation 변경
- Comfy provider/lookup wrapper 및 runtime binder/resolver 변경
- tensor layout, fallback, exception 범위, return type 또는 image mutation 변경
- B-11c final shim cutover, Phase C seed behavior, Phase D/E consolidation

## 변경 요약

- 함수 본문을 statement-for-statement 기존 `easyuse_anima.image.geometry` owner로 이동함.
- root `nodes.py` relative/flat image-geometry import가 canonical function을 explicit alias로 re-export함.
- 모든 direct caller와 runtime binder/resolver는 그대로 둠.
- analyzer/compatibility fixture는 실제 canonical binding과 root residual 수치만 반영함.

## 주요 파일

- `easyuse_anima/image/geometry.py`: `_image_tensor_size` canonical owner
- `nodes.py`: relative/flat direct identity alias와 기존 root callers 유지
- `tests/test_node_contracts.py`: shape/fallback parity와 flat/package alias identity
- analyzer/compatibility tests·fixtures: 263 canonical bindings, 39 residual functions 반영
- architecture roadmap/shim registry: B-11c3 상태와 잔여 범위 기록

## 검증 결과

- focused `unittest`: 64 tests passed
  - common/image move contracts
  - AiO preview와 legacy-generation resolver/patch seams
  - compatibility surface, nodes/backend analyzer, import boundary
- 독립 diff review: actionable finding 없음
- 정확한 PR head `df04fadc5da41de6b5c7ab29985a62661bf0ba04` 공식 `Profile full`: passed
  - Python `unittest`: 888 passed
  - frontend: 114 JavaScript files, TypeScript 6.0.3
  - Pyright: 64 files, 기존 60 errors / 0 warnings
  - import boundary: 6 groups / 0 violations
  - Ruff report-only: 기존 105 findings, 증가 없음
  - `git diff --check`: passed
- backend analyzer invariants: modules/shipped/closure 81/81/81, side effects 188, mutable globals 63, compatibility names 23, missing/unreachable/cycles 0
- Live ComfyUI/browser smoke: not run (Phase B exit checkpoint 대상)

## 남은 위험 / 미확인

- 이 PR은 함수 한 개의 owner만 이동하므로 B-11c와 Phase B를 완료하지 않음.
- AiO seed/settings, Comfy provider wrappers, stage/postprocess execution, wildcard reservation과 28 binders는 후속 rollback unit으로 남음.
- broad exception fallback은 기존 계약을 그대로 보존했으며, 별도 예외 축소나 tensor-layout 계약 변경을 하지 않음.
- live ComfyUI/browser 및 package/pack exit 검증은 Phase B exit checkpoint에 남김.
- 병합 후 예상 root residual: 39 functions, 0 classes, 32 globals, 28 runtime binders.
