### PR TITLE
refactor(backend): move AiO LoRA signature residual (B-11c4)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `47fef1deebc32644d19caa22add5fee0aa94edbe`
+- Integrated `dev` snapshot commit: `1f18c04f1078b7c547764aa572a6123ba423221d`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c2; B-11c3 image-size Move in PR #296 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c3; B-11c4 LoRA-signature Move in PR #297 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,9 +42,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,664
-  lines after B-11c2.
-- The mechanical extraction has removed 9,999
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,659
+  lines after B-11c3.
+- The mechanical extraction has removed 10,004
   lines, approximately 79.0% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
@@ -57,8 +57,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   to guarded `easyuse_anima.bootstrap` ownership in PR #293 / `f2a2ec0`.
   B-11c is split into residual-owner Moves before the final `nodes.py` shim;
   B-11c1 moved shared private input types in PR #294 / `ebeee89`, B-11c2 moved
-  the read-only workflow lookup owner in PR #295 / `47fef1d`, and B-11c3 moves
-  only the dependency-free image tensor size helper in PR #296.
+  the read-only workflow lookup owner in PR #295 / `47fef1d`, and B-11c3 moved
+  the dependency-free image tensor size helper in PR #296 / `1f18c04`.
+  B-11c4 moves only the AiO LoRA stack signature helper in PR #297.
 
 ### Current quality baseline
 
@@ -300,7 +301,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 image-size PR #296 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 LoRA-signature PR #297 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -522,9 +523,10 @@ first-pass cache state, cache-key generation, clone/reset, and LRU helpers
 to `easyuse_anima.aio.first_pass_cache`, preserving direct root identities,
 call-time state/helper replacement, limit 2, key field order, clone isolation,
 falsey misses, hit refresh, overwrite, and oldest-first eviction behavior.
-The shared `_aio_lora_stack_signature` remains root-owned because both
-`IS_CHANGED` and the cache key consume it; the canonical key resolves that root
-helper at call time.
+At B-08e integration, the shared `_aio_lora_stack_signature` remained
+root-owned because both `IS_CHANGED` and the cache key consume it. B-11c4 moves
+the implementation to `easyuse_anima.aio.model_preparation`; both canonical
+consumers continue resolving the retained root alias at call time.
 
 Rules for every B-08 PR:
 
@@ -805,6 +807,11 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     `easyuse_anima.image.geometry` owner. PR #296 retains the root direct alias,
     all root stage callers, and the existing AiO preview/legacy-generation
     runtime resolvers; resize and postprocess execution remain separate.
+  - B-11c4 moves only `_aio_lora_stack_signature` to the existing
+    `easyuse_anima.aio.model_preparation` owner. PR #297 retains the root direct
+    alias, both canonical consumer resolver paths, and call-time replacement of
+    the root `_normalize_aio_lora_stack` helper; cache policy and `IS_CHANGED`
+    behavior remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `47fef1deebc32644d19caa22add5fee0aa94edbe`
+  `1f18c04f1078b7c547764aa572a6123ba423221d`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c2 are integrated through PR #295. B-11c is
+- Current state: B-11a through B-11c3 are integrated through PR #296. B-11c is
   split into residual-owner and binder Moves before the final root shim;
-  B-11c3 image tensor size ownership is tracked by PR #296.
+  B-11c4 AiO LoRA signature ownership is tracked by PR #297.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,8 +75,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 263 after
-  B-11c3 (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 264 after
+  B-11c4 (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -84,8 +84,8 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 39 functions, 0 classes, and 32 assigned
-  globals after B-11c3 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 38 functions, 0 classes, and 32 assigned
+  globals after B-11c4 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 256, including
   literal lookups and binder-owned helper-name/default collections;
@@ -189,6 +189,20 @@ convenience-node compatibility; it remains unmapped and is not public support.
   mutation, Comfy provider, cache, or I/O dependency.
 - `_resize_image_to_size_if_needed` and all stage/postprocess execution remain
   root-owned so this PR does not alter their internal patch seams or behavior.
+
+### B-11c4 AiO LoRA stack signature alias
+
+- Canonical owner:
+  `easyuse_anima.aio.model_preparation._aio_lora_stack_signature`.
+- The private root name remains a transitional direct alias. AiO `IS_CHANGED`
+  and first-pass cache-key generation continue resolving it through their
+  existing root runtime resolvers, preserving call-time replacement.
+- The canonical owner resolves `_normalize_aio_lora_stack` through the existing
+  model-preparation runtime seam, so root monkeypatches and normalized tuple
+  ordering remain unchanged in PR #297.
+- The helper only projects normalized entries into the existing ordered
+  `name`/`strength_model`/`strength_clip` dictionaries. Cache state, eviction,
+  node change-key behavior, random state, and I/O remain unchanged.
 
 ### `nodes.py` public node-class surface
 
@@ -410,8 +424,9 @@ EasyUseAnimaWildcard
   identity aliases so generator callers, mutable-state rebinding, and focused
   monkeypatch seams preserve call-time behavior. These are internal transition
   surfaces through the B-10 compatibility audit and are not added to public
-  package `__all__`. The shared root `_aio_lora_stack_signature` is not part of
-  this move; the canonical cache key resolves it at call time.
+  package `__all__`. The shared root `_aio_lora_stack_signature` was not part
+  of B-08e; B-11c4 now gives it a canonical model-preparation owner while the
+  cache key continues resolving the retained root alias at call time.
 - B-09a public AiO input-adapter transition: `EasyUseAnimaInput` moves to
   `easyuse_anima.nodes.aio_nodes` and remains a direct root alias, so direct
   imports and the package `NODE_CLASS_MAPPINGS` entry retain class identity.

--- a/easyuse_anima/aio/model_preparation.py
+++ b/easyuse_anima/aio/model_preparation.py
@@ -191,6 +191,19 @@ def _normalize_aio_lora_stack(lora_stack) -> list[tuple[str, float, float]]:
     return entries
 
 
+def _aio_lora_stack_signature(lora_stack) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": name,
+            "strength_model": model_strength,
+            "strength_clip": clip_strength,
+        }
+        for name, model_strength, clip_strength in _runtime_helper(
+            "_normalize_aio_lora_stack"
+        )(lora_stack)
+    ]
+
+
 def _apply_aio_lora_stack(model, clip, lora_stack):
     entries = _runtime_helper("_normalize_aio_lora_stack")(lora_stack)
     if not entries:

--- a/nodes.py
+++ b/nodes.py
@@ -39,6 +39,7 @@ try:
         _bind_aio_conditioning_runtime as _bind_aio_conditioning_runtime,
     )
     from .easyuse_anima.aio.model_preparation import (
+        _aio_lora_stack_signature as _aio_lora_stack_signature,
         _apply_aio_anima_dave_patch as _apply_aio_anima_dave_patch,
         _apply_aio_kj_model_patches as _apply_aio_kj_model_patches,
         _apply_aio_lora_stack as _apply_aio_lora_stack,
@@ -559,6 +560,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _bind_aio_conditioning_runtime as _bind_aio_conditioning_runtime,
     )
     from easyuse_anima.aio.model_preparation import (
+        _aio_lora_stack_signature as _aio_lora_stack_signature,
         _apply_aio_anima_dave_patch as _apply_aio_anima_dave_patch,
         _apply_aio_kj_model_patches as _apply_aio_kj_model_patches,
         _apply_aio_lora_stack as _apply_aio_lora_stack,
@@ -1842,17 +1844,6 @@ def _find_loaded_node_class(node_id: str):
     return _adapter_find_loaded_node_class(node_id, _find_comfy_node_class)
 
 
-
-
-def _aio_lora_stack_signature(lora_stack) -> list[dict[str, Any]]:
-    return [
-        {
-            "name": name,
-            "strength_model": model_strength,
-            "strength_clip": clip_strength,
-        }
-        for name, model_strength, clip_strength in _normalize_aio_lora_stack(lora_stack)
-    ]
 
 
 def _resize_image_to_size_if_needed(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6253,7 +6253,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 296
+            "line": 309
           }
         ],
         "classification": "external",
@@ -6261,7 +6261,7 @@
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 297,
+        "line": 310,
         "name": null,
         "optional": true,
         "requested": "comfy.model_management",
@@ -14783,6 +14783,37 @@
         "target": "easyuse_anima/aio/conditioning.py"
       },
       {
+        "alias": "_aio_lora_stack_signature",
+        "bound_name": "_aio_lora_stack_signature",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_aio_lora_stack_signature",
+          "target": "easyuse_anima/aio/model_preparation.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
+        "kind": "static_from",
+        "line": 41,
+        "name": "_aio_lora_stack_signature",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.model_preparation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
         "alias": "_apply_aio_anima_dave_patch",
         "bound_name": "_apply_aio_anima_dave_patch",
         "branch_context": [
@@ -15176,7 +15207,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15207,7 +15238,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15238,7 +15269,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15269,7 +15300,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15300,7 +15331,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15331,7 +15362,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15362,7 +15393,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15393,7 +15424,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15424,7 +15455,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15455,7 +15486,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15486,7 +15517,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15517,7 +15548,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15548,7 +15579,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15579,7 +15610,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15610,7 +15641,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15641,7 +15672,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15672,7 +15703,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15703,7 +15734,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15734,7 +15765,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15765,7 +15796,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15796,7 +15827,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15827,7 +15858,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15858,7 +15889,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15889,7 +15920,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15920,7 +15951,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15951,7 +15982,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15982,7 +16013,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16013,7 +16044,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16044,7 +16075,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16075,7 +16106,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16106,7 +16137,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16137,7 +16168,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16168,7 +16199,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16199,7 +16230,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16230,7 +16261,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16261,7 +16292,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16292,7 +16323,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16323,7 +16354,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16354,7 +16385,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16385,7 +16416,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16416,7 +16447,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16447,7 +16478,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16478,7 +16509,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16509,7 +16540,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16540,7 +16571,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16571,7 +16602,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16602,7 +16633,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16633,7 +16664,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16664,7 +16695,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16695,7 +16726,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -16726,7 +16757,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16757,7 +16788,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16788,7 +16819,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16819,7 +16850,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16850,7 +16881,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16881,7 +16912,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16912,7 +16943,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16943,7 +16974,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16974,7 +17005,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17005,7 +17036,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17036,7 +17067,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17067,7 +17098,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17098,7 +17129,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17129,7 +17160,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17160,7 +17191,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17191,7 +17222,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17222,7 +17253,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17253,7 +17284,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17284,7 +17315,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17315,7 +17346,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17346,7 +17377,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17377,7 +17408,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17408,7 +17439,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17439,7 +17470,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17470,7 +17501,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17501,7 +17532,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17532,7 +17563,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17563,7 +17594,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17594,7 +17625,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17625,7 +17656,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17656,7 +17687,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17687,7 +17718,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17718,7 +17749,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17749,7 +17780,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17780,7 +17811,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17811,7 +17842,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17842,7 +17873,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17873,7 +17904,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17904,7 +17935,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17935,7 +17966,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17966,7 +17997,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17997,7 +18028,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18028,7 +18059,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18059,7 +18090,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18090,7 +18121,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18121,7 +18152,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18152,7 +18183,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18183,7 +18214,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18214,7 +18245,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18245,7 +18276,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18276,7 +18307,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18307,7 +18338,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18338,7 +18369,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18369,7 +18400,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18400,7 +18431,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18431,7 +18462,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18462,7 +18493,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18493,7 +18524,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18524,7 +18555,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18555,7 +18586,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18586,7 +18617,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18617,7 +18648,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18648,7 +18679,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18679,7 +18710,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18710,7 +18741,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18741,7 +18772,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18772,7 +18803,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18803,7 +18834,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18834,7 +18865,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18865,7 +18896,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18896,7 +18927,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18927,7 +18958,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18958,7 +18989,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18989,7 +19020,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19020,7 +19051,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19051,7 +19082,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19082,7 +19113,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19113,7 +19144,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19144,7 +19175,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19175,7 +19206,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19206,7 +19237,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19237,7 +19268,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19268,7 +19299,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19299,7 +19330,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19330,7 +19361,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19361,7 +19392,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19392,7 +19423,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19423,7 +19454,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19454,7 +19485,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19485,7 +19516,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19516,7 +19547,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 235,
+        "line": 236,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19547,7 +19578,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 315,
+        "line": 316,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19578,7 +19609,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 315,
+        "line": 316,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19609,7 +19640,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 315,
+        "line": 316,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19640,7 +19671,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 315,
+        "line": 316,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19671,7 +19702,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 321,
+        "line": 322,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19702,7 +19733,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 321,
+        "line": 322,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19733,7 +19764,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 321,
+        "line": 322,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19764,7 +19795,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 326,
+        "line": 327,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19795,7 +19826,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 326,
+        "line": 327,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19826,7 +19857,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 326,
+        "line": 327,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19857,7 +19888,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 332,
+        "line": 333,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19888,7 +19919,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 332,
+        "line": 333,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19919,7 +19950,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 332,
+        "line": 333,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19950,7 +19981,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 332,
+        "line": 333,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19981,7 +20012,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 332,
+        "line": 333,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20012,7 +20043,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 339,
+        "line": 340,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20043,7 +20074,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 339,
+        "line": 340,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20074,7 +20105,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 339,
+        "line": 340,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20105,7 +20136,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 350,
+        "line": 351,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20136,7 +20167,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 350,
+        "line": 351,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20167,7 +20198,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 350,
+        "line": 351,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20198,7 +20229,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 350,
+        "line": 351,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20229,7 +20260,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 363,
+        "line": 364,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20260,7 +20291,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 363,
+        "line": 364,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20291,7 +20322,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 371,
+        "line": 372,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20322,7 +20353,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 371,
+        "line": 372,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20353,7 +20384,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 371,
+        "line": 372,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20384,7 +20415,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 371,
+        "line": 372,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20415,7 +20446,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 371,
+        "line": 372,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20446,7 +20477,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 371,
+        "line": 372,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20477,7 +20508,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 371,
+        "line": 372,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20508,7 +20539,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 371,
+        "line": 372,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20539,7 +20570,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 382,
+        "line": 383,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20570,7 +20601,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 382,
+        "line": 383,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20601,7 +20632,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 382,
+        "line": 383,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20632,7 +20663,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 382,
+        "line": 383,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20663,7 +20694,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20694,7 +20725,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20725,7 +20756,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20756,7 +20787,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20787,7 +20818,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20818,7 +20849,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 396,
+        "line": 397,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20849,7 +20880,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 396,
+        "line": 397,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20880,7 +20911,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -20911,7 +20942,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 404,
+        "line": 405,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -20942,7 +20973,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 404,
+        "line": 405,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -20973,7 +21004,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 404,
+        "line": 405,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21004,7 +21035,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21035,7 +21066,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21066,7 +21097,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21097,7 +21128,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21128,7 +21159,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21159,7 +21190,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21190,7 +21221,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21221,7 +21252,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21252,7 +21283,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21283,7 +21314,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21314,7 +21345,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21345,7 +21376,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21376,7 +21407,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21407,7 +21438,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21438,7 +21469,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21469,7 +21500,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21500,7 +21531,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 462,
+        "line": 463,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21531,7 +21562,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 462,
+        "line": 463,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21562,7 +21593,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 466,
+        "line": 467,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21593,7 +21624,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 466,
+        "line": 467,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21624,7 +21655,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21655,7 +21686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21686,7 +21717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21717,7 +21748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21748,7 +21779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21779,7 +21810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21810,7 +21841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21841,7 +21872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21872,7 +21903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21903,7 +21934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21934,7 +21965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21965,7 +21996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21996,7 +22027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22027,7 +22058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22058,7 +22089,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22089,7 +22120,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 488,
+        "line": 489,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22120,7 +22151,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 488,
+        "line": 489,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22151,7 +22182,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 488,
+        "line": 489,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22182,7 +22213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 488,
+        "line": 489,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22213,7 +22244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 488,
+        "line": 489,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22244,7 +22275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 488,
+        "line": 489,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22275,7 +22306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 488,
+        "line": 489,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22306,7 +22337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 488,
+        "line": 489,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22337,7 +22368,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22368,7 +22399,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22399,7 +22430,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22430,7 +22461,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22461,7 +22492,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -22492,7 +22523,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -22523,7 +22554,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -22554,7 +22585,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -22585,7 +22616,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22616,7 +22647,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22647,7 +22678,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22678,7 +22709,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22709,7 +22740,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22740,7 +22771,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22771,7 +22802,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22802,7 +22833,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22833,7 +22864,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22864,7 +22895,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22895,7 +22926,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22926,7 +22957,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22957,7 +22988,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22988,7 +23019,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23019,7 +23050,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23050,7 +23081,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23081,7 +23112,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23112,7 +23143,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23143,7 +23174,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23174,7 +23205,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23205,7 +23236,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23224,7 +23255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23239,7 +23270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23258,7 +23289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23273,7 +23304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23292,7 +23323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23307,7 +23338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23326,7 +23357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23360,7 +23391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23375,7 +23406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23394,7 +23425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23409,7 +23440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23428,7 +23459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23443,7 +23474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23462,7 +23493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23477,7 +23508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23496,7 +23527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23511,7 +23542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23530,7 +23561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23545,7 +23576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23564,7 +23595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23579,7 +23610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23598,7 +23629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23613,7 +23644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23632,7 +23663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23647,7 +23678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23666,7 +23697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23681,7 +23712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 552,
+        "line": 553,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -23700,7 +23731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23715,7 +23746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 555,
+        "line": 556,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23734,7 +23765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23749,7 +23780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 555,
+        "line": 556,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23768,7 +23799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23783,7 +23814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 555,
+        "line": 556,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23802,7 +23833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23817,7 +23848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 555,
+        "line": 556,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23825,6 +23856,40 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/aio/conditioning.py"
+      },
+      {
+        "alias": "_aio_lora_stack_signature",
+        "bound_name": "_aio_lora_stack_signature",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 532,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_aio_lora_stack_signature",
+          "target": "easyuse_anima/aio/model_preparation.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
+        "kind": "static_from",
+        "line": 562,
+        "name": "_aio_lora_stack_signature",
+        "optional": false,
+        "requested": "easyuse_anima.aio.model_preparation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
       },
       {
         "alias": "_apply_aio_anima_dave_patch",
@@ -23836,7 +23901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23851,7 +23916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23870,7 +23935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23885,7 +23950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23904,7 +23969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23919,7 +23984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23938,7 +24003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23953,7 +24018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23972,7 +24037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -23987,7 +24052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24006,7 +24071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24021,7 +24086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24040,7 +24105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24055,7 +24120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24074,7 +24139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24089,7 +24154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24108,7 +24173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24123,7 +24188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24142,7 +24207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24157,7 +24222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24176,7 +24241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24191,7 +24256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24210,7 +24275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24225,7 +24290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24244,7 +24309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24259,7 +24324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24278,7 +24343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24293,7 +24358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24312,7 +24377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24327,7 +24392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24346,7 +24411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24361,7 +24426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24380,7 +24445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24395,7 +24460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24414,7 +24479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24429,7 +24494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24448,7 +24513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24463,7 +24528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24482,7 +24547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24497,7 +24562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24516,7 +24581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24531,7 +24596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24550,7 +24615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24565,7 +24630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24584,7 +24649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24599,7 +24664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24618,7 +24683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24633,7 +24698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24652,7 +24717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24667,7 +24732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24686,7 +24751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24701,7 +24766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24720,7 +24785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24735,7 +24800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24754,7 +24819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24769,7 +24834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24788,7 +24853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24803,7 +24868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24822,7 +24887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24837,7 +24902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24856,7 +24921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24871,7 +24936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24890,7 +24955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24905,7 +24970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24924,7 +24989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24939,7 +25004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24958,7 +25023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -24973,7 +25038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -24992,7 +25057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25007,7 +25072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25026,7 +25091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25041,7 +25106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25060,7 +25125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25075,7 +25140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25094,7 +25159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25109,7 +25174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25128,7 +25193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25143,7 +25208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25162,7 +25227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25177,7 +25242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25196,7 +25261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25211,7 +25276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25230,7 +25295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25245,7 +25310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25264,7 +25329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25279,7 +25344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25298,7 +25363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25313,7 +25378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25332,7 +25397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25347,7 +25412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25366,7 +25431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25381,7 +25446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25400,7 +25465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25415,7 +25480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25434,7 +25499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25449,7 +25514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25468,7 +25533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25483,7 +25548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25502,7 +25567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25517,7 +25582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25536,7 +25601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25551,7 +25616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25570,7 +25635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25585,7 +25650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25604,7 +25669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25619,7 +25684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25638,7 +25703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25653,7 +25718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25672,7 +25737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25687,7 +25752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25706,7 +25771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25721,7 +25786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25740,7 +25805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25755,7 +25820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 629,
+        "line": 631,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25774,7 +25839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25789,7 +25854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 629,
+        "line": 631,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25808,7 +25873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25823,7 +25888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 629,
+        "line": 631,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25842,7 +25907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25857,7 +25922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 629,
+        "line": 631,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25876,7 +25941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25891,7 +25956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 629,
+        "line": 631,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25910,7 +25975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25925,7 +25990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 636,
+        "line": 638,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -25944,7 +26009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25959,7 +26024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -25978,7 +26043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -25993,7 +26058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26012,7 +26077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26027,7 +26092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26046,7 +26111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26061,7 +26126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26080,7 +26145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26095,7 +26160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26114,7 +26179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26129,7 +26194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26148,7 +26213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26163,7 +26228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26182,7 +26247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26197,7 +26262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26216,7 +26281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26231,7 +26296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26250,7 +26315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26265,7 +26330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26284,7 +26349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26299,7 +26364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26318,7 +26383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26333,7 +26398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26352,7 +26417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26367,7 +26432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26386,7 +26451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26401,7 +26466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26420,7 +26485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26435,7 +26500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26454,7 +26519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26469,7 +26534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26488,7 +26553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26503,7 +26568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26522,7 +26587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26537,7 +26602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26556,7 +26621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26571,7 +26636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26590,7 +26655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26605,7 +26670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26624,7 +26689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26639,7 +26704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26658,7 +26723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26673,7 +26738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26692,7 +26757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26707,7 +26772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26726,7 +26791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26741,7 +26806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26760,7 +26825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26775,7 +26840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26794,7 +26859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26809,7 +26874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26828,7 +26893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26843,7 +26908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26862,7 +26927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26877,7 +26942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26896,7 +26961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26911,7 +26976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26930,7 +26995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26945,7 +27010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26964,7 +27029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -26979,7 +27044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26998,7 +27063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27013,7 +27078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27032,7 +27097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27047,7 +27112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27066,7 +27131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27081,7 +27146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27100,7 +27165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27115,7 +27180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27134,7 +27199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27149,7 +27214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27168,7 +27233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27183,7 +27248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27202,7 +27267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27217,7 +27282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27236,7 +27301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27251,7 +27316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27270,7 +27335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27285,7 +27350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27304,7 +27369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27319,7 +27384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27338,7 +27403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27353,7 +27418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27372,7 +27437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27387,7 +27452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27406,7 +27471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27421,7 +27486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27440,7 +27505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27455,7 +27520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27474,7 +27539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27489,7 +27554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27508,7 +27573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27523,7 +27588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27542,7 +27607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27557,7 +27622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27576,7 +27641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27591,7 +27656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27610,7 +27675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27625,7 +27690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27644,7 +27709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27659,7 +27724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27678,7 +27743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27693,7 +27758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27712,7 +27777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27727,7 +27792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27746,7 +27811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27761,7 +27826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27780,7 +27845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27795,7 +27860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27814,7 +27879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27829,7 +27894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27848,7 +27913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27863,7 +27928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27882,7 +27947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27897,7 +27962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27916,7 +27981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27931,7 +27996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27950,7 +28015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27965,7 +28030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27984,7 +28049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -27999,7 +28064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28018,7 +28083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28033,7 +28098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28052,7 +28117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28067,7 +28132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28086,7 +28151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28101,7 +28166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28120,7 +28185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28135,7 +28200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28154,7 +28219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28169,7 +28234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28188,7 +28253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28203,7 +28268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28222,7 +28287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28237,7 +28302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28256,7 +28321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28271,7 +28336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28290,7 +28355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28305,7 +28370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28324,7 +28389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28339,7 +28404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28358,7 +28423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28373,7 +28438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28392,7 +28457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28407,7 +28472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28426,7 +28491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28441,7 +28506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28460,7 +28525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28475,7 +28540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28494,7 +28559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28509,7 +28574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28528,7 +28593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28543,7 +28608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28562,7 +28627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28577,7 +28642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28596,7 +28661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28611,7 +28676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28630,7 +28695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28645,7 +28710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28664,7 +28729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28679,7 +28744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28698,7 +28763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28713,7 +28778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28732,7 +28797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28747,7 +28812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28766,7 +28831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28781,7 +28846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28800,7 +28865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28815,7 +28880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28834,7 +28899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28849,7 +28914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28868,7 +28933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28883,7 +28948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28902,7 +28967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28917,7 +28982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28936,7 +29001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28951,7 +29016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28970,7 +29035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -28985,7 +29050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29004,7 +29069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29019,7 +29084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29038,7 +29103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29053,7 +29118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 835,
+        "line": 837,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29072,7 +29137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29087,7 +29152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 835,
+        "line": 837,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29106,7 +29171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29121,7 +29186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 835,
+        "line": 837,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29140,7 +29205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29155,7 +29220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 835,
+        "line": 837,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29174,7 +29239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29189,7 +29254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 841,
+        "line": 843,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29208,7 +29273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29223,7 +29288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 841,
+        "line": 843,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29242,7 +29307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29257,7 +29322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 841,
+        "line": 843,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29276,7 +29341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29291,7 +29356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 846,
+        "line": 848,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29310,7 +29375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29325,7 +29390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 846,
+        "line": 848,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29344,7 +29409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29359,7 +29424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 846,
+        "line": 848,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29378,7 +29443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29393,7 +29458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 852,
+        "line": 854,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29412,7 +29477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29427,7 +29492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 852,
+        "line": 854,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29446,7 +29511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29461,7 +29526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 852,
+        "line": 854,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29480,7 +29545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29495,7 +29560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 852,
+        "line": 854,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29514,7 +29579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29529,7 +29594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 852,
+        "line": 854,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29548,7 +29613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29563,7 +29628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 859,
+        "line": 861,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29582,7 +29647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29597,7 +29662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 859,
+        "line": 861,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29616,7 +29681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29631,7 +29696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 859,
+        "line": 861,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29650,7 +29715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29665,7 +29730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 870,
+        "line": 872,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29684,7 +29749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29699,7 +29764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 870,
+        "line": 872,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29718,7 +29783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29733,7 +29798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 870,
+        "line": 872,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29752,7 +29817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29767,7 +29832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 870,
+        "line": 872,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29786,7 +29851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29801,7 +29866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 883,
+        "line": 885,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -29820,7 +29885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29835,7 +29900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 883,
+        "line": 885,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -29854,7 +29919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29869,7 +29934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29888,7 +29953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29903,7 +29968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29922,7 +29987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29937,7 +30002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29956,7 +30021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -29971,7 +30036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29990,7 +30055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30005,7 +30070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30024,7 +30089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30039,7 +30104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30058,7 +30123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30073,7 +30138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30092,7 +30157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30107,7 +30172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30126,7 +30191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30141,7 +30206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30160,7 +30225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30175,7 +30240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30194,7 +30259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30209,7 +30274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30228,7 +30293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30243,7 +30308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30262,7 +30327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30277,7 +30342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30296,7 +30361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30311,7 +30376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30330,7 +30395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30345,7 +30410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30364,7 +30429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30379,7 +30444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30398,7 +30463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30413,7 +30478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30432,7 +30497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30447,7 +30512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30466,7 +30531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30481,7 +30546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30500,7 +30565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30515,7 +30580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -30534,7 +30599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30549,7 +30614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30568,7 +30633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30583,7 +30648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30602,7 +30667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30617,7 +30682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30636,7 +30701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30651,7 +30716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30670,7 +30735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30685,7 +30750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30704,7 +30769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30719,7 +30784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30738,7 +30803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30753,7 +30818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30772,7 +30837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30787,7 +30852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30806,7 +30871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30821,7 +30886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 936,
+        "line": 938,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30840,7 +30905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30855,7 +30920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 936,
+        "line": 938,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30874,7 +30939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30889,7 +30954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 936,
+        "line": 938,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30908,7 +30973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30923,7 +30988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -30942,7 +31007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30957,7 +31022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -30976,7 +31041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -30991,7 +31056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31010,7 +31075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31025,7 +31090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31044,7 +31109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31059,7 +31124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31078,7 +31143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31093,7 +31158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31112,7 +31177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31127,7 +31192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31146,7 +31211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31161,7 +31226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31180,7 +31245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31195,7 +31260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 982,
+        "line": 984,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31214,7 +31279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31229,7 +31294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 982,
+        "line": 984,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31248,7 +31313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31263,7 +31328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31282,7 +31347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31297,7 +31362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31316,7 +31381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31331,7 +31396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31350,7 +31415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31365,7 +31430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31384,7 +31449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31399,7 +31464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31418,7 +31483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31433,7 +31498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31452,7 +31517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31467,7 +31532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31486,7 +31551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31501,7 +31566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31520,7 +31585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31535,7 +31600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31554,7 +31619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31569,7 +31634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31588,7 +31653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31603,7 +31668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31622,7 +31687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31637,7 +31702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31656,7 +31721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31671,7 +31736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31690,7 +31755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31705,7 +31770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31724,7 +31789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31739,7 +31804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31758,7 +31823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31773,7 +31838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31792,7 +31857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31807,7 +31872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31826,7 +31891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31841,7 +31906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31860,7 +31925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31875,7 +31940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31894,7 +31959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31909,7 +31974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31928,7 +31993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31943,7 +32008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31962,7 +32027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -31977,7 +32042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31996,7 +32061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32011,7 +32076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32030,7 +32095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32045,7 +32110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32064,7 +32129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32079,7 +32144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32098,7 +32163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32113,7 +32178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32132,7 +32197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32147,7 +32212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32166,7 +32231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32181,7 +32246,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -32200,7 +32265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32215,7 +32280,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -32234,7 +32299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32249,7 +32314,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1023,
+        "line": 1025,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -32268,7 +32333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32283,7 +32348,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -32302,7 +32367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32317,7 +32382,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -32336,7 +32401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32351,7 +32416,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -32370,7 +32435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32385,7 +32450,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1031,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32404,7 +32469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32419,7 +32484,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1031,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32438,7 +32503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32453,7 +32518,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32472,7 +32537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32487,7 +32552,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32506,7 +32571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32521,7 +32586,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32540,7 +32605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32555,7 +32620,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32574,7 +32639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32589,7 +32654,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32608,7 +32673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32623,7 +32688,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32642,7 +32707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32657,7 +32722,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32676,7 +32741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32691,7 +32756,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32710,7 +32775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32725,7 +32790,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32744,7 +32809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32759,7 +32824,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32778,7 +32843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32793,7 +32858,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32812,7 +32877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32827,7 +32892,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32846,7 +32911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32861,7 +32926,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32880,7 +32945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32895,7 +32960,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32914,7 +32979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32929,7 +32994,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32948,7 +33013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32963,7 +33028,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32982,7 +33047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -32997,7 +33062,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33016,7 +33081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -33031,7 +33096,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33050,7 +33115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -33065,7 +33130,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33083,7 +33148,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1766
+            "line": 1768
           }
         ],
         "classification": "external",
@@ -33091,7 +33156,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1767,
+        "line": 1769,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33108,7 +33173,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1803
+            "line": 1805
           }
         ],
         "classification": "external",
@@ -33116,7 +33181,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1804,
+        "line": 1806,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33133,7 +33198,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1811
+            "line": 1813
           }
         ],
         "classification": "external",
@@ -33141,7 +33206,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1812,
+        "line": 1814,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -36117,13 +36182,13 @@
       },
       {
         "is_package": false,
-        "loc": 457,
+        "loc": 470,
         "module": "easyuse_anima.aio.model_preparation",
-        "normalized_git_blob_sha1": "9488410f6ea0722496760c6e42aa63eed91e92a2",
+        "normalized_git_blob_sha1": "8b645baae71ac86cc4ba9c5427c0781d644670d7",
         "path": "easyuse_anima/aio/model_preparation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 13,
+          "function_count": 14,
           "global_count": 3
         }
       },
@@ -36729,13 +36794,13 @@
       },
       {
         "is_package": false,
-        "loc": 2659,
+        "loc": 2650,
         "module": "nodes",
-        "normalized_git_blob_sha1": "0680a8e5e7c605c79a50dd2dde5b463c2694defc",
+        "normalized_git_blob_sha1": "5ce6b92bcd7ba6a4b60d83764b764d80034e1b44",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 39,
+          "function_count": 38,
           "global_count": 32
         }
       },
@@ -38095,7 +38160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38104,7 +38169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38118,7 +38183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38127,7 +38192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38141,7 +38206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38150,7 +38215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38164,7 +38229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38173,7 +38238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38187,7 +38252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38196,7 +38261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38210,7 +38275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38219,7 +38284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38233,7 +38298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38242,7 +38307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38256,7 +38321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38265,7 +38330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38279,7 +38344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38288,7 +38353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38302,7 +38367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38311,7 +38376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38325,7 +38390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38334,7 +38399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38348,7 +38413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38357,7 +38422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38371,7 +38436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38380,7 +38445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38394,7 +38459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38403,7 +38468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 552,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38417,7 +38482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38426,7 +38491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 555,
+        "line": 556,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38440,7 +38505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38449,7 +38514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 555,
+        "line": 556,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38463,7 +38528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38472,7 +38537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 555,
+        "line": 556,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38486,7 +38551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38495,7 +38560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 555,
+        "line": 556,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38509,7 +38574,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
+        "kind": "static_from",
+        "line": 562,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38518,7 +38606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38532,7 +38620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38541,7 +38629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38555,7 +38643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38564,7 +38652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38578,7 +38666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38587,7 +38675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38601,7 +38689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38610,7 +38698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38624,7 +38712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38633,7 +38721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38647,7 +38735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38656,7 +38744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38670,7 +38758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38679,7 +38767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38693,7 +38781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38702,7 +38790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38716,7 +38804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38725,7 +38813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38739,7 +38827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38748,7 +38836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38762,7 +38850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38771,7 +38859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38785,7 +38873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38794,7 +38882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38808,7 +38896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38817,7 +38905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38831,7 +38919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38840,7 +38928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38854,7 +38942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38863,7 +38951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38877,7 +38965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38886,7 +38974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38900,7 +38988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38909,7 +38997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38923,7 +39011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38932,7 +39020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38946,7 +39034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38955,7 +39043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38969,7 +39057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -38978,7 +39066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38992,7 +39080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39001,7 +39089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 575,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39015,7 +39103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39024,7 +39112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39038,7 +39126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39047,7 +39135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39061,7 +39149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39070,7 +39158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39084,7 +39172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39093,7 +39181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39107,7 +39195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39116,7 +39204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39130,7 +39218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39139,7 +39227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39153,7 +39241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39162,7 +39250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39176,7 +39264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39185,7 +39273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39199,7 +39287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39208,7 +39296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39222,7 +39310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39231,7 +39319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 587,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39245,7 +39333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39254,7 +39342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39268,7 +39356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39277,7 +39365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39291,7 +39379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39300,7 +39388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39314,7 +39402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39323,7 +39411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39337,7 +39425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39346,7 +39434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39360,7 +39448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39369,7 +39457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39383,7 +39471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39392,7 +39480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39406,7 +39494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39415,7 +39503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39429,7 +39517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39438,7 +39526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39452,7 +39540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39461,7 +39549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39475,7 +39563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39484,7 +39572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39498,7 +39586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39507,7 +39595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39521,7 +39609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39530,7 +39618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39544,7 +39632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39553,7 +39641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39567,7 +39655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39576,7 +39664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39590,7 +39678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39599,7 +39687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39613,7 +39701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39622,7 +39710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39636,7 +39724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39645,7 +39733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39659,7 +39747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39668,7 +39756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39682,7 +39770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39691,7 +39779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39705,7 +39793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39714,7 +39802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39728,7 +39816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39737,7 +39825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39751,7 +39839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39760,7 +39848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39774,7 +39862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39783,7 +39871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39797,7 +39885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39806,7 +39894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 629,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39820,7 +39908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39829,7 +39917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 629,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39843,7 +39931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39852,7 +39940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 629,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39866,7 +39954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39875,7 +39963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 629,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39889,7 +39977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39898,7 +39986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 629,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39912,7 +40000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39921,7 +40009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 636,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39935,7 +40023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39944,7 +40032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39958,7 +40046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39967,7 +40055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39981,7 +40069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -39990,7 +40078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40004,7 +40092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40013,7 +40101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40027,7 +40115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40036,7 +40124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40050,7 +40138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40059,7 +40147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40073,7 +40161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40082,7 +40170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40096,7 +40184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40105,7 +40193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40119,7 +40207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40128,7 +40216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40142,7 +40230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40151,7 +40239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40165,7 +40253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40174,7 +40262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40188,7 +40276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40197,7 +40285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40211,7 +40299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40220,7 +40308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40234,7 +40322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40243,7 +40331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40257,7 +40345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40266,7 +40354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40280,7 +40368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40289,7 +40377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40303,7 +40391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40312,7 +40400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40326,7 +40414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40335,7 +40423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40349,7 +40437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40358,7 +40446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40372,7 +40460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40381,7 +40469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40395,7 +40483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40404,7 +40492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40418,7 +40506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40427,7 +40515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40441,7 +40529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40450,7 +40538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40464,7 +40552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40473,7 +40561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40487,7 +40575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40496,7 +40584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40510,7 +40598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40519,7 +40607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40533,7 +40621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40542,7 +40630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40556,7 +40644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40565,7 +40653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40579,7 +40667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40588,7 +40676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40602,7 +40690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40611,7 +40699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40625,7 +40713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40634,7 +40722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40648,7 +40736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40657,7 +40745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40671,7 +40759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40680,7 +40768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40694,7 +40782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40703,7 +40791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40717,7 +40805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40726,7 +40814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40740,7 +40828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40749,7 +40837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40763,7 +40851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40772,7 +40860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40786,7 +40874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40795,7 +40883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40809,7 +40897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40818,7 +40906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40832,7 +40920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40841,7 +40929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40855,7 +40943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40864,7 +40952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40878,7 +40966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40887,7 +40975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40901,7 +40989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40910,7 +40998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40924,7 +41012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40933,7 +41021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40947,7 +41035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40956,7 +41044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40970,7 +41058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -40979,7 +41067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40993,7 +41081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41002,7 +41090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41016,7 +41104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41025,7 +41113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41039,7 +41127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41048,7 +41136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41062,7 +41150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41071,7 +41159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41085,7 +41173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41094,7 +41182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41108,7 +41196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41117,7 +41205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41131,7 +41219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41140,7 +41228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41154,7 +41242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41163,7 +41251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41177,7 +41265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41186,7 +41274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41200,7 +41288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41209,7 +41297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41223,7 +41311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41232,7 +41320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41246,7 +41334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41255,7 +41343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41269,7 +41357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41278,7 +41366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41292,7 +41380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41301,7 +41389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41315,7 +41403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41324,7 +41412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41338,7 +41426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41347,7 +41435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41361,7 +41449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41370,7 +41458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41384,7 +41472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41393,7 +41481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41407,7 +41495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41416,7 +41504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41430,7 +41518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41439,7 +41527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 739,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41453,7 +41541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41462,7 +41550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41476,7 +41564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41485,7 +41573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41499,7 +41587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41508,7 +41596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41522,7 +41610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41531,7 +41619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41545,7 +41633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41554,7 +41642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41568,7 +41656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41577,7 +41665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41591,7 +41679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41600,7 +41688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41614,7 +41702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41623,7 +41711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41637,7 +41725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41646,7 +41734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41660,7 +41748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41669,7 +41757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41683,7 +41771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41692,7 +41780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41706,7 +41794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41715,7 +41803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41729,7 +41817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41738,7 +41826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41752,7 +41840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41761,7 +41849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41775,7 +41863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41784,7 +41872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41798,7 +41886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41807,7 +41895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41821,7 +41909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41830,7 +41918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41844,7 +41932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41853,7 +41941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41867,7 +41955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41876,7 +41964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41890,7 +41978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41899,7 +41987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41913,7 +42001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41922,7 +42010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41936,7 +42024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41945,7 +42033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41959,7 +42047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41968,7 +42056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41982,7 +42070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -41991,7 +42079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42005,7 +42093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42014,7 +42102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 755,
+        "line": 757,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42028,7 +42116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42037,7 +42125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 835,
+        "line": 837,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42051,7 +42139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42060,7 +42148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 835,
+        "line": 837,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42074,7 +42162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42083,7 +42171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 835,
+        "line": 837,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42097,7 +42185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42106,7 +42194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 835,
+        "line": 837,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42120,7 +42208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42129,7 +42217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 841,
+        "line": 843,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42143,7 +42231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42152,7 +42240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 841,
+        "line": 843,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42166,7 +42254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42175,7 +42263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 841,
+        "line": 843,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42189,7 +42277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42198,7 +42286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 846,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42212,7 +42300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42221,7 +42309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 846,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42235,7 +42323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42244,7 +42332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 846,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42258,7 +42346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42267,7 +42355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 852,
+        "line": 854,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42281,7 +42369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42290,7 +42378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 852,
+        "line": 854,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42304,7 +42392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42313,7 +42401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 852,
+        "line": 854,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42327,7 +42415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42336,7 +42424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 852,
+        "line": 854,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42350,7 +42438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42359,7 +42447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 852,
+        "line": 854,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42373,7 +42461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42382,7 +42470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 859,
+        "line": 861,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42396,7 +42484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42405,7 +42493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 859,
+        "line": 861,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42419,7 +42507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42428,7 +42516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 859,
+        "line": 861,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42442,7 +42530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42451,7 +42539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 870,
+        "line": 872,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42465,7 +42553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42474,7 +42562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 870,
+        "line": 872,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42488,7 +42576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42497,7 +42585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 870,
+        "line": 872,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42511,7 +42599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42520,7 +42608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 870,
+        "line": 872,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42534,7 +42622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42543,7 +42631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 883,
+        "line": 885,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42557,7 +42645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42566,7 +42654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 883,
+        "line": 885,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42580,7 +42668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42589,7 +42677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42603,7 +42691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42612,7 +42700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42626,7 +42714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42635,7 +42723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42649,7 +42737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42658,7 +42746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42672,7 +42760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42681,7 +42769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42695,7 +42783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42704,7 +42792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42718,7 +42806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42727,7 +42815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42741,7 +42829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42750,7 +42838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 891,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42764,7 +42852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42773,7 +42861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42787,7 +42875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42796,7 +42884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42810,7 +42898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42819,7 +42907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42833,7 +42921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42842,7 +42930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42856,7 +42944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42865,7 +42953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42879,7 +42967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42888,7 +42976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42902,7 +42990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42911,7 +42999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42925,7 +43013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42934,7 +43022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42948,7 +43036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42957,7 +43045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42971,7 +43059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -42980,7 +43068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42994,7 +43082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43003,7 +43091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43017,7 +43105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43026,7 +43114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43040,7 +43128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43049,7 +43137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43063,7 +43151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43072,7 +43160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43086,7 +43174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43095,7 +43183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43109,7 +43197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43118,7 +43206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43132,7 +43220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43141,7 +43229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43155,7 +43243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43164,7 +43252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43178,7 +43266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43187,7 +43275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43201,7 +43289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43210,7 +43298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43224,7 +43312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43233,7 +43321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 936,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43247,7 +43335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43256,7 +43344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 936,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43270,7 +43358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43279,7 +43367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 936,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43293,7 +43381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43302,7 +43390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43316,7 +43404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43325,7 +43413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43339,7 +43427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43348,7 +43436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43362,7 +43450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43371,7 +43459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43385,7 +43473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43394,7 +43482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43408,7 +43496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43417,7 +43505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43431,7 +43519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43440,7 +43528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43454,7 +43542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43463,7 +43551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43477,7 +43565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43486,7 +43574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 982,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43500,7 +43588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43509,7 +43597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 982,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43523,7 +43611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43532,7 +43620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43546,7 +43634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43555,7 +43643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43569,7 +43657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43578,7 +43666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43592,7 +43680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43601,7 +43689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43615,7 +43703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43624,7 +43712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43638,7 +43726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43647,7 +43735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43661,7 +43749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43670,7 +43758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43684,7 +43772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43693,7 +43781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43707,7 +43795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43716,7 +43804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43730,7 +43818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43739,7 +43827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43753,7 +43841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43762,7 +43850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43776,7 +43864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43785,7 +43873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43799,7 +43887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43808,7 +43896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43822,7 +43910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43831,7 +43919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43845,7 +43933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43854,7 +43942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43868,7 +43956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43877,7 +43965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43891,7 +43979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43900,7 +43988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43914,7 +44002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43923,7 +44011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43937,7 +44025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43946,7 +44034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43960,7 +44048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43969,7 +44057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43983,7 +44071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -43992,7 +44080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44006,7 +44094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44015,7 +44103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44029,7 +44117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44038,7 +44126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44052,7 +44140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44061,7 +44149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44075,7 +44163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44084,7 +44172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44098,7 +44186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44107,7 +44195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44121,7 +44209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44130,7 +44218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44144,7 +44232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44153,7 +44241,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44167,7 +44255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44176,7 +44264,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44190,7 +44278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44199,7 +44287,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1023,
+        "line": 1025,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44213,7 +44301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44222,7 +44310,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44236,7 +44324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44245,7 +44333,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44259,7 +44347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44268,7 +44356,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44282,7 +44370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44291,7 +44379,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1031,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44305,7 +44393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44314,7 +44402,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1031,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44328,7 +44416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44337,7 +44425,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44351,7 +44439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44360,7 +44448,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44374,7 +44462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44383,7 +44471,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44397,7 +44485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44406,7 +44494,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44420,7 +44508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44429,7 +44517,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44443,7 +44531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44452,7 +44540,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44466,7 +44554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44475,7 +44563,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44489,7 +44577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44498,7 +44586,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44512,7 +44600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44521,7 +44609,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44535,7 +44623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44544,7 +44632,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44558,7 +44646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44567,7 +44655,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44581,7 +44669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44590,7 +44678,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44604,7 +44692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44613,7 +44701,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44627,7 +44715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44636,7 +44724,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44650,7 +44738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44659,7 +44747,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44673,7 +44761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44682,7 +44770,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44696,7 +44784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44705,7 +44793,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44719,7 +44807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44728,7 +44816,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44742,7 +44830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 531,
+            "handler_line": 532,
             "kind": "try",
             "line": 11
           }
@@ -44751,7 +44839,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46244,14 +46332,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 296
+            "line": 309
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 297,
+        "line": 310,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/model_preparation.py"
@@ -48490,14 +48578,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1766
+            "line": 1768
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1767,
+        "line": 1769,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -48509,14 +48597,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1803
+            "line": 1805
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1804,
+        "line": 1806,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -48528,14 +48616,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1811
+            "line": 1813
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1812,
+        "line": 1814,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49182,14 +49270,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 296
+            "line": 309
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 297,
+        "line": 310,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/model_preparation.py"
@@ -49910,14 +49998,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1766
+            "line": 1768
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1767,
+        "line": 1769,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49929,14 +50017,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1803
+            "line": 1805
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1804,
+        "line": 1806,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49948,14 +50036,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1811
+            "line": 1813
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1812,
+        "line": 1814,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51403,7 +51491,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1052,
+        "line": 1054,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51412,7 +51500,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1717,
+        "line": 1719,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51421,7 +51509,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2561,
+        "line": 2552,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51430,7 +51518,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2564,
+        "line": 2555,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51439,7 +51527,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2567,
+        "line": 2558,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51448,7 +51536,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2570,
+        "line": 2561,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51457,7 +51545,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2573,
+        "line": 2564,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51466,7 +51554,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2576,
+        "line": 2567,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51475,7 +51563,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2579,
+        "line": 2570,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51484,7 +51572,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2582,
+        "line": 2573,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51493,7 +51581,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2585,
+        "line": 2576,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51502,7 +51590,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2588,
+        "line": 2579,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51511,7 +51599,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2591,
+        "line": 2582,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51520,7 +51608,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2594,
+        "line": 2585,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51529,7 +51617,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2597,
+        "line": 2588,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51538,7 +51626,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2600,
+        "line": 2591,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51547,7 +51635,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2604,
+        "line": 2595,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51556,7 +51644,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2607,
+        "line": 2598,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51565,7 +51653,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2611,
+        "line": 2602,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51574,7 +51662,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2614,
+        "line": 2605,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51583,7 +51671,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2618,
+        "line": 2609,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51592,7 +51680,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2621,
+        "line": 2612,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51601,7 +51689,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2624,
+        "line": 2615,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51610,7 +51698,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2627,
+        "line": 2618,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51619,7 +51707,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2630,
+        "line": 2621,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51628,7 +51716,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2633,
+        "line": 2624,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51637,7 +51725,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2640,
+        "line": 2631,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51646,7 +51734,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2646,
+        "line": 2637,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51655,7 +51743,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2651,
+        "line": 2642,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51664,7 +51752,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2655,
+        "line": 2646,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52166,25 +52254,25 @@
       },
       {
         "kind": "dict",
-        "line": 1122,
+        "line": 1124,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1111,
+        "line": 1113,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1106,
+        "line": 1108,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "set",
-        "line": 1716,
+        "line": 1718,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "47fef1deebc32644d19caa22add5fee0aa94edbe",
+    "base_commit": "1f18c04f1078b7c547764aa572a6123ba423221d",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -32,7 +32,8 @@
       "B-11b",
       "B-11c1",
       "B-11c2",
-      "B-11c3"
+      "B-11c3",
+      "B-11c4"
     ]
   },
   "enums": {
@@ -67,11 +68,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 263,
+    "nodes_canonical_bindings": 264,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 39,
+    "root_residual_functions": 38,
     "root_residual_classes": 0,
     "root_residual_globals": 32,
     "runtime_binders": 28,
@@ -1967,6 +1968,7 @@
       "id": "nodes_canonical_bindings:easyuse_anima.aio.model_preparation:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "_aio_lora_stack_signature": "_aio_lora_stack_signature",
         "_apply_aio_anima_dave_patch": "_apply_aio_anima_dave_patch",
         "_apply_aio_kj_model_patches": "_apply_aio_kj_model_patches",
         "_apply_aio_lora_stack": "_apply_aio_lora_stack",
@@ -1991,13 +1993,17 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.first_pass_cache",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.model_preparation"
+        "canonical runtime resolver: easyuse_anima.aio.model_preparation",
+        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.first_pass_cache string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.model_preparation string runtime lookup"
+        "AST:easyuse_anima.aio.model_preparation string runtime lookup",
+        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -3917,7 +3923,6 @@
         "_aio_final_fit_size": "_aio_final_fit_size",
         "_aio_generation_settings_json": "_aio_generation_settings_json",
         "_aio_input_settings_json": "_aio_input_settings_json",
-        "_aio_lora_stack_signature": "_aio_lora_stack_signature",
         "_aio_usdu_auto_tile_dimension": "_aio_usdu_auto_tile_dimension",
         "_aio_usdu_tile_plan": "_aio_usdu_tile_plan",
         "_aio_usdu_tile_size": "_aio_usdu_tile_size",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -19,6 +19,7 @@ if str(ROOT) not in sys.path:
 
 import nodes
 from easyuse_anima import workflow
+from easyuse_anima.aio import model_preparation as aio_model_preparation
 from easyuse_anima.common import serialization as common_serialization
 from easyuse_anima.common import values as common_values
 from easyuse_anima.image import detailer as image_detailer
@@ -568,6 +569,55 @@ class CommonHelperMoveContractTests(unittest.TestCase):
             image_geometry._aligned_size_near_scale(128, 64, 2.0, 64, 0),
             (256, 128, 2.0),
         )
+
+
+class AioLoraSignatureMoveContractTests(unittest.TestCase):
+    EXPECTED_SIGNATURE = [
+        {
+            "name": "styles/test.safetensors",
+            "strength_model": 0.8,
+            "strength_clip": 0.6,
+        }
+    ]
+
+    def test_root_alias_and_call_time_normalizer_rebind(self):
+        self.assertIs(
+            nodes._aio_lora_stack_signature,
+            aio_model_preparation._aio_lora_stack_signature,
+        )
+        normalized = [("styles/test.safetensors", 0.8, 0.6)]
+        with patch.object(
+            nodes,
+            "_normalize_aio_lora_stack",
+            return_value=normalized,
+        ) as normalize:
+            self.assertEqual(
+                aio_model_preparation._aio_lora_stack_signature("raw"),
+                self.EXPECTED_SIGNATURE,
+            )
+        normalize.assert_called_once_with("raw")
+
+    def test_package_alias_and_call_time_normalizer_rebind(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_model_preparation = sys.modules[
+                f"{package_name}.easyuse_anima.aio.model_preparation"
+            ]
+            self.assertIs(
+                package_nodes._aio_lora_stack_signature,
+                package_model_preparation._aio_lora_stack_signature,
+            )
+            normalized = [("styles/test.safetensors", 0.8, 0.6)]
+            with patch.object(
+                package_nodes,
+                "_normalize_aio_lora_stack",
+                return_value=normalized,
+            ) as normalize:
+                self.assertEqual(
+                    package_model_preparation._aio_lora_stack_signature("raw"),
+                    self.EXPECTED_SIGNATURE,
+                )
+            normalize.assert_called_once_with("raw")
 
 
 class ComfyAdapterMoveContractTests(unittest.TestCase):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "0680a8e5e7c605c79a50dd2dde5b463c2694defc")
-        # Issue #184 B-11c3 moves the dependency-free image tensor size helper
-        # while preserving the root alias and existing binder/resolver seams.
-        self.assertEqual(report["top_level"]["function_count"], 39)
+        self.assertEqual(report["git_blob_sha1"], "5ce6b92bcd7ba6a4b60d83764b764d80034e1b44")
+        # Issue #184 B-11c4 moves the AiO LoRA stack signature helper while
+        # preserving the root alias and call-time normalizer resolver seam.
+        self.assertEqual(report["top_level"]["function_count"], 38)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_659)
+        self.assertEqual(report["line_count"], 2_650)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "47fef1deebc32644d19caa22add5fee0aa94edbe"
+BASE_COMMIT = "1f18c04f1078b7c547764aa572a6123ba423221d"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1306,6 +1306,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c1",
                 "B-11c2",
                 "B-11c3",
+                "B-11c4",
             ],
         },
         "enums": {
@@ -1318,11 +1319,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 263,
+            "nodes_canonical_bindings": 264,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 39,
+            "root_residual_functions": 38,
             "root_residual_classes": 0,
             "root_residual_globals": 32,
             "runtime_binders": 28,


### PR DESCRIPTION
## 변경 전 inventory

- 기준: `dev` / `1f18c04f1078b7c547764aa572a6123ba423221d`
- 유형: Move-only (`B-11c4 AiO LoRA stack signature residual`)
- 선택 근거:
  - B-11c3 뒤 root `nodes.py`에는 39 functions, 0 classes, 32 globals, 28 runtime binders가 남아 있음.
  - `_aio_lora_stack_signature`는 자체 global/cache/I/O가 없고 기존 canonical LoRA stack normalizer의 출력을 안정된 dict 목록으로 투영하는 단일 함수임.
  - `easyuse_anima.aio.model_preparation`의 기존 runtime resolver를 재사용하면 새 binder나 dependency Contract 없이 call-time root normalization seam을 보존할 수 있음.
  - USDU tile dimension은 root `_align_nearest` call-time seam을 잃지 않으려면 새 dependency seam이 필요하므로 이번 Move보다 뒤로 보류함.
- symbol/caller:
  - `_aio_lora_stack_signature(lora_stack)`는 normalized `(name, model_strength, clip_strength)` 항목을 같은 순서의 `name`, `strength_model`, `strength_clip` dict 목록으로 반환함.
  - 생산 호출자는 `easyuse_anima.nodes.aio_nodes.EasyUseAnimaAIOGenerator.IS_CHANGED`와 `easyuse_anima.aio.first_pass_cache._aio_first_pass_cache_key` 두 곳임.
  - 두 호출자 모두 기존 root runtime resolver로 `_aio_lora_stack_signature`를 호출하며 root 직접 실행 caller는 없음.
- alias/compatibility:
  - 현재는 root definition이며 canonical alias가 없음.
  - 이동 후 root relative/flat import가 같은 canonical function을 direct identity alias로 유지함.
  - moved function은 기존 model-preparation `_runtime_helper("_normalize_aio_lora_stack")`를 사용해 `nodes._normalize_aio_lora_stack`의 call-time 재바인딩을 보존함.
  - `_bind_aio_model_preparation_runtime`, AiO node/first-pass-cache binder와 caller는 변경하지 않음.
- global state:
  - 자체 mutable global, cache, random, lock, file/network I/O를 소유하지 않으며 입력 순서와 normalized 값만 읽음.

## 허용 경계

- production: `easyuse_anima/aio/model_preparation.py`, root `nodes.py`
- focused contracts: normalized signature parity, flat/package root direct identity, call-time root normalizer rebind
- analyzer/compatibility: nodes analyzer baseline, backend analyzer fixture, compatibility surface test/fixture
- status docs: backend execution roadmap, compatibility shim registry

## 금지 경계

- `_normalize_aio_lora_stack` 구현/입출력, LoRA 적용, 이름/strength coercion 변경
- first-pass cache key 구조·정책·state 또는 AiO `IS_CHANGED` 동작 변경
- runtime binder/resolver signature, binding 순서, caller 변경
- AiO seed/settings/upscale/stage/postprocess 또는 wildcard reservation 변경
- B-11c final shim cutover, Phase C Contract/Behavior, Phase E lifecycle

## 구현 결과

- 함수의 list/dict projection을 `easyuse_anima.aio.model_preparation` owner로 이동함.
- normalizer lookup은 기존 module runtime resolver를 사용해 root call-time patch seam을 유지함.
- root `nodes.py` relative/flat model-preparation import가 canonical function을 explicit alias로 re-export함.
- analyzer/compatibility fixture는 canonical binding 264, root residual functions 38, globals 32, binders 28을 기록함.
- backend analyzer의 modules/shipped/closure는 81/81/81, side-effect candidates 188, mutable globals 63, compatibility names 23으로 유지됨.

## 검증

- 정확한 PR head: `1299965ffa4c0462a5b6dcf8664d974f8eac5a76`
- focused `python -m unittest -v`: AiO LoRA signature/model-preparation/first-pass-cache/node 계약, compatibility, nodes/backend analyzer, import boundary 67건 통과
- `tools/check_project.ps1 -Profile full`: Python 890건 통과, frontend 114 JavaScript 파일 통과
- Pyright baseline ratchet: 64파일, 기존 60 errors, 증가 없음
- import boundary: 6 completed package groups, 0 violations
- Ruff report-only: 기존 105 findings, 증가 없음
- `git diff --check`: 통과
- 독립 read-only diff review: 지적사항 없음
- ComfyUI Codex test instance: repository contract/full validation
- Live ComfyUI/browser smoke: 이번 Move-only 단위에서는 미실행

## 남은 위험 / 미확인

- 이 PR은 함수 한 개의 owner만 이동하므로 B-11c와 Phase B를 완료하지 않음.
- AiO seed/settings, Comfy provider wrappers, upscale/stage/postprocess execution, wildcard reservation과 28 binders는 후속 rollback unit으로 남음.
- live ComfyUI/browser 및 package/pack exit 검증은 Phase B exit checkpoint에 남김.
