### PR TITLE
refactor(backend): move AiO Spectrum normalizer residual (B-11c5)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `1f18c04f1078b7c547764aa572a6123ba423221d`
+- Integrated `dev` snapshot commit: `09805305b54932a23db697c04132caaedc95c68b`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c3; B-11c4 LoRA-signature Move in PR #297 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c4; B-11c5 Spectrum-normalizer Move in PR #298 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,659
-  lines after B-11c3.
-- The mechanical extraction has removed 10,004
-  lines, approximately 79.0% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,650
+  lines after B-11c4.
+- The mechanical extraction has removed 10,013
+  lines, approximately 79.1% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -59,7 +59,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   B-11c1 moved shared private input types in PR #294 / `ebeee89`, B-11c2 moved
   the read-only workflow lookup owner in PR #295 / `47fef1d`, and B-11c3 moved
   the dependency-free image tensor size helper in PR #296 / `1f18c04`.
-  B-11c4 moves only the AiO LoRA stack signature helper in PR #297.
+  B-11c4 moved the AiO LoRA stack signature helper in PR #297 / `0980530`.
+  B-11c5 moves only the AiO Spectrum settings normalizer in PR #298.
 
 ### Current quality baseline
 
@@ -301,7 +302,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 LoRA-signature PR #297 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 Spectrum-normalizer PR #298 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -812,6 +813,11 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     alias, both canonical consumer resolver paths, and call-time replacement of
     the root `_normalize_aio_lora_stack` helper; cache policy and `IS_CHANGED`
     behavior remain separate.
+  - B-11c5 moves only `_normalize_aio_spectrum_settings` to its existing sole
+    caller owner, `easyuse_anima.aio.generation_normalization`. PR #298 retains
+    the root direct alias, the existing caller resolver, call-time coercion
+    helper replacement, in-place dict semantics, and exact clamp/fallback order;
+    DiT correction, seed, schema/default, and sampler behavior remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `1f18c04f1078b7c547764aa572a6123ba423221d`
+  `09805305b54932a23db697c04132caaedc95c68b`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c3 are integrated through PR #296. B-11c is
+- Current state: B-11a through B-11c4 are integrated through PR #297. B-11c is
   split into residual-owner and binder Moves before the final root shim;
-  B-11c4 AiO LoRA signature ownership is tracked by PR #297.
+  B-11c5 AiO Spectrum normalizer ownership is tracked by PR #298.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,8 +75,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 264 after
-  B-11c4 (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 265 after
+  B-11c5 (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -84,8 +84,8 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 38 functions, 0 classes, and 32 assigned
-  globals after B-11c4 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 37 functions, 0 classes, and 32 assigned
+  globals after B-11c5 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 256, including
   literal lookups and binder-owned helper-name/default collections;
@@ -203,6 +203,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - The helper only projects normalized entries into the existing ordered
   `name`/`strength_model`/`strength_clip` dictionaries. Cache state, eviction,
   node change-key behavior, random state, and I/O remain unchanged.
+
+### B-11c5 AiO Spectrum settings normalizer alias
+
+- Canonical owner:
+  `easyuse_anima.aio.generation_normalization._normalize_aio_spectrum_settings`.
+- The private root name remains a transitional direct alias. The canonical
+  generation normalizer continues resolving that root name at call time for
+  highres, upscale, and detailer target settings.
+- The moved helper resolves `_as_bool`, `_as_float`, `_as_int`, and `_choice`
+  through the existing generation-normalization runtime seam, preserving root
+  monkeypatch behavior without adding a binder or canonical-to-root import.
+- Dict identity/in-place mutation, unknown keys, defaults, clamp bounds,
+  compatibility policy choices, and nested fallback order remain unchanged in
+  PR #298. DiT correction, seed, schema/default, and sampler execution stay
+  outside this Move.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/generation_normalization.py
+++ b/easyuse_anima/aio/generation_normalization.py
@@ -45,6 +45,115 @@ def _merge_versioned_settings(defaults: dict[str, Any], value) -> dict[str, Any]
     return merge_dict(merged, incoming)
 
 
+def _normalize_aio_spectrum_settings(
+    value,
+    defaults: dict[str, Any],
+) -> dict[str, Any]:
+    _as_bool = _runtime_helper("_as_bool")
+    _as_float = _runtime_helper("_as_float")
+    _as_int = _runtime_helper("_as_int")
+    _choice = _runtime_helper("_choice")
+    spectrum = value if isinstance(value, dict) else {}
+    spectrum["enabled"] = _as_bool(
+        spectrum.get("enabled"),
+        _as_bool(defaults.get("enabled"), False),
+    )
+    spectrum["window_size"] = max(
+        1.0,
+        min(
+            10.0,
+            _as_float(
+                spectrum.get("window_size"),
+                _as_float(defaults.get("window_size"), 2.0),
+            ),
+        ),
+    )
+    spectrum["flex_window"] = max(
+        0.0,
+        min(
+            2.0,
+            _as_float(
+                spectrum.get("flex_window"),
+                _as_float(defaults.get("flex_window"), 0.25),
+            ),
+        ),
+    )
+    spectrum["warmup_steps"] = max(
+        0,
+        min(
+            10000,
+            _as_int(
+                spectrum.get("warmup_steps"),
+                _as_int(defaults.get("warmup_steps"), 6),
+            ),
+        ),
+    )
+    spectrum["tail_actual_steps"] = max(
+        0,
+        min(
+            10000,
+            _as_int(
+                spectrum.get("tail_actual_steps"),
+                _as_int(defaults.get("tail_actual_steps"), 3),
+            ),
+        ),
+    )
+    spectrum["blend_w"] = max(
+        0.0,
+        min(
+            1.0,
+            _as_float(
+                spectrum.get("blend_w"),
+                _as_float(defaults.get("blend_w"), 0.3),
+            ),
+        ),
+    )
+    spectrum["cheby_degree"] = max(
+        1,
+        min(
+            10,
+            _as_int(
+                spectrum.get("cheby_degree"),
+                _as_int(defaults.get("cheby_degree"), 3),
+            ),
+        ),
+    )
+    spectrum["ridge_lambda"] = max(
+        0.001,
+        min(
+            10.0,
+            _as_float(
+                spectrum.get("ridge_lambda"),
+                _as_float(defaults.get("ridge_lambda"), 0.1),
+            ),
+        ),
+    )
+    spectrum["history_size"] = max(
+        5,
+        min(
+            10000,
+            _as_int(
+                spectrum.get("history_size"),
+                _as_int(defaults.get("history_size"), 100),
+            ),
+        ),
+    )
+    spectrum["one_sampler_only"] = _as_bool(
+        spectrum.get("one_sampler_only"),
+        _as_bool(defaults.get("one_sampler_only"), False),
+    )
+    spectrum["verbose"] = _as_bool(
+        spectrum.get("verbose"),
+        _as_bool(defaults.get("verbose"), False),
+    )
+    spectrum["compat_policy"] = _choice(
+        spectrum.get("compat_policy"),
+        ("legacy", "conservative", "strict"),
+        str(defaults.get("compat_policy") or "conservative"),
+    )
+    return spectrum
+
+
 def _normalize_aio_generation_settings(value) -> dict[str, Any]:
     AIO_FINAL_FIT_MODES = _runtime_helper("AIO_FINAL_FIT_MODES")
     AIO_FINAL_UPSCALE_BACKENDS = _runtime_helper("AIO_FINAL_UPSCALE_BACKENDS")

--- a/nodes.py
+++ b/nodes.py
@@ -28,6 +28,7 @@ try:
         _bind_aio_generation_normalization_runtime as _bind_aio_generation_normalization_runtime,
         _merge_versioned_settings as _merge_versioned_settings,
         _normalize_aio_generation_settings as _normalize_aio_generation_settings,
+        _normalize_aio_spectrum_settings as _normalize_aio_spectrum_settings,
     )
     from .easyuse_anima.aio.generation_settings import (
         round_trip_aio_generation_settings as _round_trip_aio_generation_settings,
@@ -549,6 +550,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _bind_aio_generation_normalization_runtime as _bind_aio_generation_normalization_runtime,
         _merge_versioned_settings as _merge_versioned_settings,
         _normalize_aio_generation_settings as _normalize_aio_generation_settings,
+        _normalize_aio_spectrum_settings as _normalize_aio_spectrum_settings,
     )
     from easyuse_anima.aio.generation_settings import (
         round_trip_aio_generation_settings as _round_trip_aio_generation_settings,
@@ -1600,54 +1602,6 @@ def _normalize_aio_input_settings(value) -> dict[str, Any]:
         "default",
     )
     return settings
-
-
-def _normalize_aio_spectrum_settings(value, defaults: dict[str, Any]) -> dict[str, Any]:
-    spectrum = value if isinstance(value, dict) else {}
-    spectrum["enabled"] = _as_bool(spectrum.get("enabled"), _as_bool(defaults.get("enabled"), False))
-    spectrum["window_size"] = max(
-        1.0,
-        min(10.0, _as_float(spectrum.get("window_size"), _as_float(defaults.get("window_size"), 2.0))),
-    )
-    spectrum["flex_window"] = max(
-        0.0,
-        min(2.0, _as_float(spectrum.get("flex_window"), _as_float(defaults.get("flex_window"), 0.25))),
-    )
-    spectrum["warmup_steps"] = max(
-        0,
-        min(10000, _as_int(spectrum.get("warmup_steps"), _as_int(defaults.get("warmup_steps"), 6))),
-    )
-    spectrum["tail_actual_steps"] = max(
-        0,
-        min(10000, _as_int(spectrum.get("tail_actual_steps"), _as_int(defaults.get("tail_actual_steps"), 3))),
-    )
-    spectrum["blend_w"] = max(
-        0.0,
-        min(1.0, _as_float(spectrum.get("blend_w"), _as_float(defaults.get("blend_w"), 0.3))),
-    )
-    spectrum["cheby_degree"] = max(
-        1,
-        min(10, _as_int(spectrum.get("cheby_degree"), _as_int(defaults.get("cheby_degree"), 3))),
-    )
-    spectrum["ridge_lambda"] = max(
-        0.001,
-        min(10.0, _as_float(spectrum.get("ridge_lambda"), _as_float(defaults.get("ridge_lambda"), 0.1))),
-    )
-    spectrum["history_size"] = max(
-        5,
-        min(10000, _as_int(spectrum.get("history_size"), _as_int(defaults.get("history_size"), 100))),
-    )
-    spectrum["one_sampler_only"] = _as_bool(
-        spectrum.get("one_sampler_only"),
-        _as_bool(defaults.get("one_sampler_only"), False),
-    )
-    spectrum["verbose"] = _as_bool(spectrum.get("verbose"), _as_bool(defaults.get("verbose"), False))
-    spectrum["compat_policy"] = _choice(
-        spectrum.get("compat_policy"),
-        ("legacy", "conservative", "strict"),
-        str(defaults.get("compat_policy") or "conservative"),
-    )
-    return spectrum
 
 
 def _normalize_aio_dit_corrections_settings(value, defaults: dict[str, Any]) -> dict[str, Any]:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14628,6 +14628,37 @@
         "target": "easyuse_anima/aio/generation_normalization.py"
       },
       {
+        "alias": "_normalize_aio_spectrum_settings",
+        "bound_name": "_normalize_aio_spectrum_settings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_aio_spectrum_settings",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_normalize_aio_spectrum_settings",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
         "alias": "_round_trip_aio_generation_settings",
         "bound_name": "_round_trip_aio_generation_settings",
         "branch_context": [
@@ -14649,7 +14680,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 32,
+        "line": 33,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -14680,7 +14711,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 35,
+        "line": 36,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14711,7 +14742,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 35,
+        "line": 36,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14742,7 +14773,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 35,
+        "line": 36,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14773,7 +14804,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 35,
+        "line": 36,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14804,7 +14835,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14835,7 +14866,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14866,7 +14897,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14897,7 +14928,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14928,7 +14959,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14959,7 +14990,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14990,7 +15021,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15021,7 +15052,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15052,7 +15083,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15083,7 +15114,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15114,7 +15145,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15145,7 +15176,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15176,7 +15207,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15207,7 +15238,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15238,7 +15269,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15269,7 +15300,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15300,7 +15331,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15331,7 +15362,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15362,7 +15393,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15393,7 +15424,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15424,7 +15455,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15455,7 +15486,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15486,7 +15517,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15517,7 +15548,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15548,7 +15579,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15579,7 +15610,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15610,7 +15641,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15641,7 +15672,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15672,7 +15703,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15703,7 +15734,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15734,7 +15765,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15765,7 +15796,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15796,7 +15827,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15827,7 +15858,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15858,7 +15889,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15889,7 +15920,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15920,7 +15951,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15951,7 +15982,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15982,7 +16013,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16013,7 +16044,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16044,7 +16075,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16075,7 +16106,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16106,7 +16137,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16137,7 +16168,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16168,7 +16199,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16199,7 +16230,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16230,7 +16261,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16261,7 +16292,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16292,7 +16323,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16323,7 +16354,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16354,7 +16385,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16385,7 +16416,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16416,7 +16447,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16447,7 +16478,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16478,7 +16509,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16509,7 +16540,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16540,7 +16571,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16571,7 +16602,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16602,7 +16633,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16633,7 +16664,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16664,7 +16695,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16695,7 +16726,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16726,7 +16757,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -16757,7 +16788,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16788,7 +16819,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16819,7 +16850,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16850,7 +16881,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16881,7 +16912,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 124,
+        "line": 125,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16912,7 +16943,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 124,
+        "line": 125,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16943,7 +16974,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 124,
+        "line": 125,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16974,7 +17005,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 124,
+        "line": 125,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17005,7 +17036,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 124,
+        "line": 125,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17036,7 +17067,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 124,
+        "line": 125,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17067,7 +17098,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 124,
+        "line": 125,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17098,7 +17129,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 124,
+        "line": 125,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17129,7 +17160,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 124,
+        "line": 125,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17160,7 +17191,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 124,
+        "line": 125,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17191,7 +17222,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17222,7 +17253,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17253,7 +17284,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17284,7 +17315,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17315,7 +17346,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17346,7 +17377,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17377,7 +17408,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17408,7 +17439,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17439,7 +17470,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17470,7 +17501,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17501,7 +17532,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17532,7 +17563,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17563,7 +17594,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17594,7 +17625,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17625,7 +17656,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17656,7 +17687,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17687,7 +17718,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17718,7 +17749,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17749,7 +17780,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17780,7 +17811,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17811,7 +17842,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17842,7 +17873,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17873,7 +17904,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17904,7 +17935,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17935,7 +17966,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17966,7 +17997,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17997,7 +18028,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18028,7 +18059,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18059,7 +18090,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18090,7 +18121,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18121,7 +18152,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18152,7 +18183,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18183,7 +18214,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18214,7 +18245,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18245,7 +18276,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18276,7 +18307,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18307,7 +18338,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18338,7 +18369,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18369,7 +18400,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18400,7 +18431,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18431,7 +18462,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18462,7 +18493,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18493,7 +18524,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18524,7 +18555,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18555,7 +18586,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18586,7 +18617,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18617,7 +18648,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18648,7 +18679,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18679,7 +18710,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18710,7 +18741,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18741,7 +18772,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18772,7 +18803,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18803,7 +18834,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18834,7 +18865,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18865,7 +18896,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18896,7 +18927,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18927,7 +18958,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18958,7 +18989,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18989,7 +19020,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19020,7 +19051,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19051,7 +19082,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19082,7 +19113,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19113,7 +19144,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19144,7 +19175,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19175,7 +19206,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19206,7 +19237,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19237,7 +19268,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19268,7 +19299,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19299,7 +19330,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19330,7 +19361,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19361,7 +19392,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19392,7 +19423,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19423,7 +19454,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19454,7 +19485,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19485,7 +19516,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19516,7 +19547,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19547,7 +19578,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 236,
+        "line": 237,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19578,7 +19609,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 316,
+        "line": 317,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19609,7 +19640,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 316,
+        "line": 317,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19640,7 +19671,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 316,
+        "line": 317,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19671,7 +19702,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 316,
+        "line": 317,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19702,7 +19733,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 322,
+        "line": 323,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19733,7 +19764,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 322,
+        "line": 323,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19764,7 +19795,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 322,
+        "line": 323,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19795,7 +19826,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 327,
+        "line": 328,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19826,7 +19857,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 327,
+        "line": 328,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19857,7 +19888,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 327,
+        "line": 328,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19888,7 +19919,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19919,7 +19950,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19950,7 +19981,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19981,7 +20012,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20012,7 +20043,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20043,7 +20074,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20074,7 +20105,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20105,7 +20136,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20136,7 +20167,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20167,7 +20198,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20198,7 +20229,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20229,7 +20260,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20260,7 +20291,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 364,
+        "line": 365,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20291,7 +20322,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 364,
+        "line": 365,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20322,7 +20353,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 372,
+        "line": 373,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20353,7 +20384,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 372,
+        "line": 373,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20384,7 +20415,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 372,
+        "line": 373,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20415,7 +20446,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 372,
+        "line": 373,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20446,7 +20477,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 372,
+        "line": 373,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20477,7 +20508,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 372,
+        "line": 373,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20508,7 +20539,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 372,
+        "line": 373,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20539,7 +20570,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 372,
+        "line": 373,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20570,7 +20601,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20601,7 +20632,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20632,7 +20663,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20663,7 +20694,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20694,7 +20725,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 389,
+        "line": 390,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20725,7 +20756,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 389,
+        "line": 390,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20756,7 +20787,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 389,
+        "line": 390,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20787,7 +20818,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 389,
+        "line": 390,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20818,7 +20849,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 389,
+        "line": 390,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20849,7 +20880,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 397,
+        "line": 398,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20880,7 +20911,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 397,
+        "line": 398,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20911,7 +20942,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -20942,7 +20973,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 405,
+        "line": 406,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -20973,7 +21004,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 405,
+        "line": 406,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21004,7 +21035,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 405,
+        "line": 406,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21035,7 +21066,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21066,7 +21097,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21097,7 +21128,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21128,7 +21159,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21159,7 +21190,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21190,7 +21221,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 417,
+        "line": 418,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21221,7 +21252,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 417,
+        "line": 418,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21252,7 +21283,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 417,
+        "line": 418,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21283,7 +21314,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 422,
+        "line": 423,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21314,7 +21345,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 422,
+        "line": 423,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21345,7 +21376,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 422,
+        "line": 423,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21376,7 +21407,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21407,7 +21438,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21438,7 +21469,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21469,7 +21500,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21500,7 +21531,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21531,7 +21562,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 463,
+        "line": 464,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21562,7 +21593,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 463,
+        "line": 464,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21593,7 +21624,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 467,
+        "line": 468,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21624,7 +21655,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 467,
+        "line": 468,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21655,7 +21686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21686,7 +21717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21717,7 +21748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21748,7 +21779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21779,7 +21810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21810,7 +21841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21841,7 +21872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21872,7 +21903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21903,7 +21934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21934,7 +21965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21965,7 +21996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21996,7 +22027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22027,7 +22058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22058,7 +22089,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22089,7 +22120,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22120,7 +22151,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 489,
+        "line": 490,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22151,7 +22182,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 489,
+        "line": 490,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22182,7 +22213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 489,
+        "line": 490,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22213,7 +22244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 489,
+        "line": 490,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22244,7 +22275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 489,
+        "line": 490,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22275,7 +22306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 489,
+        "line": 490,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22306,7 +22337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 489,
+        "line": 490,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22337,7 +22368,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 489,
+        "line": 490,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22368,7 +22399,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22399,7 +22430,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22430,7 +22461,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22461,7 +22492,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22492,7 +22523,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -22523,7 +22554,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -22554,7 +22585,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -22585,7 +22616,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -22616,7 +22647,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22647,7 +22678,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22678,7 +22709,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22709,7 +22740,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22740,7 +22771,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22771,7 +22802,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22802,7 +22833,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22833,7 +22864,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22864,7 +22895,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22895,7 +22926,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22926,7 +22957,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22957,7 +22988,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22988,7 +23019,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23019,7 +23050,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23050,7 +23081,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23081,7 +23112,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23112,7 +23143,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23143,7 +23174,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23174,7 +23205,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23205,7 +23236,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23236,7 +23267,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23255,7 +23286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23270,7 +23301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23289,7 +23320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23304,7 +23335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23323,7 +23354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23338,7 +23369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23357,7 +23388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23391,7 +23422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23406,7 +23437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23425,7 +23456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23440,7 +23471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23459,7 +23490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23474,7 +23505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23493,7 +23524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23508,7 +23539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23527,7 +23558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23542,7 +23573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23561,7 +23592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23576,7 +23607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23595,7 +23626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23610,7 +23641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23629,7 +23660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23644,7 +23675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23663,7 +23694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23678,8 +23709,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "_normalize_aio_generation_settings",
+        "optional": false,
+        "requested": "easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": "_normalize_aio_spectrum_settings",
+        "bound_name": "_normalize_aio_spectrum_settings",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 533,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_aio_spectrum_settings",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
+        "kind": "static_from",
+        "line": 549,
+        "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
         "role": "compatibility_fallback",
@@ -23697,7 +23762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23712,7 +23777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -23731,7 +23796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23746,7 +23811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 556,
+        "line": 558,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23765,7 +23830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23780,7 +23845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 556,
+        "line": 558,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23799,7 +23864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23814,7 +23879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 556,
+        "line": 558,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23833,7 +23898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23848,7 +23913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 556,
+        "line": 558,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23867,7 +23932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23882,7 +23947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23901,7 +23966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23916,7 +23981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23935,7 +24000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23950,7 +24015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23969,7 +24034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -23984,7 +24049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24003,7 +24068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24018,7 +24083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24037,7 +24102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24052,7 +24117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24071,7 +24136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24086,7 +24151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24105,7 +24170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24120,7 +24185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24139,7 +24204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24154,7 +24219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24173,7 +24238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24188,7 +24253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24207,7 +24272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24222,7 +24287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24241,7 +24306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24256,7 +24321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24275,7 +24340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24290,7 +24355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24309,7 +24374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24324,7 +24389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24343,7 +24408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24358,7 +24423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24377,7 +24442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24392,7 +24457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24411,7 +24476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24426,7 +24491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24445,7 +24510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24460,7 +24525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24479,7 +24544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24494,7 +24559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24513,7 +24578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24528,7 +24593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24547,7 +24612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24562,7 +24627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24581,7 +24646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24596,7 +24661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24615,7 +24680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24630,7 +24695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24649,7 +24714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24664,7 +24729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24683,7 +24748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24698,7 +24763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24717,7 +24782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24732,7 +24797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24751,7 +24816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24766,7 +24831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24785,7 +24850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24800,7 +24865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24819,7 +24884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24834,7 +24899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24853,7 +24918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24868,7 +24933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24887,7 +24952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24902,7 +24967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24921,7 +24986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24936,7 +25001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24955,7 +25020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -24970,7 +25035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24989,7 +25054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25004,7 +25069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25023,7 +25088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25038,7 +25103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25057,7 +25122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25072,7 +25137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25091,7 +25156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25106,7 +25171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25125,7 +25190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25140,7 +25205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25159,7 +25224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25174,7 +25239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25193,7 +25258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25208,7 +25273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25227,7 +25292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25242,7 +25307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25261,7 +25326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25276,7 +25341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25295,7 +25360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25310,7 +25375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25329,7 +25394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25344,7 +25409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25363,7 +25428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25378,7 +25443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25397,7 +25462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25412,7 +25477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25431,7 +25496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25446,7 +25511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25465,7 +25530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25480,7 +25545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25499,7 +25564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25514,7 +25579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25533,7 +25598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25548,7 +25613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25567,7 +25632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25582,7 +25647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25601,7 +25666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25616,7 +25681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25635,7 +25700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25650,7 +25715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25669,7 +25734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25684,7 +25749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25703,7 +25768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25718,7 +25783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25737,7 +25802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25752,7 +25817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25771,7 +25836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25786,7 +25851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25805,7 +25870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25820,7 +25885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25839,7 +25904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25854,7 +25919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25873,7 +25938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25888,7 +25953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25907,7 +25972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25922,7 +25987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25941,7 +26006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25956,7 +26021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25975,7 +26040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -25990,7 +26055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 638,
+        "line": 640,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -26009,7 +26074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26024,7 +26089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26043,7 +26108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26058,7 +26123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26077,7 +26142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26092,7 +26157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26111,7 +26176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26126,7 +26191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26145,7 +26210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26160,7 +26225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26179,7 +26244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26194,7 +26259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26213,7 +26278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26228,7 +26293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26247,7 +26312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26262,7 +26327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26281,7 +26346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26296,7 +26361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26315,7 +26380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26330,7 +26395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26349,7 +26414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26364,7 +26429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26383,7 +26448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26398,7 +26463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26417,7 +26482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26432,7 +26497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26451,7 +26516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26466,7 +26531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26485,7 +26550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26500,7 +26565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26519,7 +26584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26534,7 +26599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26553,7 +26618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26568,7 +26633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26587,7 +26652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26602,7 +26667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26621,7 +26686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26636,7 +26701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26655,7 +26720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26670,7 +26735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26689,7 +26754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26704,7 +26769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26723,7 +26788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26738,7 +26803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26757,7 +26822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26772,7 +26837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26791,7 +26856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26806,7 +26871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26825,7 +26890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26840,7 +26905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26859,7 +26924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26874,7 +26939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26893,7 +26958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26908,7 +26973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26927,7 +26992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26942,7 +27007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26961,7 +27026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -26976,7 +27041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26995,7 +27060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27010,7 +27075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27029,7 +27094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27044,7 +27109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27063,7 +27128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27078,7 +27143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27097,7 +27162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27112,7 +27177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27131,7 +27196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27146,7 +27211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27165,7 +27230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27180,7 +27245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27199,7 +27264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27214,7 +27279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27233,7 +27298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27248,7 +27313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27267,7 +27332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27282,7 +27347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27301,7 +27366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27316,7 +27381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27335,7 +27400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27350,7 +27415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27369,7 +27434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27384,7 +27449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27403,7 +27468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27418,7 +27483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27437,7 +27502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27452,7 +27517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27471,7 +27536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27486,7 +27551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27505,7 +27570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27520,7 +27585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27539,7 +27604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27554,7 +27619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27573,7 +27638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27588,7 +27653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27607,7 +27672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27622,7 +27687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27641,7 +27706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27656,7 +27721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27675,7 +27740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27690,7 +27755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27709,7 +27774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27724,7 +27789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27743,7 +27808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27758,7 +27823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27777,7 +27842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27792,7 +27857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27811,7 +27876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27826,7 +27891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27845,7 +27910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27860,7 +27925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27879,7 +27944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27894,7 +27959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27913,7 +27978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27928,7 +27993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27947,7 +28012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27962,7 +28027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -27981,7 +28046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -27996,7 +28061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28015,7 +28080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28030,7 +28095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28049,7 +28114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28064,7 +28129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28083,7 +28148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28098,7 +28163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28117,7 +28182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28132,7 +28197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28151,7 +28216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28166,7 +28231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28185,7 +28250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28200,7 +28265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28219,7 +28284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28234,7 +28299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28253,7 +28318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28268,7 +28333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28287,7 +28352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28302,7 +28367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28321,7 +28386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28336,7 +28401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28355,7 +28420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28370,7 +28435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28389,7 +28454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28404,7 +28469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28423,7 +28488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28438,7 +28503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28457,7 +28522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28472,7 +28537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28491,7 +28556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28506,7 +28571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28525,7 +28590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28540,7 +28605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28559,7 +28624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28574,7 +28639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28593,7 +28658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28608,7 +28673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28627,7 +28692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28642,7 +28707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28661,7 +28726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28676,7 +28741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28695,7 +28760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28710,7 +28775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28729,7 +28794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28744,7 +28809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28763,7 +28828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28778,7 +28843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28797,7 +28862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28812,7 +28877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28831,7 +28896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28846,7 +28911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28865,7 +28930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28880,7 +28945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28899,7 +28964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28914,7 +28979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28933,7 +28998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28948,7 +29013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28967,7 +29032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -28982,7 +29047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29001,7 +29066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29016,7 +29081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29035,7 +29100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29050,7 +29115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29069,7 +29134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29084,7 +29149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29103,7 +29168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29118,7 +29183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 837,
+        "line": 839,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29137,7 +29202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29152,7 +29217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 837,
+        "line": 839,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29171,7 +29236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29186,7 +29251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 837,
+        "line": 839,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29205,7 +29270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29220,7 +29285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 837,
+        "line": 839,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29239,7 +29304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29254,7 +29319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 843,
+        "line": 845,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29273,7 +29338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29288,7 +29353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 843,
+        "line": 845,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29307,7 +29372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29322,7 +29387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 843,
+        "line": 845,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29341,7 +29406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29356,7 +29421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 848,
+        "line": 850,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29375,7 +29440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29390,7 +29455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 848,
+        "line": 850,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29409,7 +29474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29424,7 +29489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 848,
+        "line": 850,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29443,7 +29508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29458,7 +29523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 854,
+        "line": 856,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29477,7 +29542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29492,7 +29557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 854,
+        "line": 856,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29511,7 +29576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29526,7 +29591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 854,
+        "line": 856,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29545,7 +29610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29560,7 +29625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 854,
+        "line": 856,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29579,7 +29644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29594,7 +29659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 854,
+        "line": 856,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29613,7 +29678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29628,7 +29693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 861,
+        "line": 863,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29647,7 +29712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29662,7 +29727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 861,
+        "line": 863,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29681,7 +29746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29696,7 +29761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 861,
+        "line": 863,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29715,7 +29780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29730,7 +29795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29749,7 +29814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29764,7 +29829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29783,7 +29848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29798,7 +29863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29817,7 +29882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29832,7 +29897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29851,7 +29916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29866,7 +29931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 885,
+        "line": 887,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -29885,7 +29950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29900,7 +29965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 885,
+        "line": 887,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -29919,7 +29984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29934,7 +29999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29953,7 +30018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -29968,7 +30033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -29987,7 +30052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30002,7 +30067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30021,7 +30086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30036,7 +30101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30055,7 +30120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30070,7 +30135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30089,7 +30154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30104,7 +30169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30123,7 +30188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30138,7 +30203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30157,7 +30222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30172,7 +30237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30191,7 +30256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30206,7 +30271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30225,7 +30290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30240,7 +30305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30259,7 +30324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30274,7 +30339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30293,7 +30358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30308,7 +30373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30327,7 +30392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30342,7 +30407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30361,7 +30426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30376,7 +30441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30395,7 +30460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30410,7 +30475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30429,7 +30494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30444,7 +30509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30463,7 +30528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30478,7 +30543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30497,7 +30562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30512,7 +30577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30531,7 +30596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30546,7 +30611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30565,7 +30630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30580,7 +30645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -30599,7 +30664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30614,7 +30679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30633,7 +30698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30648,7 +30713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30667,7 +30732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30682,7 +30747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30701,7 +30766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30716,7 +30781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30735,7 +30800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30750,7 +30815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30769,7 +30834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30784,7 +30849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30803,7 +30868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30818,7 +30883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30837,7 +30902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30852,7 +30917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30871,7 +30936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30886,7 +30951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30905,7 +30970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30920,7 +30985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30939,7 +31004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30954,7 +31019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30973,7 +31038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -30988,7 +31053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31007,7 +31072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31022,7 +31087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31041,7 +31106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31056,7 +31121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31075,7 +31140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31090,7 +31155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31109,7 +31174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31124,7 +31189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31143,7 +31208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31158,7 +31223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31177,7 +31242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31192,7 +31257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31211,7 +31276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31226,7 +31291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31245,7 +31310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31260,7 +31325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31279,7 +31344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31294,7 +31359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31313,7 +31378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31328,7 +31393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31347,7 +31412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31362,7 +31427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31381,7 +31446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31396,7 +31461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31415,7 +31480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31430,7 +31495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31449,7 +31514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31464,7 +31529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31483,7 +31548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31498,7 +31563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31517,7 +31582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31532,7 +31597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31551,7 +31616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31566,7 +31631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31585,7 +31650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31600,7 +31665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31619,7 +31684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31634,7 +31699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31653,7 +31718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31668,7 +31733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31687,7 +31752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31702,7 +31767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31721,7 +31786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31736,7 +31801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31755,7 +31820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31770,7 +31835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31789,7 +31854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31804,7 +31869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31823,7 +31888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31838,7 +31903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31857,7 +31922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31872,7 +31937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31891,7 +31956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31906,7 +31971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31925,7 +31990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31940,7 +32005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31959,7 +32024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -31974,7 +32039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31993,7 +32058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32008,7 +32073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32027,7 +32092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32042,7 +32107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32061,7 +32126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32076,7 +32141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32095,7 +32160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32110,7 +32175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32129,7 +32194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32144,7 +32209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32163,7 +32228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32178,7 +32243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32197,7 +32262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32212,7 +32277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32231,7 +32296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32246,7 +32311,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -32265,7 +32330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32280,7 +32345,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -32299,7 +32364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32314,7 +32379,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1027,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -32333,7 +32398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32348,7 +32413,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -32367,7 +32432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32382,7 +32447,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -32401,7 +32466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32416,7 +32481,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -32435,7 +32500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32450,7 +32515,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1033,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32469,7 +32534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32484,7 +32549,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1033,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32503,7 +32568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32518,7 +32583,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32537,7 +32602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32552,7 +32617,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32571,7 +32636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32586,7 +32651,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32605,7 +32670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32620,7 +32685,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32639,7 +32704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32654,7 +32719,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32673,7 +32738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32688,7 +32753,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32707,7 +32772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32722,7 +32787,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32741,7 +32806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32756,7 +32821,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32775,7 +32840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32790,7 +32855,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32809,7 +32874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32824,7 +32889,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32843,7 +32908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32858,7 +32923,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32877,7 +32942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32892,7 +32957,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32911,7 +32976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32926,7 +32991,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32945,7 +33010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32960,7 +33025,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32979,7 +33044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -32994,7 +33059,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33013,7 +33078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -33028,7 +33093,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33047,7 +33112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -33062,7 +33127,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33081,7 +33146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -33096,7 +33161,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33115,7 +33180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -33130,7 +33195,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33148,7 +33213,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1768
+            "line": 1722
           }
         ],
         "classification": "external",
@@ -33156,7 +33221,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1769,
+        "line": 1723,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33173,7 +33238,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1805
+            "line": 1759
           }
         ],
         "classification": "external",
@@ -33181,7 +33246,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1806,
+        "line": 1760,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33198,7 +33263,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1813
+            "line": 1767
           }
         ],
         "classification": "external",
@@ -33206,7 +33271,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1814,
+        "line": 1768,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -36110,13 +36175,13 @@
       },
       {
         "is_package": false,
-        "loc": 734,
+        "loc": 843,
         "module": "easyuse_anima.aio.generation_normalization",
-        "normalized_git_blob_sha1": "22ac54d0d14cded44ea76aa087e81fa40478c1d4",
+        "normalized_git_blob_sha1": "96eb4f5e7950170397346caec0b3ee6cb6e19f12",
         "path": "easyuse_anima/aio/generation_normalization.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 4,
+          "function_count": 5,
           "global_count": 3
         }
       },
@@ -36794,13 +36859,13 @@
       },
       {
         "is_package": false,
-        "loc": 2650,
+        "loc": 2604,
         "module": "nodes",
-        "normalized_git_blob_sha1": "5ce6b92bcd7ba6a4b60d83764b764d80034e1b44",
+        "normalized_git_blob_sha1": "0fd503050bfa9b8881df791bf4c13b5f278133bd",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 38,
+          "function_count": 37,
           "global_count": 32
         }
       },
@@ -38160,7 +38225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38169,7 +38234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38183,7 +38248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38192,7 +38257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38206,7 +38271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38215,7 +38280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38229,7 +38294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38238,7 +38303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38252,7 +38317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38261,7 +38326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38275,7 +38340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38284,7 +38349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38298,7 +38363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38307,7 +38372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38321,7 +38386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38330,7 +38395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38344,7 +38409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38353,7 +38418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38367,7 +38432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38376,7 +38441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38390,7 +38455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38399,7 +38464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38413,7 +38478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38422,7 +38487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38436,7 +38501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38445,7 +38510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38459,7 +38524,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
+        "kind": "static_from",
+        "line": 549,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38468,7 +38556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38482,7 +38570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38491,7 +38579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 556,
+        "line": 558,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38505,7 +38593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38514,7 +38602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 556,
+        "line": 558,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38528,7 +38616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38537,7 +38625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 556,
+        "line": 558,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38551,7 +38639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38560,7 +38648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 556,
+        "line": 558,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38574,7 +38662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38583,7 +38671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38597,7 +38685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38606,7 +38694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38620,7 +38708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38629,7 +38717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38643,7 +38731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38652,7 +38740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38666,7 +38754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38675,7 +38763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38689,7 +38777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38698,7 +38786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38712,7 +38800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38721,7 +38809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38735,7 +38823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38744,7 +38832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38758,7 +38846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38767,7 +38855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38781,7 +38869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38790,7 +38878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38804,7 +38892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38813,7 +38901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38827,7 +38915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38836,7 +38924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38850,7 +38938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38859,7 +38947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 562,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38873,7 +38961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38882,7 +38970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38896,7 +38984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38905,7 +38993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38919,7 +39007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38928,7 +39016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38942,7 +39030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38951,7 +39039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38965,7 +39053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38974,7 +39062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38988,7 +39076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -38997,7 +39085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39011,7 +39099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39020,7 +39108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39034,7 +39122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39043,7 +39131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39057,7 +39145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39066,7 +39154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39080,7 +39168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39089,7 +39177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 577,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39103,7 +39191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39112,7 +39200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39126,7 +39214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39135,7 +39223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39149,7 +39237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39158,7 +39246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39172,7 +39260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39181,7 +39269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39195,7 +39283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39204,7 +39292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39218,7 +39306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39227,7 +39315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39241,7 +39329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39250,7 +39338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39264,7 +39352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39273,7 +39361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39287,7 +39375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39296,7 +39384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39310,7 +39398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39319,7 +39407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 589,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39333,7 +39421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39342,7 +39430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39356,7 +39444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39365,7 +39453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39379,7 +39467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39388,7 +39476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39402,7 +39490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39411,7 +39499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39425,7 +39513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39434,7 +39522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39448,7 +39536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39457,7 +39545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39471,7 +39559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39480,7 +39568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39494,7 +39582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39503,7 +39591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39517,7 +39605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39526,7 +39614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39540,7 +39628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39549,7 +39637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39563,7 +39651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39572,7 +39660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39586,7 +39674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39595,7 +39683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39609,7 +39697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39618,7 +39706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39632,7 +39720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39641,7 +39729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39655,7 +39743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39664,7 +39752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39678,7 +39766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39687,7 +39775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39701,7 +39789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39710,7 +39798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39724,7 +39812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39733,7 +39821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39747,7 +39835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39756,7 +39844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39770,7 +39858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39779,7 +39867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39793,7 +39881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39802,7 +39890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 613,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39816,7 +39904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39825,7 +39913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39839,7 +39927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39848,7 +39936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39862,7 +39950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39871,7 +39959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39885,7 +39973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39894,7 +39982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39908,7 +39996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39917,7 +40005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39931,7 +40019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39940,7 +40028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39954,7 +40042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39963,7 +40051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39977,7 +40065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -39986,7 +40074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40000,7 +40088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40009,7 +40097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 638,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40023,7 +40111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40032,7 +40120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40046,7 +40134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40055,7 +40143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40069,7 +40157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40078,7 +40166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40092,7 +40180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40101,7 +40189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40115,7 +40203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40124,7 +40212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40138,7 +40226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40147,7 +40235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40161,7 +40249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40170,7 +40258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40184,7 +40272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40193,7 +40281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40207,7 +40295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40216,7 +40304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40230,7 +40318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40239,7 +40327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40253,7 +40341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40262,7 +40350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40276,7 +40364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40285,7 +40373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40299,7 +40387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40308,7 +40396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40322,7 +40410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40331,7 +40419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40345,7 +40433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40354,7 +40442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40368,7 +40456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40377,7 +40465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40391,7 +40479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40400,7 +40488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40414,7 +40502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40423,7 +40511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40437,7 +40525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40446,7 +40534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40460,7 +40548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40469,7 +40557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40483,7 +40571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40492,7 +40580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40506,7 +40594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40515,7 +40603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40529,7 +40617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40538,7 +40626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40552,7 +40640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40561,7 +40649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40575,7 +40663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40584,7 +40672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40598,7 +40686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40607,7 +40695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40621,7 +40709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40630,7 +40718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40644,7 +40732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40653,7 +40741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40667,7 +40755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40676,7 +40764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40690,7 +40778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40699,7 +40787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40713,7 +40801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40722,7 +40810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40736,7 +40824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40745,7 +40833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40759,7 +40847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40768,7 +40856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40782,7 +40870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40791,7 +40879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40805,7 +40893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40814,7 +40902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40828,7 +40916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40837,7 +40925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40851,7 +40939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40860,7 +40948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40874,7 +40962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40883,7 +40971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40897,7 +40985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40906,7 +40994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40920,7 +41008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40929,7 +41017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40943,7 +41031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40952,7 +41040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40966,7 +41054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40975,7 +41063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40989,7 +41077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -40998,7 +41086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41012,7 +41100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41021,7 +41109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41035,7 +41123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41044,7 +41132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41058,7 +41146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41067,7 +41155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41081,7 +41169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41090,7 +41178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41104,7 +41192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41113,7 +41201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41127,7 +41215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41136,7 +41224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41150,7 +41238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41159,7 +41247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41173,7 +41261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41182,7 +41270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41196,7 +41284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41205,7 +41293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41219,7 +41307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41228,7 +41316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41242,7 +41330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41251,7 +41339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41265,7 +41353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41274,7 +41362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41288,7 +41376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41297,7 +41385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41311,7 +41399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41320,7 +41408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41334,7 +41422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41343,7 +41431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41357,7 +41445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41366,7 +41454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41380,7 +41468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41389,7 +41477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41403,7 +41491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41412,7 +41500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41426,7 +41514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41435,7 +41523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41449,7 +41537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41458,7 +41546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41472,7 +41560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41481,7 +41569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41495,7 +41583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41504,7 +41592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41518,7 +41606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41527,7 +41615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 741,
+        "line": 743,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41541,7 +41629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41550,7 +41638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41564,7 +41652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41573,7 +41661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41587,7 +41675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41596,7 +41684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41610,7 +41698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41619,7 +41707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41633,7 +41721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41642,7 +41730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41656,7 +41744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41665,7 +41753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41679,7 +41767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41688,7 +41776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41702,7 +41790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41711,7 +41799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41725,7 +41813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41734,7 +41822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41748,7 +41836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41757,7 +41845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41771,7 +41859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41780,7 +41868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41794,7 +41882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41803,7 +41891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41817,7 +41905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41826,7 +41914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41840,7 +41928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41849,7 +41937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41863,7 +41951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41872,7 +41960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41886,7 +41974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41895,7 +41983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41909,7 +41997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41918,7 +42006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41932,7 +42020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41941,7 +42029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41955,7 +42043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41964,7 +42052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41978,7 +42066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -41987,7 +42075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42001,7 +42089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42010,7 +42098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42024,7 +42112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42033,7 +42121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42047,7 +42135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42056,7 +42144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42070,7 +42158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42079,7 +42167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42093,7 +42181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42102,7 +42190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 757,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42116,7 +42204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42125,7 +42213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 837,
+        "line": 839,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42139,7 +42227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42148,7 +42236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 837,
+        "line": 839,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42162,7 +42250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42171,7 +42259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 837,
+        "line": 839,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42185,7 +42273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42194,7 +42282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 837,
+        "line": 839,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42208,7 +42296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42217,7 +42305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 843,
+        "line": 845,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42231,7 +42319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42240,7 +42328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 843,
+        "line": 845,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42254,7 +42342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42263,7 +42351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 843,
+        "line": 845,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42277,7 +42365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42286,7 +42374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 848,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42300,7 +42388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42309,7 +42397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 848,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42323,7 +42411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42332,7 +42420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 848,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42346,7 +42434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42355,7 +42443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 854,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42369,7 +42457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42378,7 +42466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 854,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42392,7 +42480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42401,7 +42489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 854,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42415,7 +42503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42424,7 +42512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 854,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42438,7 +42526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42447,7 +42535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 854,
+        "line": 856,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42461,7 +42549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42470,7 +42558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 861,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42484,7 +42572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42493,7 +42581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 861,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42507,7 +42595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42516,7 +42604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 861,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42530,7 +42618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42539,7 +42627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42553,7 +42641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42562,7 +42650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42576,7 +42664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42585,7 +42673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42599,7 +42687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42608,7 +42696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42622,7 +42710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42631,7 +42719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 885,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42645,7 +42733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42654,7 +42742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 885,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42668,7 +42756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42677,7 +42765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42691,7 +42779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42700,7 +42788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42714,7 +42802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42723,7 +42811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42737,7 +42825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42746,7 +42834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42760,7 +42848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42769,7 +42857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42783,7 +42871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42792,7 +42880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42806,7 +42894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42815,7 +42903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42829,7 +42917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42838,7 +42926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 893,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42852,7 +42940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42861,7 +42949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42875,7 +42963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42884,7 +42972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42898,7 +42986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42907,7 +42995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42921,7 +43009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42930,7 +43018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42944,7 +43032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42953,7 +43041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42967,7 +43055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42976,7 +43064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42990,7 +43078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -42999,7 +43087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43013,7 +43101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43022,7 +43110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43036,7 +43124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43045,7 +43133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43059,7 +43147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43068,7 +43156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43082,7 +43170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43091,7 +43179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43105,7 +43193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43114,7 +43202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43128,7 +43216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43137,7 +43225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43151,7 +43239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43160,7 +43248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43174,7 +43262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43183,7 +43271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43197,7 +43285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43206,7 +43294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43220,7 +43308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43229,7 +43317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43243,7 +43331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43252,7 +43340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43266,7 +43354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43275,7 +43363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43289,7 +43377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43298,7 +43386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43312,7 +43400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43321,7 +43409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43335,7 +43423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43344,7 +43432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43358,7 +43446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43367,7 +43455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43381,7 +43469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43390,7 +43478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43404,7 +43492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43413,7 +43501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43427,7 +43515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43436,7 +43524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43450,7 +43538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43459,7 +43547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43473,7 +43561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43482,7 +43570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43496,7 +43584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43505,7 +43593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43519,7 +43607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43528,7 +43616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43542,7 +43630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43551,7 +43639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43565,7 +43653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43574,7 +43662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43588,7 +43676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43597,7 +43685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43611,7 +43699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43620,7 +43708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43634,7 +43722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43643,7 +43731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43657,7 +43745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43666,7 +43754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43680,7 +43768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43689,7 +43777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43703,7 +43791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43712,7 +43800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43726,7 +43814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43735,7 +43823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43749,7 +43837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43758,7 +43846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43772,7 +43860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43781,7 +43869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43795,7 +43883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43804,7 +43892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43818,7 +43906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43827,7 +43915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43841,7 +43929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43850,7 +43938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43864,7 +43952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43873,7 +43961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43887,7 +43975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43896,7 +43984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43910,7 +43998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43919,7 +44007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43933,7 +44021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43942,7 +44030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43956,7 +44044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43965,7 +44053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43979,7 +44067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -43988,7 +44076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44002,7 +44090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44011,7 +44099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44025,7 +44113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44034,7 +44122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44048,7 +44136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44057,7 +44145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44071,7 +44159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44080,7 +44168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44094,7 +44182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44103,7 +44191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44117,7 +44205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44126,7 +44214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44140,7 +44228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44149,7 +44237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44163,7 +44251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44172,7 +44260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44186,7 +44274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44195,7 +44283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44209,7 +44297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44218,7 +44306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44232,7 +44320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44241,7 +44329,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44255,7 +44343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44264,7 +44352,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44278,7 +44366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44287,7 +44375,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1027,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44301,7 +44389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44310,7 +44398,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44324,7 +44412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44333,7 +44421,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44347,7 +44435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44356,7 +44444,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44370,7 +44458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44379,7 +44467,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44393,7 +44481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44402,7 +44490,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44416,7 +44504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44425,7 +44513,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44439,7 +44527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44448,7 +44536,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44462,7 +44550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44471,7 +44559,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44485,7 +44573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44494,7 +44582,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44508,7 +44596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44517,7 +44605,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44531,7 +44619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44540,7 +44628,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44554,7 +44642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44563,7 +44651,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44577,7 +44665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44586,7 +44674,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44600,7 +44688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44609,7 +44697,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44623,7 +44711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44632,7 +44720,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44646,7 +44734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44655,7 +44743,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44669,7 +44757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44678,7 +44766,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44692,7 +44780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44701,7 +44789,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44715,7 +44803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44724,7 +44812,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44738,7 +44826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44747,7 +44835,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44761,7 +44849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44770,7 +44858,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44784,7 +44872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44793,7 +44881,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44807,7 +44895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44816,7 +44904,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44830,7 +44918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 532,
+            "handler_line": 533,
             "kind": "try",
             "line": 11
           }
@@ -44839,7 +44927,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48578,14 +48666,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1768
+            "line": 1722
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1769,
+        "line": 1723,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -48597,14 +48685,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1805
+            "line": 1759
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1806,
+        "line": 1760,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -48616,14 +48704,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1813
+            "line": 1767
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1814,
+        "line": 1768,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49998,14 +50086,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1768
+            "line": 1722
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1769,
+        "line": 1723,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50017,14 +50105,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1805
+            "line": 1759
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1806,
+        "line": 1760,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50036,14 +50124,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1813
+            "line": 1767
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1814,
+        "line": 1768,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51491,7 +51579,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1054,
+        "line": 1056,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51500,7 +51588,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1719,
+        "line": 1673,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51509,7 +51597,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2552,
+        "line": 2506,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51518,7 +51606,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2555,
+        "line": 2509,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51527,7 +51615,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2558,
+        "line": 2512,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51536,7 +51624,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2561,
+        "line": 2515,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51545,7 +51633,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2564,
+        "line": 2518,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51554,7 +51642,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2567,
+        "line": 2521,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51563,7 +51651,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2570,
+        "line": 2524,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51572,7 +51660,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2573,
+        "line": 2527,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51581,7 +51669,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2576,
+        "line": 2530,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51590,7 +51678,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2579,
+        "line": 2533,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51599,7 +51687,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2582,
+        "line": 2536,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51608,7 +51696,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2585,
+        "line": 2539,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51617,7 +51705,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2588,
+        "line": 2542,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51626,7 +51714,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2591,
+        "line": 2545,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51635,7 +51723,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2595,
+        "line": 2549,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51644,7 +51732,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2598,
+        "line": 2552,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51653,7 +51741,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2602,
+        "line": 2556,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51662,7 +51750,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2605,
+        "line": 2559,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51671,7 +51759,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2609,
+        "line": 2563,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51680,7 +51768,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2612,
+        "line": 2566,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51689,7 +51777,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2615,
+        "line": 2569,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51698,7 +51786,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2618,
+        "line": 2572,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51707,7 +51795,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2621,
+        "line": 2575,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51716,7 +51804,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2624,
+        "line": 2578,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51725,7 +51813,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2631,
+        "line": 2585,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51734,7 +51822,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2637,
+        "line": 2591,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51743,7 +51831,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2642,
+        "line": 2596,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51752,7 +51840,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2646,
+        "line": 2600,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52254,25 +52342,25 @@
       },
       {
         "kind": "dict",
-        "line": 1124,
+        "line": 1126,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1113,
+        "line": 1115,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1108,
+        "line": 1110,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "set",
-        "line": 1718,
+        "line": 1672,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "1f18c04f1078b7c547764aa572a6123ba423221d",
+    "base_commit": "09805305b54932a23db697c04132caaedc95c68b",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -33,7 +33,8 @@
       "B-11c1",
       "B-11c2",
       "B-11c3",
-      "B-11c4"
+      "B-11c4",
+      "B-11c5"
     ]
   },
   "enums": {
@@ -68,11 +69,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 264,
+    "nodes_canonical_bindings": 265,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 38,
+    "root_residual_functions": 37,
     "root_residual_classes": 0,
     "root_residual_globals": 32,
     "runtime_binders": 28,
@@ -1877,7 +1878,8 @@
       "symbols": {
         "_bind_aio_generation_normalization_runtime": "_bind_aio_generation_normalization_runtime",
         "_merge_versioned_settings": "_merge_versioned_settings",
-        "_normalize_aio_generation_settings": "_normalize_aio_generation_settings"
+        "_normalize_aio_generation_settings": "_normalize_aio_generation_settings",
+        "_normalize_aio_spectrum_settings": "_normalize_aio_spectrum_settings"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -1890,11 +1892,13 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
@@ -3942,7 +3946,6 @@
         "_normalize_aio_dit_corrections_settings": "_normalize_aio_dit_corrections_settings",
         "_normalize_aio_input_settings": "_normalize_aio_input_settings",
         "_normalize_aio_seed": "_normalize_aio_seed",
-        "_normalize_aio_spectrum_settings": "_normalize_aio_spectrum_settings",
         "_require_any_custom_node_class": "_require_any_custom_node_class",
         "_require_custom_node_class": "_require_custom_node_class",
         "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -19,6 +19,9 @@ if str(ROOT) not in sys.path:
 
 import nodes
 from easyuse_anima import workflow
+from easyuse_anima.aio import (
+    generation_normalization as aio_generation_normalization,
+)
 from easyuse_anima.aio import model_preparation as aio_model_preparation
 from easyuse_anima.common import serialization as common_serialization
 from easyuse_anima.common import values as common_values
@@ -618,6 +621,100 @@ class AioLoraSignatureMoveContractTests(unittest.TestCase):
                     self.EXPECTED_SIGNATURE,
                 )
             normalize.assert_called_once_with("raw")
+
+
+class AioSpectrumNormalizationMoveContractTests(unittest.TestCase):
+    DEFAULTS = {
+        "enabled": False,
+        "window_size": 2.0,
+        "flex_window": 0.25,
+        "warmup_steps": 6,
+        "tail_actual_steps": 3,
+        "blend_w": 0.3,
+        "cheby_degree": 3,
+        "ridge_lambda": 0.1,
+        "history_size": 100,
+        "one_sampler_only": False,
+        "verbose": False,
+        "compat_policy": "legacy",
+    }
+    EXPECTED = {
+        "enabled": True,
+        "window_size": 10.0,
+        "flex_window": 0.0,
+        "warmup_steps": 0,
+        "tail_actual_steps": 10000,
+        "blend_w": 1.0,
+        "cheby_degree": 1,
+        "ridge_lambda": 0.001,
+        "history_size": 5,
+        "one_sampler_only": True,
+        "verbose": False,
+        "compat_policy": "legacy",
+        "future": "kept",
+    }
+
+    def _assert_contract(self, root_module, canonical_module):
+        self.assertIs(
+            root_module._normalize_aio_spectrum_settings,
+            canonical_module._normalize_aio_spectrum_settings,
+        )
+        value = {
+            "enabled": True,
+            "window_size": 99,
+            "flex_window": -1,
+            "warmup_steps": -5,
+            "tail_actual_steps": 20000,
+            "blend_w": 2,
+            "cheby_degree": 0,
+            "ridge_lambda": 0,
+            "history_size": 1,
+            "one_sampler_only": True,
+            "verbose": False,
+            "compat_policy": "unknown",
+            "future": "kept",
+        }
+        with (
+            patch.object(
+                root_module,
+                "_as_bool",
+                wraps=root_module._as_bool,
+            ) as as_bool,
+            patch.object(
+                root_module,
+                "_as_float",
+                wraps=root_module._as_float,
+            ) as as_float,
+            patch.object(
+                root_module,
+                "_as_int",
+                wraps=root_module._as_int,
+            ) as as_int,
+            patch.object(
+                root_module,
+                "_choice",
+                wraps=root_module._choice,
+            ) as choice,
+        ):
+            result = canonical_module._normalize_aio_spectrum_settings(
+                value,
+                self.DEFAULTS,
+            )
+        self.assertIs(result, value)
+        self.assertEqual(result, self.EXPECTED)
+        for helper in (as_bool, as_float, as_int, choice):
+            self.assertGreater(helper.call_count, 0)
+
+    def test_root_alias_and_call_time_helpers(self):
+        self._assert_contract(nodes, aio_generation_normalization)
+
+    def test_package_alias_and_call_time_helpers(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_generation_normalization = sys.modules[
+                f"{package_name}.easyuse_anima.aio.generation_normalization"
+            ]
+            self._assert_contract(package_nodes, package_generation_normalization)
 
 
 class ComfyAdapterMoveContractTests(unittest.TestCase):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "5ce6b92bcd7ba6a4b60d83764b764d80034e1b44")
-        # Issue #184 B-11c4 moves the AiO LoRA stack signature helper while
-        # preserving the root alias and call-time normalizer resolver seam.
-        self.assertEqual(report["top_level"]["function_count"], 38)
+        self.assertEqual(report["git_blob_sha1"], "0fd503050bfa9b8881df791bf4c13b5f278133bd")
+        # Issue #184 B-11c5 moves the AiO Spectrum settings normalizer while
+        # preserving the root alias and call-time coercion helper seams.
+        self.assertEqual(report["top_level"]["function_count"], 37)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_650)
+        self.assertEqual(report["line_count"], 2_604)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "1f18c04f1078b7c547764aa572a6123ba423221d"
+BASE_COMMIT = "09805305b54932a23db697c04132caaedc95c68b"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1307,6 +1307,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c2",
                 "B-11c3",
                 "B-11c4",
+                "B-11c5",
             ],
         },
         "enums": {
@@ -1319,11 +1320,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 264,
+            "nodes_canonical_bindings": 265,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 38,
+            "root_residual_functions": 37,
             "root_residual_classes": 0,
             "root_residual_globals": 32,
             "runtime_binders": 28,


### PR DESCRIPTION
## 변경 전 inventory

- 기준: `dev` / `09805305b54932a23db697c04132caaedc95c68b`
- 유형: Move-only (`B-11c5 AiO Spectrum settings normalizer residual`)
- 선택 근거:
  - B-11c4 뒤 root `nodes.py`에는 38 functions, 0 classes, 32 globals, 28 runtime binders가 남아 있음.
  - `_normalize_aio_spectrum_settings`는 자체 상수·global·cache·I/O가 없고 전달된 Spectrum 설정 dict만 기존 범위로 정규화하는 단일 함수임.
  - canonical caller와 기존 runtime resolver가 이미 `easyuse_anima.aio.generation_normalization`에 있어 새 모듈, binder, dependency Contract가 필요하지 않음.
  - AiO seed family는 mutable special-seed set과 RNG 실행 해석을 분리해야 하고, Comfy provider family는 late-bound provider Contract가 선행되어야 하므로 이번 최소 Move보다 뒤로 보류함.
- symbol/caller:
  - dict 입력이면 같은 객체를 제자리 갱신해 반환하고, 비-dict 입력이면 새 dict를 만듦.
  - `enabled`, window/flex/warmup/tail/blend/Chebyshev/ridge/history, one-sampler/verbose, compatibility policy를 기존 coercion·clamp·fallback 순서로 정규화함.
  - 생산 호출자는 `easyuse_anima.aio.generation_normalization._normalize_aio_generation_settings` 안의 highres, upscale, detailer target 경로임.
  - caller는 매 호출마다 기존 root runtime resolver로 `_normalize_aio_spectrum_settings`를 조회함.
- alias/compatibility:
  - 현재는 root definition이며 canonical alias가 없음.
  - 이동 후 root relative/flat import가 같은 canonical function을 direct identity alias로 유지함.
  - moved function은 기존 generation-normalization resolver로 root `_as_bool`, `_as_float`, `_as_int`, `_choice`를 조회해 call-time helper replacement를 보존함.
  - `_bind_aio_generation_normalization_runtime`, caller 및 resolver 이름/호출 시점은 변경하지 않음.
- global state:
  - 자체 mutable global, cache, random, lock, file/network I/O가 없음.
  - `defaults`는 읽기만 하고 입력 dict의 기존 in-place mutation 의미만 유지함.

## 허용 경계

- production: `easyuse_anima/aio/generation_normalization.py`, root `nodes.py`
- focused contracts: flat/package direct identity, helper call-time rebind, dict identity, exact coercion/clamp/fallback parity
- analyzer/compatibility: nodes analyzer baseline, backend analyzer fixture, compatibility surface test/fixture
- status docs: backend execution roadmap, compatibility shim registry

## 금지 경계

- Spectrum key, 기본값, clamp 범위, nested fallback 및 helper 호출 순서 변경
- dict mutation/copy 정책, unknown key 보존, compatibility policy choices 변경
- `_normalize_aio_dit_corrections_settings` 또는 sampler 내부 정규화 통합
- settings schema/default JSON, seed, cache/change-key, Spectrum sampler 실행 행동 변경
- runtime binder/resolver signature·binding 순서·caller 변경
- B-11c final shim cutover, Phase C Contract/Behavior, Phase E lifecycle

## 구현 결과

- 현재 함수 본문을 `easyuse_anima.aio.generation_normalization` owner로 이동함.
- 함수 시작에서 네 coercion helper만 기존 module runtime resolver로 조회함.
- root `nodes.py` relative/flat generation-normalization import가 canonical function을 explicit alias로 re-export함.
- analyzer/compatibility fixture는 canonical binding 265, root residual functions 37, globals 32, binders 28을 기록함.
- backend analyzer의 modules/shipped/closure는 81/81/81, side-effect candidates 188, mutable globals 63, compatibility names 23으로 유지됨.

## 검증

- 정확한 PR head: `a4fd4a9dd650f82e9f34735718339a355f133fc2`
- focused `python -m unittest -v`: Spectrum normalizer, AiO settings/storage, typed generation settings, compatibility, nodes/backend analyzer, import boundary 71건 통과
- `tools/check_project.ps1 -Profile full`: Python 892건 통과, frontend 114 JavaScript 파일 통과
- Pyright baseline ratchet: 64파일, 기존 60 errors, 증가 없음
- import boundary: 6 completed package groups, 0 violations
- Ruff report-only: 기존 105 findings, 증가 없음
- `git diff --check`: 통과
- 독립 read-only diff review: 지적사항 없음
- ComfyUI Codex test instance: repository contract/full validation
- Live ComfyUI/browser smoke: 이번 Move-only 단위에서는 미실행

## 남은 위험 / 미확인

- 이 PR은 함수 한 개의 owner만 이동하므로 B-11c와 Phase B를 완료하지 않음.
- DiT correction normalizer, AiO seed/settings defaults, Comfy provider, upscale/stage/postprocess, wildcard reservation 및 28 binders는 후속 rollback unit 또는 선행 Contract 대상으로 남음.
- live ComfyUI/browser 및 package/pack exit 검증은 Phase B exit checkpoint에 남김.
