### PR TITLE
refactor(backend): move AiO DiT normalizer residual (B-11c6)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `09805305b54932a23db697c04132caaedc95c68b`
+- Integrated `dev` snapshot commit: `617ea140b2f07d6d1a8c341d9145e05a613bed8c`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c4; B-11c5 Spectrum-normalizer Move in PR #298 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c5; B-11c6 DiT-normalizer Move in PR #299 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,650
-  lines after B-11c4.
-- The mechanical extraction has removed 10,013
-  lines, approximately 79.1% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,604
+  lines after B-11c5.
+- The mechanical extraction has removed 10,059
+  lines, approximately 79.4% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -60,7 +60,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   the read-only workflow lookup owner in PR #295 / `47fef1d`, and B-11c3 moved
   the dependency-free image tensor size helper in PR #296 / `1f18c04`.
   B-11c4 moved the AiO LoRA stack signature helper in PR #297 / `0980530`.
-  B-11c5 moves only the AiO Spectrum settings normalizer in PR #298.
+  B-11c5 moved the AiO Spectrum settings normalizer in PR #298 / `617ea14`.
+  B-11c6 moves only the AiO DiT correction normalizer in PR #299.
 
 ### Current quality baseline
 
@@ -302,7 +303,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 Spectrum-normalizer PR #298 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 DiT-normalizer PR #299 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -818,6 +819,11 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     the root direct alias, the existing caller resolver, call-time coercion
     helper replacement, in-place dict semantics, and exact clamp/fallback order;
     DiT correction, seed, schema/default, and sampler behavior remain separate.
+  - B-11c6 moves only `_normalize_aio_dit_corrections_settings` to the same
+    generation-normalization owner. PR #299 retains the root direct alias, the
+    existing caller resolver, call-time coercion helper replacement, in-place
+    dict semantics, and exact DCW/SMC/CFG++/FSG clamp and fallback order;
+    Spectrum, seed, schema/default, and sampler execution remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `09805305b54932a23db697c04132caaedc95c68b`
+  `617ea140b2f07d6d1a8c341d9145e05a613bed8c`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c4 are integrated through PR #297. B-11c is
+- Current state: B-11a through B-11c5 are integrated through PR #298. B-11c is
   split into residual-owner and binder Moves before the final root shim;
-  B-11c5 AiO Spectrum normalizer ownership is tracked by PR #298.
+  B-11c6 AiO DiT correction normalizer ownership is tracked by PR #299.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,8 +75,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 265 after
-  B-11c5 (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 266 after
+  B-11c6 (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -84,8 +84,8 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 37 functions, 0 classes, and 32 assigned
-  globals after B-11c5 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 36 functions, 0 classes, and 32 assigned
+  globals after B-11c6 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 256, including
   literal lookups and binder-owned helper-name/default collections;
@@ -218,6 +218,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
   compatibility policy choices, and nested fallback order remain unchanged in
   PR #298. DiT correction, seed, schema/default, and sampler execution stay
   outside this Move.
+
+### B-11c6 AiO DiT correction settings normalizer alias
+
+- Canonical owner:
+  `easyuse_anima.aio.generation_normalization._normalize_aio_dit_corrections_settings`.
+- The private root name remains a transitional direct alias. The canonical
+  generation normalizer continues resolving that root name at call time for
+  highres, upscale, and detailer target settings.
+- The moved helper resolves `_as_bool`, `_as_float`, `_as_int`, and `_choice`
+  through the existing generation-normalization runtime seam, preserving root
+  monkeypatch behavior without adding a binder or canonical-to-root import.
+- Dict identity/in-place mutation, unknown keys, defaults, and the exact
+  DCW/SMC/CFG++/FSG choices, clamp bounds, and nested fallback order remain
+  unchanged in PR #299. Spectrum, seed, schema/default, and sampler execution
+  stay outside this Move.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/generation_normalization.py
+++ b/easyuse_anima/aio/generation_normalization.py
@@ -154,6 +154,143 @@ def _normalize_aio_spectrum_settings(
     return spectrum
 
 
+def _normalize_aio_dit_corrections_settings(
+    value,
+    defaults: dict[str, Any],
+) -> dict[str, Any]:
+    _as_bool = _runtime_helper("_as_bool")
+    _as_float = _runtime_helper("_as_float")
+    _as_int = _runtime_helper("_as_int")
+    _choice = _runtime_helper("_choice")
+    corrections = value if isinstance(value, dict) else {}
+    corrections["enabled"] = _as_bool(
+        corrections.get("enabled"),
+        _as_bool(defaults.get("enabled"), False),
+    )
+    corrections["dcw_mode"] = _choice(
+        corrections.get("dcw_mode"),
+        ("off", "manual", "auto"),
+        str(defaults.get("dcw_mode") or "off"),
+    )
+    corrections["dcw_lambda"] = max(
+        -1.0,
+        min(
+            1.0,
+            _as_float(
+                corrections.get("dcw_lambda"),
+                _as_float(defaults.get("dcw_lambda"), 0.01),
+            ),
+        ),
+    )
+    corrections["dcw_band_mask"] = _choice(
+        corrections.get("dcw_band_mask"),
+        ("LL", "all", "HH", "LH+HL+HH"),
+        str(defaults.get("dcw_band_mask") or "LL"),
+    )
+    corrections["dcw_calibrator"] = str(
+        corrections.get("dcw_calibrator")
+        or defaults.get("dcw_calibrator")
+        or "(auto-download default)"
+    )
+    corrections["smc_cfg"] = _as_bool(
+        corrections.get("smc_cfg"),
+        _as_bool(defaults.get("smc_cfg"), False),
+    )
+    corrections["adaptive_smc_alpha"] = max(
+        0.0,
+        min(
+            1.0,
+            _as_float(
+                corrections.get("adaptive_smc_alpha"),
+                _as_float(defaults.get("adaptive_smc_alpha"), 0.0),
+            ),
+        ),
+    )
+    corrections["smc_cfg_lambda"] = max(
+        0.0,
+        min(
+            20.0,
+            _as_float(
+                corrections.get("smc_cfg_lambda"),
+                _as_float(defaults.get("smc_cfg_lambda"), 6.0),
+            ),
+        ),
+    )
+    corrections["cfgpp"] = _as_bool(
+        corrections.get("cfgpp"),
+        _as_bool(defaults.get("cfgpp"), False),
+    )
+    corrections["cfgpp_lambda"] = max(
+        0.0,
+        min(
+            8.0,
+            _as_float(
+                corrections.get("cfgpp_lambda"),
+                _as_float(defaults.get("cfgpp_lambda"), 0.0),
+            ),
+        ),
+    )
+    corrections["fsg"] = _as_bool(
+        corrections.get("fsg"),
+        _as_bool(defaults.get("fsg"), False),
+    )
+    corrections["fsg_band_lo"] = max(
+        0.0,
+        min(
+            1.0,
+            _as_float(
+                corrections.get("fsg_band_lo"),
+                _as_float(defaults.get("fsg_band_lo"), 0.59),
+            ),
+        ),
+    )
+    corrections["fsg_band_hi"] = max(
+        0.0,
+        min(
+            1.0,
+            _as_float(
+                corrections.get("fsg_band_hi"),
+                _as_float(defaults.get("fsg_band_hi"), 0.75),
+            ),
+        ),
+    )
+    corrections["fsg_k"] = max(
+        0,
+        min(
+            32,
+            _as_int(
+                corrections.get("fsg_k"),
+                _as_int(defaults.get("fsg_k"), 3),
+            ),
+        ),
+    )
+    corrections["fsg_d_sigma"] = max(
+        0.0,
+        min(
+            1.0,
+            _as_float(
+                corrections.get("fsg_d_sigma"),
+                _as_float(defaults.get("fsg_d_sigma"), 0.1),
+            ),
+        ),
+    )
+    corrections["fsg_gamma"] = max(
+        0.0,
+        min(
+            10.0,
+            _as_float(
+                corrections.get("fsg_gamma"),
+                _as_float(defaults.get("fsg_gamma"), 0.0),
+            ),
+        ),
+    )
+    corrections["replace_existing_cfg"] = _as_bool(
+        corrections.get("replace_existing_cfg"),
+        _as_bool(defaults.get("replace_existing_cfg"), False),
+    )
+    return corrections
+
+
 def _normalize_aio_generation_settings(value) -> dict[str, Any]:
     AIO_FINAL_FIT_MODES = _runtime_helper("AIO_FINAL_FIT_MODES")
     AIO_FINAL_UPSCALE_BACKENDS = _runtime_helper("AIO_FINAL_UPSCALE_BACKENDS")

--- a/nodes.py
+++ b/nodes.py
@@ -27,6 +27,7 @@ try:
     from .easyuse_anima.aio.generation_normalization import (
         _bind_aio_generation_normalization_runtime as _bind_aio_generation_normalization_runtime,
         _merge_versioned_settings as _merge_versioned_settings,
+        _normalize_aio_dit_corrections_settings as _normalize_aio_dit_corrections_settings,
         _normalize_aio_generation_settings as _normalize_aio_generation_settings,
         _normalize_aio_spectrum_settings as _normalize_aio_spectrum_settings,
     )
@@ -549,6 +550,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.aio.generation_normalization import (
         _bind_aio_generation_normalization_runtime as _bind_aio_generation_normalization_runtime,
         _merge_versioned_settings as _merge_versioned_settings,
+        _normalize_aio_dit_corrections_settings as _normalize_aio_dit_corrections_settings,
         _normalize_aio_generation_settings as _normalize_aio_generation_settings,
         _normalize_aio_spectrum_settings as _normalize_aio_spectrum_settings,
     )
@@ -1602,71 +1604,6 @@ def _normalize_aio_input_settings(value) -> dict[str, Any]:
         "default",
     )
     return settings
-
-
-def _normalize_aio_dit_corrections_settings(value, defaults: dict[str, Any]) -> dict[str, Any]:
-    corrections = value if isinstance(value, dict) else {}
-    corrections["enabled"] = _as_bool(corrections.get("enabled"), _as_bool(defaults.get("enabled"), False))
-    corrections["dcw_mode"] = _choice(
-        corrections.get("dcw_mode"),
-        ("off", "manual", "auto"),
-        str(defaults.get("dcw_mode") or "off"),
-    )
-    corrections["dcw_lambda"] = max(
-        -1.0,
-        min(1.0, _as_float(corrections.get("dcw_lambda"), _as_float(defaults.get("dcw_lambda"), 0.01))),
-    )
-    corrections["dcw_band_mask"] = _choice(
-        corrections.get("dcw_band_mask"),
-        ("LL", "all", "HH", "LH+HL+HH"),
-        str(defaults.get("dcw_band_mask") or "LL"),
-    )
-    corrections["dcw_calibrator"] = str(
-        corrections.get("dcw_calibrator") or defaults.get("dcw_calibrator") or "(auto-download default)"
-    )
-    corrections["smc_cfg"] = _as_bool(corrections.get("smc_cfg"), _as_bool(defaults.get("smc_cfg"), False))
-    corrections["adaptive_smc_alpha"] = max(
-        0.0,
-        min(
-            1.0,
-            _as_float(
-                corrections.get("adaptive_smc_alpha"),
-                _as_float(defaults.get("adaptive_smc_alpha"), 0.0),
-            ),
-        ),
-    )
-    corrections["smc_cfg_lambda"] = max(
-        0.0,
-        min(20.0, _as_float(corrections.get("smc_cfg_lambda"), _as_float(defaults.get("smc_cfg_lambda"), 6.0))),
-    )
-    corrections["cfgpp"] = _as_bool(corrections.get("cfgpp"), _as_bool(defaults.get("cfgpp"), False))
-    corrections["cfgpp_lambda"] = max(
-        0.0,
-        min(8.0, _as_float(corrections.get("cfgpp_lambda"), _as_float(defaults.get("cfgpp_lambda"), 0.0))),
-    )
-    corrections["fsg"] = _as_bool(corrections.get("fsg"), _as_bool(defaults.get("fsg"), False))
-    corrections["fsg_band_lo"] = max(
-        0.0,
-        min(1.0, _as_float(corrections.get("fsg_band_lo"), _as_float(defaults.get("fsg_band_lo"), 0.59))),
-    )
-    corrections["fsg_band_hi"] = max(
-        0.0,
-        min(1.0, _as_float(corrections.get("fsg_band_hi"), _as_float(defaults.get("fsg_band_hi"), 0.75))),
-    )
-    corrections["fsg_k"] = max(0, min(32, _as_int(corrections.get("fsg_k"), _as_int(defaults.get("fsg_k"), 3))))
-    corrections["fsg_d_sigma"] = max(
-        0.0,
-        min(1.0, _as_float(corrections.get("fsg_d_sigma"), _as_float(defaults.get("fsg_d_sigma"), 0.1))),
-    )
-    corrections["fsg_gamma"] = max(
-        0.0,
-        min(10.0, _as_float(corrections.get("fsg_gamma"), _as_float(defaults.get("fsg_gamma"), 0.0))),
-    )
-    corrections["replace_existing_cfg"] = _as_bool(
-        corrections.get("replace_existing_cfg"),
-        _as_bool(defaults.get("replace_existing_cfg"), False),
-    )
-    return corrections
 
 
 _AIO_DETAILER_RESERVED_KEYS = {"enabled", "order", "sam3"}

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14597,6 +14597,37 @@
         "target": "easyuse_anima/aio/generation_normalization.py"
       },
       {
+        "alias": "_normalize_aio_dit_corrections_settings",
+        "bound_name": "_normalize_aio_dit_corrections_settings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_aio_dit_corrections_settings",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_normalize_aio_dit_corrections_settings",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
         "alias": "_normalize_aio_generation_settings",
         "bound_name": "_normalize_aio_generation_settings",
         "branch_context": [
@@ -14680,7 +14711,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 33,
+        "line": 34,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -14711,7 +14742,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14742,7 +14773,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14773,7 +14804,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14804,7 +14835,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14835,7 +14866,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14866,7 +14897,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14897,7 +14928,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14928,7 +14959,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14959,7 +14990,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14990,7 +15021,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15021,7 +15052,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15052,7 +15083,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15083,7 +15114,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15114,7 +15145,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15145,7 +15176,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15176,7 +15207,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15207,7 +15238,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 42,
+        "line": 43,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15238,7 +15269,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15269,7 +15300,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15300,7 +15331,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15331,7 +15362,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15362,7 +15393,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15393,7 +15424,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15424,7 +15455,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15455,7 +15486,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15486,7 +15517,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15517,7 +15548,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15548,7 +15579,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15579,7 +15610,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15610,7 +15641,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15641,7 +15672,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15672,7 +15703,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15703,7 +15734,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15734,7 +15765,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15765,7 +15796,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15796,7 +15827,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15827,7 +15858,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15858,7 +15889,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15889,7 +15920,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15920,7 +15951,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15951,7 +15982,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15982,7 +16013,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16013,7 +16044,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16044,7 +16075,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16075,7 +16106,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16106,7 +16137,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16137,7 +16168,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16168,7 +16199,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16199,7 +16230,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16230,7 +16261,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16261,7 +16292,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16292,7 +16323,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16323,7 +16354,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16354,7 +16385,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16385,7 +16416,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16416,7 +16447,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16447,7 +16478,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16478,7 +16509,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16509,7 +16540,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16540,7 +16571,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16571,7 +16602,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16602,7 +16633,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16633,7 +16664,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16664,7 +16695,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16695,7 +16726,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16726,7 +16757,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16757,7 +16788,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -16788,7 +16819,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16819,7 +16850,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16850,7 +16881,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16881,7 +16912,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16912,7 +16943,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 125,
+        "line": 126,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16943,7 +16974,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 125,
+        "line": 126,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16974,7 +17005,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 125,
+        "line": 126,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17005,7 +17036,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 125,
+        "line": 126,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17036,7 +17067,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 125,
+        "line": 126,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17067,7 +17098,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 125,
+        "line": 126,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17098,7 +17129,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 125,
+        "line": 126,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17129,7 +17160,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 125,
+        "line": 126,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17160,7 +17191,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 125,
+        "line": 126,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17191,7 +17222,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 125,
+        "line": 126,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17222,7 +17253,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17253,7 +17284,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17284,7 +17315,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17315,7 +17346,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17346,7 +17377,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17377,7 +17408,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17408,7 +17439,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17439,7 +17470,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17470,7 +17501,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17501,7 +17532,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17532,7 +17563,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17563,7 +17594,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17594,7 +17625,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17625,7 +17656,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17656,7 +17687,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17687,7 +17718,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17718,7 +17749,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17749,7 +17780,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17780,7 +17811,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17811,7 +17842,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17842,7 +17873,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17873,7 +17904,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17904,7 +17935,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17935,7 +17966,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17966,7 +17997,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17997,7 +18028,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18028,7 +18059,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18059,7 +18090,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18090,7 +18121,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18121,7 +18152,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18152,7 +18183,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18183,7 +18214,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18214,7 +18245,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18245,7 +18276,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18276,7 +18307,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18307,7 +18338,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18338,7 +18369,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18369,7 +18400,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18400,7 +18431,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18431,7 +18462,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18462,7 +18493,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18493,7 +18524,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18524,7 +18555,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18555,7 +18586,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18586,7 +18617,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18617,7 +18648,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18648,7 +18679,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18679,7 +18710,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18710,7 +18741,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18741,7 +18772,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18772,7 +18803,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18803,7 +18834,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18834,7 +18865,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18865,7 +18896,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18896,7 +18927,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18927,7 +18958,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18958,7 +18989,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18989,7 +19020,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19020,7 +19051,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19051,7 +19082,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19082,7 +19113,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19113,7 +19144,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19144,7 +19175,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19175,7 +19206,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19206,7 +19237,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19237,7 +19268,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19268,7 +19299,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19299,7 +19330,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19330,7 +19361,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19361,7 +19392,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19392,7 +19423,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19423,7 +19454,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19454,7 +19485,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19485,7 +19516,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19516,7 +19547,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19547,7 +19578,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19578,7 +19609,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 237,
+        "line": 238,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19609,7 +19640,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 317,
+        "line": 318,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19640,7 +19671,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 317,
+        "line": 318,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19671,7 +19702,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 317,
+        "line": 318,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19702,7 +19733,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 317,
+        "line": 318,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19733,7 +19764,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 323,
+        "line": 324,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19764,7 +19795,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 323,
+        "line": 324,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19795,7 +19826,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 323,
+        "line": 324,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19826,7 +19857,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 328,
+        "line": 329,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19857,7 +19888,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 328,
+        "line": 329,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19888,7 +19919,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 328,
+        "line": 329,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19919,7 +19950,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 334,
+        "line": 335,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19950,7 +19981,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 334,
+        "line": 335,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19981,7 +20012,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 334,
+        "line": 335,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20012,7 +20043,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 334,
+        "line": 335,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20043,7 +20074,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 334,
+        "line": 335,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20074,7 +20105,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 341,
+        "line": 342,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20105,7 +20136,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 341,
+        "line": 342,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20136,7 +20167,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 341,
+        "line": 342,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20167,7 +20198,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20198,7 +20229,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20229,7 +20260,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20260,7 +20291,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20291,7 +20322,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 365,
+        "line": 366,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20322,7 +20353,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 365,
+        "line": 366,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20353,7 +20384,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 373,
+        "line": 374,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20384,7 +20415,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 373,
+        "line": 374,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20415,7 +20446,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 373,
+        "line": 374,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20446,7 +20477,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 373,
+        "line": 374,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20477,7 +20508,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 373,
+        "line": 374,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20508,7 +20539,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 373,
+        "line": 374,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20539,7 +20570,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 373,
+        "line": 374,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20570,7 +20601,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 373,
+        "line": 374,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20601,7 +20632,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 384,
+        "line": 385,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20632,7 +20663,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 384,
+        "line": 385,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20663,7 +20694,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 384,
+        "line": 385,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20694,7 +20725,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 384,
+        "line": 385,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20725,7 +20756,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 390,
+        "line": 391,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20756,7 +20787,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 390,
+        "line": 391,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20787,7 +20818,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 390,
+        "line": 391,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20818,7 +20849,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 390,
+        "line": 391,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20849,7 +20880,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 390,
+        "line": 391,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20880,7 +20911,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20911,7 +20942,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20942,7 +20973,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -20973,7 +21004,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 406,
+        "line": 407,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21004,7 +21035,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 406,
+        "line": 407,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21035,7 +21066,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 406,
+        "line": 407,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21066,7 +21097,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 411,
+        "line": 412,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21097,7 +21128,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 411,
+        "line": 412,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21128,7 +21159,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 411,
+        "line": 412,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21159,7 +21190,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 411,
+        "line": 412,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21190,7 +21221,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 411,
+        "line": 412,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21221,7 +21252,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 418,
+        "line": 419,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21252,7 +21283,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 418,
+        "line": 419,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21283,7 +21314,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 418,
+        "line": 419,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21314,7 +21345,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 423,
+        "line": 424,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21345,7 +21376,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 423,
+        "line": 424,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21376,7 +21407,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 423,
+        "line": 424,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21407,7 +21438,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21438,7 +21469,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21469,7 +21500,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21500,7 +21531,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21531,7 +21562,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21562,7 +21593,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 464,
+        "line": 465,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21593,7 +21624,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 464,
+        "line": 465,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21624,7 +21655,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 468,
+        "line": 469,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21655,7 +21686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 468,
+        "line": 469,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21686,7 +21717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21717,7 +21748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21748,7 +21779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21779,7 +21810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21810,7 +21841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21841,7 +21872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21872,7 +21903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21903,7 +21934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21934,7 +21965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21965,7 +21996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21996,7 +22027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22027,7 +22058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22058,7 +22089,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22089,7 +22120,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22120,7 +22151,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22151,7 +22182,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22182,7 +22213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22213,7 +22244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22244,7 +22275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22275,7 +22306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22306,7 +22337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22337,7 +22368,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22368,7 +22399,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22399,7 +22430,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22430,7 +22461,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22461,7 +22492,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22492,7 +22523,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22523,7 +22554,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -22554,7 +22585,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -22585,7 +22616,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -22616,7 +22647,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -22647,7 +22678,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22678,7 +22709,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 511,
+        "line": 512,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22709,7 +22740,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22740,7 +22771,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22771,7 +22802,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22802,7 +22833,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22833,7 +22864,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22864,7 +22895,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22895,7 +22926,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22926,7 +22957,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22957,7 +22988,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22988,7 +23019,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23019,7 +23050,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23050,7 +23081,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23081,7 +23112,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23112,7 +23143,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23143,7 +23174,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23174,7 +23205,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23205,7 +23236,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23236,7 +23267,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23267,7 +23298,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23286,7 +23317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23301,7 +23332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23320,7 +23351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23335,7 +23366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23354,7 +23385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23369,7 +23400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23388,7 +23419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23422,7 +23453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23437,7 +23468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23456,7 +23487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23471,7 +23502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23490,7 +23521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23505,7 +23536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23524,7 +23555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23539,7 +23570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23558,7 +23589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23573,7 +23604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23592,7 +23623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23607,7 +23638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23626,7 +23657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23641,7 +23672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23660,7 +23691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23675,8 +23706,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_merge_versioned_settings",
+        "optional": false,
+        "requested": "easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": "_normalize_aio_dit_corrections_settings",
+        "bound_name": "_normalize_aio_dit_corrections_settings",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 534,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_aio_dit_corrections_settings",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
+        "kind": "static_from",
+        "line": 550,
+        "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
         "role": "compatibility_fallback",
@@ -23694,7 +23759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23709,7 +23774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23728,7 +23793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23743,7 +23808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23762,7 +23827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23777,7 +23842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -23796,7 +23861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23811,7 +23876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 558,
+        "line": 560,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23830,7 +23895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23845,7 +23910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 558,
+        "line": 560,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23864,7 +23929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23879,7 +23944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 558,
+        "line": 560,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23898,7 +23963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23913,7 +23978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 558,
+        "line": 560,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23932,7 +23997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23947,7 +24012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -23966,7 +24031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -23981,7 +24046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24000,7 +24065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24015,7 +24080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24034,7 +24099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24049,7 +24114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24068,7 +24133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24083,7 +24148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24102,7 +24167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24117,7 +24182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24136,7 +24201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24151,7 +24216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24170,7 +24235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24185,7 +24250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24204,7 +24269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24219,7 +24284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24238,7 +24303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24253,7 +24318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24272,7 +24337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24287,7 +24352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24306,7 +24371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24321,7 +24386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24340,7 +24405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24355,7 +24420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24374,7 +24439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24389,7 +24454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24408,7 +24473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24423,7 +24488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24442,7 +24507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24457,7 +24522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24476,7 +24541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24491,7 +24556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24510,7 +24575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24525,7 +24590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24544,7 +24609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24559,7 +24624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24578,7 +24643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24593,7 +24658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24612,7 +24677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24627,7 +24692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24646,7 +24711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24661,7 +24726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24680,7 +24745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24695,7 +24760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24714,7 +24779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24729,7 +24794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24748,7 +24813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24763,7 +24828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24782,7 +24847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24797,7 +24862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24816,7 +24881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24831,7 +24896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24850,7 +24915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24865,7 +24930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24884,7 +24949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24899,7 +24964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24918,7 +24983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24933,7 +24998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24952,7 +25017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -24967,7 +25032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24986,7 +25051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25001,7 +25066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25020,7 +25085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25035,7 +25100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25054,7 +25119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25069,7 +25134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25088,7 +25153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25103,7 +25168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25122,7 +25187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25137,7 +25202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25156,7 +25221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25171,7 +25236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25190,7 +25255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25205,7 +25270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25224,7 +25289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25239,7 +25304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25258,7 +25323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25273,7 +25338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25292,7 +25357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25307,7 +25372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25326,7 +25391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25341,7 +25406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25360,7 +25425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25375,7 +25440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25394,7 +25459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25409,7 +25474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25428,7 +25493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25443,7 +25508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25462,7 +25527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25477,7 +25542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25496,7 +25561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25511,7 +25576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25530,7 +25595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25545,7 +25610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25564,7 +25629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25579,7 +25644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25598,7 +25663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25613,7 +25678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25632,7 +25697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25647,7 +25712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25666,7 +25731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25681,7 +25746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25700,7 +25765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25715,7 +25780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25734,7 +25799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25749,7 +25814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25768,7 +25833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25783,7 +25848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25802,7 +25867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25817,7 +25882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25836,7 +25901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25851,7 +25916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25870,7 +25935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25885,7 +25950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25904,7 +25969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25919,7 +25984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25938,7 +26003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25953,7 +26018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25972,7 +26037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -25987,7 +26052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26006,7 +26071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26021,7 +26086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26040,7 +26105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26055,7 +26120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -26074,7 +26139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26089,7 +26154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26108,7 +26173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26123,7 +26188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26142,7 +26207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26157,7 +26222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26176,7 +26241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26191,7 +26256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26210,7 +26275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26225,7 +26290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26244,7 +26309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26259,7 +26324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26278,7 +26343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26293,7 +26358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26312,7 +26377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26327,7 +26392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26346,7 +26411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26361,7 +26426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26380,7 +26445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26395,7 +26460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26414,7 +26479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26429,7 +26494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26448,7 +26513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26463,7 +26528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26482,7 +26547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26497,7 +26562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26516,7 +26581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26531,7 +26596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26550,7 +26615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26565,7 +26630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26584,7 +26649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26599,7 +26664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26618,7 +26683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26633,7 +26698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26652,7 +26717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26667,7 +26732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26686,7 +26751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26701,7 +26766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26720,7 +26785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26735,7 +26800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26754,7 +26819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26769,7 +26834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26788,7 +26853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26803,7 +26868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26822,7 +26887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26837,7 +26902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26856,7 +26921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26871,7 +26936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26890,7 +26955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26905,7 +26970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26924,7 +26989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26939,7 +27004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26958,7 +27023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -26973,7 +27038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26992,7 +27057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27007,7 +27072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27026,7 +27091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27041,7 +27106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27060,7 +27125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27075,7 +27140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27094,7 +27159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27109,7 +27174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27128,7 +27193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27143,7 +27208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27162,7 +27227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27177,7 +27242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27196,7 +27261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27211,7 +27276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27230,7 +27295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27245,7 +27310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27264,7 +27329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27279,7 +27344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27298,7 +27363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27313,7 +27378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27332,7 +27397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27347,7 +27412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27366,7 +27431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27381,7 +27446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27400,7 +27465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27415,7 +27480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27434,7 +27499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27449,7 +27514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27468,7 +27533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27483,7 +27548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27502,7 +27567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27517,7 +27582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27536,7 +27601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27551,7 +27616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27570,7 +27635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27585,7 +27650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27604,7 +27669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27619,7 +27684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27638,7 +27703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27653,7 +27718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27672,7 +27737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27687,7 +27752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27706,7 +27771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27721,7 +27786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27740,7 +27805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27755,7 +27820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27774,7 +27839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27789,7 +27854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27808,7 +27873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27823,7 +27888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27842,7 +27907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27857,7 +27922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27876,7 +27941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27891,7 +27956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27910,7 +27975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27925,7 +27990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27944,7 +28009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27959,7 +28024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27978,7 +28043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -27993,7 +28058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28012,7 +28077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28027,7 +28092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28046,7 +28111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28061,7 +28126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28080,7 +28145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28095,7 +28160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28114,7 +28179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28129,7 +28194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28148,7 +28213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28163,7 +28228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28182,7 +28247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28197,7 +28262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28216,7 +28281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28231,7 +28296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28250,7 +28315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28265,7 +28330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28284,7 +28349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28299,7 +28364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28318,7 +28383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28333,7 +28398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28352,7 +28417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28367,7 +28432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28386,7 +28451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28401,7 +28466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28420,7 +28485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28435,7 +28500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28454,7 +28519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28469,7 +28534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28488,7 +28553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28503,7 +28568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28522,7 +28587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28537,7 +28602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28556,7 +28621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28571,7 +28636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28590,7 +28655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28605,7 +28670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28624,7 +28689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28639,7 +28704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28658,7 +28723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28673,7 +28738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28692,7 +28757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28707,7 +28772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28726,7 +28791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28741,7 +28806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28760,7 +28825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28775,7 +28840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28794,7 +28859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28809,7 +28874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28828,7 +28893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28843,7 +28908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28862,7 +28927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28877,7 +28942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28896,7 +28961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28911,7 +28976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28930,7 +28995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28945,7 +29010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28964,7 +29029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -28979,7 +29044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28998,7 +29063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29013,7 +29078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29032,7 +29097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29047,7 +29112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29066,7 +29131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29081,7 +29146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29100,7 +29165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29115,7 +29180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29134,7 +29199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29149,7 +29214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29168,7 +29233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29183,7 +29248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 839,
+        "line": 841,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29202,7 +29267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29217,7 +29282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 839,
+        "line": 841,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29236,7 +29301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29251,7 +29316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 839,
+        "line": 841,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29270,7 +29335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29285,7 +29350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 839,
+        "line": 841,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29304,7 +29369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29319,7 +29384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 845,
+        "line": 847,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29338,7 +29403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29353,7 +29418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 845,
+        "line": 847,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29372,7 +29437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29387,7 +29452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 845,
+        "line": 847,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29406,7 +29471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29421,7 +29486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 850,
+        "line": 852,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29440,7 +29505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29455,7 +29520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 850,
+        "line": 852,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29474,7 +29539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29489,7 +29554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 850,
+        "line": 852,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29508,7 +29573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29523,7 +29588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29542,7 +29607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29557,7 +29622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29576,7 +29641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29591,7 +29656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29610,7 +29675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29625,7 +29690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29644,7 +29709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29659,7 +29724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29678,7 +29743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29693,7 +29758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 863,
+        "line": 865,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29712,7 +29777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29727,7 +29792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 863,
+        "line": 865,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29746,7 +29811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29761,7 +29826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 863,
+        "line": 865,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29780,7 +29845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29795,7 +29860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29814,7 +29879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29829,7 +29894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29848,7 +29913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29863,7 +29928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29882,7 +29947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29897,7 +29962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29916,7 +29981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29931,7 +29996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -29950,7 +30015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29965,7 +30030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -29984,7 +30049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -29999,7 +30064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30018,7 +30083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30033,7 +30098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30052,7 +30117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30067,7 +30132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30086,7 +30151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30101,7 +30166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30120,7 +30185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30135,7 +30200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30154,7 +30219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30169,7 +30234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30188,7 +30253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30203,7 +30268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30222,7 +30287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30237,7 +30302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30256,7 +30321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30271,7 +30336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30290,7 +30355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30305,7 +30370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30324,7 +30389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30339,7 +30404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30358,7 +30423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30373,7 +30438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30392,7 +30457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30407,7 +30472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30426,7 +30491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30441,7 +30506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30460,7 +30525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30475,7 +30540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30494,7 +30559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30509,7 +30574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30528,7 +30593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30543,7 +30608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30562,7 +30627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30577,7 +30642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30596,7 +30661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30611,7 +30676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30630,7 +30695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30645,7 +30710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -30664,7 +30729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30679,7 +30744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 928,
+        "line": 930,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30698,7 +30763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30713,7 +30778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 928,
+        "line": 930,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30732,7 +30797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30747,7 +30812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 928,
+        "line": 930,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30766,7 +30831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30781,7 +30846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30800,7 +30865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30815,7 +30880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30834,7 +30899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30849,7 +30914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30868,7 +30933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30883,7 +30948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30902,7 +30967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30917,7 +30982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30936,7 +31001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30951,7 +31016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -30970,7 +31035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -30985,7 +31050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31004,7 +31069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31019,7 +31084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31038,7 +31103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31053,7 +31118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31072,7 +31137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31087,7 +31152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31106,7 +31171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31121,7 +31186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31140,7 +31205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31155,7 +31220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31174,7 +31239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31189,7 +31254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31208,7 +31273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31223,7 +31288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31242,7 +31307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31257,7 +31322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31276,7 +31341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31291,7 +31356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31310,7 +31375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31325,7 +31390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31344,7 +31409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31359,7 +31424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31378,7 +31443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31393,7 +31458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31412,7 +31477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31427,7 +31492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31446,7 +31511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31461,7 +31526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31480,7 +31545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31495,7 +31560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31514,7 +31579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31529,7 +31594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31548,7 +31613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31563,7 +31628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31582,7 +31647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31597,7 +31662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31616,7 +31681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31631,7 +31696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31650,7 +31715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31665,7 +31730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31684,7 +31749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31699,7 +31764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31718,7 +31783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31733,7 +31798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31752,7 +31817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31767,7 +31832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31786,7 +31851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31801,7 +31866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31820,7 +31885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31835,7 +31900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31854,7 +31919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31869,7 +31934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31888,7 +31953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31903,7 +31968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31922,7 +31987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31937,7 +32002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31956,7 +32021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -31971,7 +32036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -31990,7 +32055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32005,7 +32070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32024,7 +32089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32039,7 +32104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32058,7 +32123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32073,7 +32138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32092,7 +32157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32107,7 +32172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32126,7 +32191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32141,7 +32206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32160,7 +32225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32175,7 +32240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32194,7 +32259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32209,7 +32274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32228,7 +32293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32243,7 +32308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32262,7 +32327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32277,7 +32342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32296,7 +32361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32311,7 +32376,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -32330,7 +32395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32345,7 +32410,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -32364,7 +32429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32379,7 +32444,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1029,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -32398,7 +32463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32413,7 +32478,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -32432,7 +32497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32447,7 +32512,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -32466,7 +32531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32481,7 +32546,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -32500,7 +32565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32515,7 +32580,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1035,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32534,7 +32599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32549,7 +32614,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1035,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32568,7 +32633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32583,7 +32648,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32602,7 +32667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32617,7 +32682,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32636,7 +32701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32651,7 +32716,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32670,7 +32735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32685,7 +32750,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32704,7 +32769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32719,7 +32784,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32738,7 +32803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32753,7 +32818,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32772,7 +32837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32787,7 +32852,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32806,7 +32871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32821,7 +32886,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32840,7 +32905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32855,7 +32920,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32874,7 +32939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32889,7 +32954,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32908,7 +32973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32923,7 +32988,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32942,7 +33007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32957,7 +33022,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32976,7 +33041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -32991,7 +33056,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33010,7 +33075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -33025,7 +33090,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33044,7 +33109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -33059,7 +33124,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33078,7 +33143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -33093,7 +33158,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33112,7 +33177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -33127,7 +33192,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33146,7 +33211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -33161,7 +33226,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33180,7 +33245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -33195,7 +33260,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33213,7 +33278,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1722
+            "line": 1659
           }
         ],
         "classification": "external",
@@ -33221,7 +33286,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1723,
+        "line": 1660,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33238,7 +33303,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1759
+            "line": 1696
           }
         ],
         "classification": "external",
@@ -33246,7 +33311,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1760,
+        "line": 1697,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33263,7 +33328,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1767
+            "line": 1704
           }
         ],
         "classification": "external",
@@ -33271,7 +33336,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1768,
+        "line": 1705,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -36175,13 +36240,13 @@
       },
       {
         "is_package": false,
-        "loc": 843,
+        "loc": 980,
         "module": "easyuse_anima.aio.generation_normalization",
-        "normalized_git_blob_sha1": "96eb4f5e7950170397346caec0b3ee6cb6e19f12",
+        "normalized_git_blob_sha1": "a572e52e277e279cd20d1a519a8f13411cbf9431",
         "path": "easyuse_anima/aio/generation_normalization.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 5,
+          "function_count": 6,
           "global_count": 3
         }
       },
@@ -36859,13 +36924,13 @@
       },
       {
         "is_package": false,
-        "loc": 2604,
+        "loc": 2541,
         "module": "nodes",
-        "normalized_git_blob_sha1": "0fd503050bfa9b8881df791bf4c13b5f278133bd",
+        "normalized_git_blob_sha1": "2ee992eddb12f7e90269ce89cff2c4c8c372d7d0",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 37,
+          "function_count": 36,
           "global_count": 32
         }
       },
@@ -38225,7 +38290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38234,7 +38299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38248,7 +38313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38257,7 +38322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38271,7 +38336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38280,7 +38345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38294,7 +38359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38303,7 +38368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38317,7 +38382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38326,7 +38391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38340,7 +38405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38349,7 +38414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38363,7 +38428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38372,7 +38437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38386,7 +38451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38395,7 +38460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38409,7 +38474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38418,7 +38483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38432,7 +38497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38441,7 +38506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38455,7 +38520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38464,7 +38529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38478,7 +38543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38487,7 +38552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38501,7 +38566,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
+        "kind": "static_from",
+        "line": 550,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38510,7 +38598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38524,7 +38612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38533,7 +38621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38547,7 +38635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38556,7 +38644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38570,7 +38658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38579,7 +38667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 558,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38593,7 +38681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38602,7 +38690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 558,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38616,7 +38704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38625,7 +38713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 558,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38639,7 +38727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38648,7 +38736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 558,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38662,7 +38750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38671,7 +38759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38685,7 +38773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38694,7 +38782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38708,7 +38796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38717,7 +38805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38731,7 +38819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38740,7 +38828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38754,7 +38842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38763,7 +38851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38777,7 +38865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38786,7 +38874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38800,7 +38888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38809,7 +38897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38823,7 +38911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38832,7 +38920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38846,7 +38934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38855,7 +38943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38869,7 +38957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38878,7 +38966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38892,7 +38980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38901,7 +38989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38915,7 +39003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38924,7 +39012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38938,7 +39026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38947,7 +39035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 564,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38961,7 +39049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38970,7 +39058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38984,7 +39072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -38993,7 +39081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39007,7 +39095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39016,7 +39104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39030,7 +39118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39039,7 +39127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39053,7 +39141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39062,7 +39150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39076,7 +39164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39085,7 +39173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39099,7 +39187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39108,7 +39196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39122,7 +39210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39131,7 +39219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39145,7 +39233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39154,7 +39242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39168,7 +39256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39177,7 +39265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 579,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39191,7 +39279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39200,7 +39288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39214,7 +39302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39223,7 +39311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39237,7 +39325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39246,7 +39334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39260,7 +39348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39269,7 +39357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39283,7 +39371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39292,7 +39380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39306,7 +39394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39315,7 +39403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39329,7 +39417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39338,7 +39426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39352,7 +39440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39361,7 +39449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39375,7 +39463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39384,7 +39472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39398,7 +39486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39407,7 +39495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39421,7 +39509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39430,7 +39518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39444,7 +39532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39453,7 +39541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39467,7 +39555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39476,7 +39564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39490,7 +39578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39499,7 +39587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39513,7 +39601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39522,7 +39610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39536,7 +39624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39545,7 +39633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39559,7 +39647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39568,7 +39656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39582,7 +39670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39591,7 +39679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39605,7 +39693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39614,7 +39702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39628,7 +39716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39637,7 +39725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39651,7 +39739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39660,7 +39748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39674,7 +39762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39683,7 +39771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39697,7 +39785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39706,7 +39794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39720,7 +39808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39729,7 +39817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39743,7 +39831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39752,7 +39840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39766,7 +39854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39775,7 +39863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39789,7 +39877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39798,7 +39886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39812,7 +39900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39821,7 +39909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39835,7 +39923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39844,7 +39932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39858,7 +39946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39867,7 +39955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39881,7 +39969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39890,7 +39978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 615,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39904,7 +39992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39913,7 +40001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39927,7 +40015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39936,7 +40024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39950,7 +40038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39959,7 +40047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39973,7 +40061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -39982,7 +40070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39996,7 +40084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40005,7 +40093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40019,7 +40107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40028,7 +40116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40042,7 +40130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40051,7 +40139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40065,7 +40153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40074,7 +40162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40088,7 +40176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40097,7 +40185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 640,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40111,7 +40199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40120,7 +40208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40134,7 +40222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40143,7 +40231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40157,7 +40245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40166,7 +40254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40180,7 +40268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40189,7 +40277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40203,7 +40291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40212,7 +40300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40226,7 +40314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40235,7 +40323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40249,7 +40337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40258,7 +40346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40272,7 +40360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40281,7 +40369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40295,7 +40383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40304,7 +40392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40318,7 +40406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40327,7 +40415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40341,7 +40429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40350,7 +40438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40364,7 +40452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40373,7 +40461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40387,7 +40475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40396,7 +40484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40410,7 +40498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40419,7 +40507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40433,7 +40521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40442,7 +40530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40456,7 +40544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40465,7 +40553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40479,7 +40567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40488,7 +40576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40502,7 +40590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40511,7 +40599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40525,7 +40613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40534,7 +40622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40548,7 +40636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40557,7 +40645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40571,7 +40659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40580,7 +40668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40594,7 +40682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40603,7 +40691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40617,7 +40705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40626,7 +40714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40640,7 +40728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40649,7 +40737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40663,7 +40751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40672,7 +40760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40686,7 +40774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40695,7 +40783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40709,7 +40797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40718,7 +40806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40732,7 +40820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40741,7 +40829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40755,7 +40843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40764,7 +40852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40778,7 +40866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40787,7 +40875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40801,7 +40889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40810,7 +40898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40824,7 +40912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40833,7 +40921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40847,7 +40935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40856,7 +40944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40870,7 +40958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40879,7 +40967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40893,7 +40981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40902,7 +40990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40916,7 +41004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40925,7 +41013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40939,7 +41027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40948,7 +41036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40962,7 +41050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40971,7 +41059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40985,7 +41073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -40994,7 +41082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41008,7 +41096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41017,7 +41105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41031,7 +41119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41040,7 +41128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41054,7 +41142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41063,7 +41151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41077,7 +41165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41086,7 +41174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41100,7 +41188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41109,7 +41197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41123,7 +41211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41132,7 +41220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41146,7 +41234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41155,7 +41243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41169,7 +41257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41178,7 +41266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41192,7 +41280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41201,7 +41289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41215,7 +41303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41224,7 +41312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41238,7 +41326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41247,7 +41335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41261,7 +41349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41270,7 +41358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41284,7 +41372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41293,7 +41381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41307,7 +41395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41316,7 +41404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41330,7 +41418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41339,7 +41427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41353,7 +41441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41362,7 +41450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41376,7 +41464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41385,7 +41473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41399,7 +41487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41408,7 +41496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 715,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41422,7 +41510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41431,7 +41519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41445,7 +41533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41454,7 +41542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41468,7 +41556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41477,7 +41565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41491,7 +41579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41500,7 +41588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41514,7 +41602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41523,7 +41611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41537,7 +41625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41546,7 +41634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41560,7 +41648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41569,7 +41657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41583,7 +41671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41592,7 +41680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41606,7 +41694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41615,7 +41703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 743,
+        "line": 745,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41629,7 +41717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41638,7 +41726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41652,7 +41740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41661,7 +41749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41675,7 +41763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41684,7 +41772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41698,7 +41786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41707,7 +41795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41721,7 +41809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41730,7 +41818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41744,7 +41832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41753,7 +41841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41767,7 +41855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41776,7 +41864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41790,7 +41878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41799,7 +41887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41813,7 +41901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41822,7 +41910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41836,7 +41924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41845,7 +41933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41859,7 +41947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41868,7 +41956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41882,7 +41970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41891,7 +41979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41905,7 +41993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41914,7 +42002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41928,7 +42016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41937,7 +42025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41951,7 +42039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41960,7 +42048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41974,7 +42062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -41983,7 +42071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41997,7 +42085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42006,7 +42094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42020,7 +42108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42029,7 +42117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42043,7 +42131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42052,7 +42140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42066,7 +42154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42075,7 +42163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42089,7 +42177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42098,7 +42186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42112,7 +42200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42121,7 +42209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42135,7 +42223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42144,7 +42232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42158,7 +42246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42167,7 +42255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42181,7 +42269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42190,7 +42278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42204,7 +42292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42213,7 +42301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 839,
+        "line": 841,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42227,7 +42315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42236,7 +42324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 839,
+        "line": 841,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42250,7 +42338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42259,7 +42347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 839,
+        "line": 841,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42273,7 +42361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42282,7 +42370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 839,
+        "line": 841,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42296,7 +42384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42305,7 +42393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 845,
+        "line": 847,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42319,7 +42407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42328,7 +42416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 845,
+        "line": 847,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42342,7 +42430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42351,7 +42439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 845,
+        "line": 847,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42365,7 +42453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42374,7 +42462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 850,
+        "line": 852,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42388,7 +42476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42397,7 +42485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 850,
+        "line": 852,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42411,7 +42499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42420,7 +42508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 850,
+        "line": 852,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42434,7 +42522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42443,7 +42531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42457,7 +42545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42466,7 +42554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42480,7 +42568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42489,7 +42577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42503,7 +42591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42512,7 +42600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42526,7 +42614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42535,7 +42623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 856,
+        "line": 858,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42549,7 +42637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42558,7 +42646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 863,
+        "line": 865,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42572,7 +42660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42581,7 +42669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 863,
+        "line": 865,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42595,7 +42683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42604,7 +42692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 863,
+        "line": 865,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42618,7 +42706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42627,7 +42715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42641,7 +42729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42650,7 +42738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42664,7 +42752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42673,7 +42761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42687,7 +42775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42696,7 +42784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42710,7 +42798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42719,7 +42807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42733,7 +42821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42742,7 +42830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 887,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42756,7 +42844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42765,7 +42853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42779,7 +42867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42788,7 +42876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42802,7 +42890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42811,7 +42899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42825,7 +42913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42834,7 +42922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42848,7 +42936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42857,7 +42945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42871,7 +42959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42880,7 +42968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42894,7 +42982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42903,7 +42991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42917,7 +43005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42926,7 +43014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 895,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42940,7 +43028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42949,7 +43037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42963,7 +43051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42972,7 +43060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42986,7 +43074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -42995,7 +43083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43009,7 +43097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43018,7 +43106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43032,7 +43120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43041,7 +43129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43055,7 +43143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43064,7 +43152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43078,7 +43166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43087,7 +43175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43101,7 +43189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43110,7 +43198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43124,7 +43212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43133,7 +43221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43147,7 +43235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43156,7 +43244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43170,7 +43258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43179,7 +43267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43193,7 +43281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43202,7 +43290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43216,7 +43304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43225,7 +43313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 928,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43239,7 +43327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43248,7 +43336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 928,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43262,7 +43350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43271,7 +43359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 928,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43285,7 +43373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43294,7 +43382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43308,7 +43396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43317,7 +43405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43331,7 +43419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43340,7 +43428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43354,7 +43442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43363,7 +43451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43377,7 +43465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43386,7 +43474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43400,7 +43488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43409,7 +43497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43423,7 +43511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43432,7 +43520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43446,7 +43534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43455,7 +43543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43469,7 +43557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43478,7 +43566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43492,7 +43580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43501,7 +43589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43515,7 +43603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43524,7 +43612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43538,7 +43626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43547,7 +43635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43561,7 +43649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43570,7 +43658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43584,7 +43672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43593,7 +43681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43607,7 +43695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43616,7 +43704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43630,7 +43718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43639,7 +43727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43653,7 +43741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43662,7 +43750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43676,7 +43764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43685,7 +43773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43699,7 +43787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43708,7 +43796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43722,7 +43810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43731,7 +43819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43745,7 +43833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43754,7 +43842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43768,7 +43856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43777,7 +43865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43791,7 +43879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43800,7 +43888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43814,7 +43902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43823,7 +43911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43837,7 +43925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43846,7 +43934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43860,7 +43948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43869,7 +43957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43883,7 +43971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43892,7 +43980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43906,7 +43994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43915,7 +44003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43929,7 +44017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43938,7 +44026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43952,7 +44040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43961,7 +44049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43975,7 +44063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -43984,7 +44072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43998,7 +44086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44007,7 +44095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44021,7 +44109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44030,7 +44118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44044,7 +44132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44053,7 +44141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44067,7 +44155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44076,7 +44164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44090,7 +44178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44099,7 +44187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44113,7 +44201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44122,7 +44210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44136,7 +44224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44145,7 +44233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44159,7 +44247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44168,7 +44256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44182,7 +44270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44191,7 +44279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44205,7 +44293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44214,7 +44302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44228,7 +44316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44237,7 +44325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44251,7 +44339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44260,7 +44348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44274,7 +44362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44283,7 +44371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44297,7 +44385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44306,7 +44394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44320,7 +44408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44329,7 +44417,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44343,7 +44431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44352,7 +44440,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44366,7 +44454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44375,7 +44463,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1029,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44389,7 +44477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44398,7 +44486,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44412,7 +44500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44421,7 +44509,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44435,7 +44523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44444,7 +44532,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44458,7 +44546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44467,7 +44555,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44481,7 +44569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44490,7 +44578,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44504,7 +44592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44513,7 +44601,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44527,7 +44615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44536,7 +44624,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44550,7 +44638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44559,7 +44647,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44573,7 +44661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44582,7 +44670,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44596,7 +44684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44605,7 +44693,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44619,7 +44707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44628,7 +44716,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44642,7 +44730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44651,7 +44739,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44665,7 +44753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44674,7 +44762,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44688,7 +44776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44697,7 +44785,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44711,7 +44799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44720,7 +44808,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44734,7 +44822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44743,7 +44831,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44757,7 +44845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44766,7 +44854,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44780,7 +44868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44789,7 +44877,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44803,7 +44891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44812,7 +44900,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44826,7 +44914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44835,7 +44923,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44849,7 +44937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44858,7 +44946,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44872,7 +44960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44881,7 +44969,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44895,7 +44983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44904,7 +44992,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44918,7 +45006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 533,
+            "handler_line": 534,
             "kind": "try",
             "line": 11
           }
@@ -44927,7 +45015,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48666,14 +48754,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1722
+            "line": 1659
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1723,
+        "line": 1660,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -48685,14 +48773,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1759
+            "line": 1696
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1760,
+        "line": 1697,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -48704,14 +48792,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1767
+            "line": 1704
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1768,
+        "line": 1705,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50086,14 +50174,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1722
+            "line": 1659
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1723,
+        "line": 1660,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50105,14 +50193,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1759
+            "line": 1696
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1760,
+        "line": 1697,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50124,14 +50212,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1767
+            "line": 1704
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1768,
+        "line": 1705,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51579,7 +51667,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1056,
+        "line": 1058,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51588,7 +51676,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1673,
+        "line": 1610,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51597,7 +51685,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2506,
+        "line": 2443,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51606,7 +51694,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2509,
+        "line": 2446,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51615,7 +51703,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2512,
+        "line": 2449,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51624,7 +51712,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2515,
+        "line": 2452,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51633,7 +51721,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2518,
+        "line": 2455,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51642,7 +51730,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2521,
+        "line": 2458,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51651,7 +51739,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2524,
+        "line": 2461,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51660,7 +51748,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2527,
+        "line": 2464,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51669,7 +51757,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2530,
+        "line": 2467,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51678,7 +51766,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2533,
+        "line": 2470,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51687,7 +51775,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2536,
+        "line": 2473,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51696,7 +51784,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2539,
+        "line": 2476,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51705,7 +51793,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2542,
+        "line": 2479,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51714,7 +51802,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2545,
+        "line": 2482,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51723,7 +51811,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2549,
+        "line": 2486,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51732,7 +51820,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2552,
+        "line": 2489,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51741,7 +51829,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2556,
+        "line": 2493,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51750,7 +51838,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2559,
+        "line": 2496,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51759,7 +51847,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2563,
+        "line": 2500,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51768,7 +51856,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2566,
+        "line": 2503,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51777,7 +51865,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2569,
+        "line": 2506,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51786,7 +51874,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2572,
+        "line": 2509,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51795,7 +51883,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2575,
+        "line": 2512,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51804,7 +51892,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2578,
+        "line": 2515,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51813,7 +51901,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2585,
+        "line": 2522,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51822,7 +51910,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2591,
+        "line": 2528,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51831,7 +51919,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2596,
+        "line": 2533,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51840,7 +51928,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2600,
+        "line": 2537,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52342,25 +52430,25 @@
       },
       {
         "kind": "dict",
-        "line": 1126,
+        "line": 1128,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1115,
+        "line": 1117,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1110,
+        "line": 1112,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "set",
-        "line": 1672,
+        "line": 1609,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "09805305b54932a23db697c04132caaedc95c68b",
+    "base_commit": "617ea140b2f07d6d1a8c341d9145e05a613bed8c",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -34,7 +34,8 @@
       "B-11c2",
       "B-11c3",
       "B-11c4",
-      "B-11c5"
+      "B-11c5",
+      "B-11c6"
     ]
   },
   "enums": {
@@ -69,11 +70,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 265,
+    "nodes_canonical_bindings": 266,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 37,
+    "root_residual_functions": 36,
     "root_residual_classes": 0,
     "root_residual_globals": 32,
     "runtime_binders": 28,
@@ -1878,6 +1879,7 @@
       "symbols": {
         "_bind_aio_generation_normalization_runtime": "_bind_aio_generation_normalization_runtime",
         "_merge_versioned_settings": "_merge_versioned_settings",
+        "_normalize_aio_dit_corrections_settings": "_normalize_aio_dit_corrections_settings",
         "_normalize_aio_generation_settings": "_normalize_aio_generation_settings",
         "_normalize_aio_spectrum_settings": "_normalize_aio_spectrum_settings"
       },
@@ -3943,7 +3945,6 @@
         "_find_loaded_node_class": "_find_loaded_node_class",
         "_is_aio_detailer_target_name": "_is_aio_detailer_target_name",
         "_new_aio_random_seed": "_new_aio_random_seed",
-        "_normalize_aio_dit_corrections_settings": "_normalize_aio_dit_corrections_settings",
         "_normalize_aio_input_settings": "_normalize_aio_input_settings",
         "_normalize_aio_seed": "_normalize_aio_seed",
         "_require_any_custom_node_class": "_require_any_custom_node_class",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -717,6 +717,115 @@ class AioSpectrumNormalizationMoveContractTests(unittest.TestCase):
             self._assert_contract(package_nodes, package_generation_normalization)
 
 
+class AioDitNormalizationMoveContractTests(unittest.TestCase):
+    DEFAULTS = {
+        "enabled": False,
+        "dcw_mode": "off",
+        "dcw_lambda": 0.01,
+        "dcw_band_mask": "LL",
+        "dcw_calibrator": "(auto-download default)",
+        "smc_cfg": False,
+        "adaptive_smc_alpha": 0.0,
+        "smc_cfg_lambda": 6.0,
+        "cfgpp": False,
+        "cfgpp_lambda": 0.0,
+        "fsg": False,
+        "fsg_band_lo": 0.59,
+        "fsg_band_hi": 0.75,
+        "fsg_k": 3,
+        "fsg_d_sigma": 0.1,
+        "fsg_gamma": 0.0,
+        "replace_existing_cfg": False,
+    }
+    EXPECTED = {
+        "enabled": True,
+        "dcw_mode": "off",
+        "dcw_lambda": 1.0,
+        "dcw_band_mask": "LL",
+        "dcw_calibrator": "(auto-download default)",
+        "smc_cfg": True,
+        "adaptive_smc_alpha": 1.0,
+        "smc_cfg_lambda": 20.0,
+        "cfgpp": True,
+        "cfgpp_lambda": 8.0,
+        "fsg": True,
+        "fsg_band_lo": 0.0,
+        "fsg_band_hi": 1.0,
+        "fsg_k": 32,
+        "fsg_d_sigma": 1.0,
+        "fsg_gamma": 10.0,
+        "replace_existing_cfg": True,
+        "future": "kept",
+    }
+
+    def _assert_contract(self, root_module, canonical_module):
+        self.assertIs(
+            root_module._normalize_aio_dit_corrections_settings,
+            canonical_module._normalize_aio_dit_corrections_settings,
+        )
+        value = {
+            "enabled": True,
+            "dcw_mode": "unknown",
+            "dcw_lambda": 5,
+            "dcw_band_mask": "unknown",
+            "dcw_calibrator": "",
+            "smc_cfg": True,
+            "adaptive_smc_alpha": 2,
+            "smc_cfg_lambda": 99,
+            "cfgpp": True,
+            "cfgpp_lambda": 99,
+            "fsg": True,
+            "fsg_band_lo": -1,
+            "fsg_band_hi": 2,
+            "fsg_k": 99,
+            "fsg_d_sigma": 2,
+            "fsg_gamma": 99,
+            "replace_existing_cfg": True,
+            "future": "kept",
+        }
+        with (
+            patch.object(
+                root_module,
+                "_as_bool",
+                wraps=root_module._as_bool,
+            ) as as_bool,
+            patch.object(
+                root_module,
+                "_as_float",
+                wraps=root_module._as_float,
+            ) as as_float,
+            patch.object(
+                root_module,
+                "_as_int",
+                wraps=root_module._as_int,
+            ) as as_int,
+            patch.object(
+                root_module,
+                "_choice",
+                wraps=root_module._choice,
+            ) as choice,
+        ):
+            result = canonical_module._normalize_aio_dit_corrections_settings(
+                value,
+                self.DEFAULTS,
+            )
+        self.assertIs(result, value)
+        self.assertEqual(result, self.EXPECTED)
+        for helper in (as_bool, as_float, as_int, choice):
+            self.assertGreater(helper.call_count, 0)
+
+    def test_root_alias_and_call_time_helpers(self):
+        self._assert_contract(nodes, aio_generation_normalization)
+
+    def test_package_alias_and_call_time_helpers(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_generation_normalization = sys.modules[
+                f"{package_name}.easyuse_anima.aio.generation_normalization"
+            ]
+            self._assert_contract(package_nodes, package_generation_normalization)
+
+
 class ComfyAdapterMoveContractTests(unittest.TestCase):
     RETIRED_SAM3_SERVICE_HELPERS = (
         "_call_impact_detailer",

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "0fd503050bfa9b8881df791bf4c13b5f278133bd")
-        # Issue #184 B-11c5 moves the AiO Spectrum settings normalizer while
+        self.assertEqual(report["git_blob_sha1"], "2ee992eddb12f7e90269ce89cff2c4c8c372d7d0")
+        # Issue #184 B-11c6 moves the AiO DiT correction normalizer while
         # preserving the root alias and call-time coercion helper seams.
-        self.assertEqual(report["top_level"]["function_count"], 37)
+        self.assertEqual(report["top_level"]["function_count"], 36)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_604)
+        self.assertEqual(report["line_count"], 2_541)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "09805305b54932a23db697c04132caaedc95c68b"
+BASE_COMMIT = "617ea140b2f07d6d1a8c341d9145e05a613bed8c"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1308,6 +1308,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c3",
                 "B-11c4",
                 "B-11c5",
+                "B-11c6",
             ],
         },
         "enums": {
@@ -1320,11 +1321,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 265,
+            "nodes_canonical_bindings": 266,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 37,
+            "root_residual_functions": 36,
             "root_residual_classes": 0,
             "root_residual_globals": 32,
             "runtime_binders": 28,


### PR DESCRIPTION
## 변경 전 inventory

- 기준: `dev` / `617ea140b2f07d6d1a8c341d9145e05a613bed8c`
- 유형: Move-only (`B-11c6 AiO DiT correction settings normalizer residual`)
- 선택 근거:
  - B-11c5 뒤 root `nodes.py`에는 37 functions, 0 classes, 32 globals, 28 runtime binders가 남아 있음.
  - `_normalize_aio_dit_corrections_settings`는 자체 상수·global·cache·I/O가 없고 전달된 DiT correction 설정 dict만 기존 범위로 정규화하는 단일 함수임.
  - canonical caller와 기존 runtime resolver가 이미 `easyuse_anima.aio.generation_normalization`에 있어 새 모듈, binder, dependency Contract가 필요하지 않음.
- symbol/caller:
  - dict 입력이면 같은 객체를 제자리 갱신해 반환하고, 비-dict 입력이면 새 dict를 만듦.
  - DCW mode/lambda/band/calibrator, SMC CFG, CFG++, FSG 및 replace-existing-CFG 필드를 기존 coercion·clamp·fallback 순서로 정규화함.
  - 생산 호출자는 `easyuse_anima.aio.generation_normalization._normalize_aio_generation_settings` 안의 highres, upscale, detailer target 경로임.
  - caller는 매 호출마다 기존 root runtime resolver로 `_normalize_aio_dit_corrections_settings`를 조회함.
- alias/compatibility:
  - 현재는 root definition이며 canonical alias가 없음.
  - 이동 후 root relative/flat import가 같은 canonical function을 direct identity alias로 유지함.
  - moved function은 기존 generation-normalization resolver로 root `_as_bool`, `_as_float`, `_as_int`, `_choice`를 조회해 call-time helper replacement를 보존함.
  - `_bind_aio_generation_normalization_runtime`, caller 및 resolver 이름/호출 시점은 변경하지 않음.
- global state:
  - 자체 mutable global, cache, random, lock, file/network I/O가 없음.
  - `defaults`는 읽기만 하고 입력 dict의 기존 in-place mutation 의미만 유지함.

## 허용 경계

- production: `easyuse_anima/aio/generation_normalization.py`, root `nodes.py`
- focused contracts: flat/package direct identity, helper call-time rebind, dict identity, exact coercion/clamp/fallback parity
- analyzer/compatibility: nodes analyzer baseline, backend analyzer fixture, compatibility surface test/fixture
- status docs: backend execution roadmap, compatibility shim registry

## 금지 경계

- DiT correction key, 기본값, clamp 범위, nested fallback 및 helper 호출 순서 변경
- dict mutation/copy 정책, unknown key 보존, DCW/FSG 선택지 변경
- Spectrum normalizer, sampler 내부 보정 실행, dependency detection 통합
- settings schema/default JSON, seed, cache/change-key, model patch 또는 sampler 행동 변경
- runtime binder/resolver signature·binding 순서·caller 변경
- B-11c final shim cutover, Phase C Contract/Behavior, Phase E lifecycle

## 구현 결과

- 현재 함수 본문을 `easyuse_anima.aio.generation_normalization` owner로 이동함.
- 함수 시작에서 네 coercion helper만 기존 module runtime resolver로 조회함.
- root `nodes.py` relative/flat generation-normalization import가 canonical function을 explicit alias로 re-export함.
- analyzer/compatibility fixture는 canonical binding 266, root residual functions 36, globals 32, binders 28을 기록함.
- backend analyzer의 modules/shipped/closure는 81/81/81, side-effect candidates 188, mutable globals 63, compatibility names 23으로 유지됨.

## 검증

- 정확한 PR head: `ced619106b4e27e1dc27949f7649a63e7f08c38d`
- focused `python -m unittest -v`: DiT correction normalizer, AiO settings/storage, typed generation settings, compatibility, nodes/backend analyzer, import boundary 71건 통과
- `tools/check_project.ps1 -Profile full`: Python 894건 통과, frontend 114 JavaScript 파일 통과
- Pyright baseline ratchet: 64파일, 기존 60 errors, 증가 없음
- import boundary: 6 completed package groups, 0 violations
- Ruff report-only: 기존 105 findings, 증가 없음
- `git diff --check`: 통과
- 독립 read-only diff review: 지적사항 없음
- ComfyUI Codex test instance: repository contract/full validation
- Live ComfyUI/browser smoke: 이번 Move-only 단위에서는 미실행

## 남은 위험 / 미확인

- 이 PR은 함수 한 개의 owner만 이동하므로 B-11c와 Phase B를 완료하지 않음.
- AiO seed/settings defaults, Comfy provider, upscale/stage/postprocess, wildcard reservation 및 28 binders는 후속 rollback unit 또는 선행 Contract 대상으로 남음.
- live ComfyUI/browser 및 package/pack exit 검증은 Phase B exit checkpoint에 남김.
