### PR TITLE
refactor(backend): move AiO seed normalization ownership (B-11c7a)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `617ea140b2f07d6d1a8c341d9145e05a613bed8c`
+- Integrated `dev` snapshot commit: `bbca312b684f009aafbd1ed813a8f136e5520b3d`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c5; B-11c6 DiT-normalizer Move in PR #299 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c6; B-11c7a seed-normalizer Move in PR #300 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,604
-  lines after B-11c5.
-- The mechanical extraction has removed 10,059
-  lines, approximately 79.4% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,541
+  lines after B-11c6.
+- The mechanical extraction has removed 10,122
+  lines, approximately 79.9% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -61,7 +61,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   the dependency-free image tensor size helper in PR #296 / `1f18c04`.
   B-11c4 moved the AiO LoRA stack signature helper in PR #297 / `0980530`.
   B-11c5 moved the AiO Spectrum settings normalizer in PR #298 / `617ea14`.
-  B-11c6 moves only the AiO DiT correction normalizer in PR #299.
+  B-11c6 moved the AiO DiT correction normalizer in PR #299 / `bbca312`.
+  B-11c7a moves only the AiO special-seed constants and settings normalizer in
+  PR #300; runtime RNG generation and seed interpretation remain separate.
 
 ### Current quality baseline
 
@@ -303,7 +305,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 DiT-normalizer PR #299 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a seed-normalizer PR #300 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -824,6 +826,14 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     existing caller resolver, call-time coercion helper replacement, in-place
     dict semantics, and exact DCW/SMC/CFG++/FSG clamp and fallback order;
     Spectrum, seed, schema/default, and sampler execution remain separate.
+  - B-11c7a moves only `AIO_SPECIAL_SEED_RANDOM`,
+    `AIO_SPECIAL_SEED_INCREMENT`, `AIO_SPECIAL_SEED_DECREMENT`,
+    `AIO_SPECIAL_SEEDS`, and `_normalize_aio_seed` to the same
+    generation-normalization owner. PR #300 retains direct root alias identity,
+    the mutable special-seed set, and call-time root `_as_int`, `MAX_SEED`, and
+    lower-bound replacement. Runtime random seed generation, special-seed
+    interpretation, increment/decrement behavior, and seed reservation remain
+    separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `617ea140b2f07d6d1a8c341d9145e05a613bed8c`
+  `bbca312b684f009aafbd1ed813a8f136e5520b3d`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c5 are integrated through PR #298. B-11c is
+- Current state: B-11a through B-11c6 are integrated through PR #299. B-11c is
   split into residual-owner and binder Moves before the final root shim;
-  B-11c6 AiO DiT correction normalizer ownership is tracked by PR #299.
+  B-11c7a AiO seed-normalizer ownership is tracked by PR #300.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,8 +75,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 266 after
-  B-11c6 (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 271 after
+  B-11c7a (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -84,8 +84,8 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 36 functions, 0 classes, and 32 assigned
-  globals after B-11c6 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 35 functions, 0 classes, and 28 assigned
+  globals after B-11c7a (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 256, including
   literal lookups and binder-owned helper-name/default collections;
@@ -233,6 +233,23 @@ convenience-node compatibility; it remains unmapped and is not public support.
   DCW/SMC/CFG++/FSG choices, clamp bounds, and nested fallback order remain
   unchanged in PR #299. Spectrum, seed, schema/default, and sampler execution
   stay outside this Move.
+
+### B-11c7a AiO special-seed settings aliases
+
+- Canonical owner:
+  `easyuse_anima.aio.generation_normalization` for
+  `AIO_SPECIAL_SEED_RANDOM`, `AIO_SPECIAL_SEED_INCREMENT`,
+  `AIO_SPECIAL_SEED_DECREMENT`, `AIO_SPECIAL_SEEDS`, and
+  `_normalize_aio_seed`.
+- The private root names remain transitional direct aliases in both relative
+  package and flat import modes. The mutable special-seed set keeps exact
+  root/canonical object identity.
+- The moved normalizer resolves root `_as_int`, `MAX_SEED`, and the lower-bound
+  constant through the existing generation-normalization runtime seam, so
+  call-time replacement and the `[-3, MAX_SEED]` clamp remain unchanged.
+- PR #300 does not move or alter `_new_aio_random_seed`,
+  `_resolve_aio_runtime_seed`, Python RNG consumption, `seed_after_generate`,
+  increment/decrement behavior, cache keys, or backend seed reservation.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/generation_normalization.py
+++ b/easyuse_anima/aio/generation_normalization.py
@@ -26,6 +26,23 @@ def _runtime_helper(name: str) -> Any:
     return resolver(name)
 
 
+AIO_SPECIAL_SEED_RANDOM = -1
+AIO_SPECIAL_SEED_INCREMENT = -2
+AIO_SPECIAL_SEED_DECREMENT = -3
+AIO_SPECIAL_SEEDS = {
+    AIO_SPECIAL_SEED_RANDOM,
+    AIO_SPECIAL_SEED_INCREMENT,
+    AIO_SPECIAL_SEED_DECREMENT,
+}
+
+
+def _normalize_aio_seed(value, default: int = AIO_SPECIAL_SEED_RANDOM) -> int:
+    _as_int = _runtime_helper("_as_int")
+    max_seed = _runtime_helper("MAX_SEED")
+    minimum_seed = _runtime_helper("AIO_SPECIAL_SEED_DECREMENT")
+    return max(minimum_seed, min(max_seed, _as_int(value, default)))
+
+
 def _merge_versioned_settings(defaults: dict[str, Any], value) -> dict[str, Any]:
     _json_clone = _runtime_helper("_json_clone")
     _json_object = _runtime_helper("_json_object")

--- a/nodes.py
+++ b/nodes.py
@@ -25,10 +25,15 @@ try:
         _run_aio_legacy_generation as _run_aio_legacy_generation,
     )
     from .easyuse_anima.aio.generation_normalization import (
+        AIO_SPECIAL_SEEDS as AIO_SPECIAL_SEEDS,
+        AIO_SPECIAL_SEED_DECREMENT as AIO_SPECIAL_SEED_DECREMENT,
+        AIO_SPECIAL_SEED_INCREMENT as AIO_SPECIAL_SEED_INCREMENT,
+        AIO_SPECIAL_SEED_RANDOM as AIO_SPECIAL_SEED_RANDOM,
         _bind_aio_generation_normalization_runtime as _bind_aio_generation_normalization_runtime,
         _merge_versioned_settings as _merge_versioned_settings,
         _normalize_aio_dit_corrections_settings as _normalize_aio_dit_corrections_settings,
         _normalize_aio_generation_settings as _normalize_aio_generation_settings,
+        _normalize_aio_seed as _normalize_aio_seed,
         _normalize_aio_spectrum_settings as _normalize_aio_spectrum_settings,
     )
     from .easyuse_anima.aio.generation_settings import (
@@ -548,10 +553,15 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _run_aio_legacy_generation as _run_aio_legacy_generation,
     )
     from easyuse_anima.aio.generation_normalization import (
+        AIO_SPECIAL_SEEDS as AIO_SPECIAL_SEEDS,
+        AIO_SPECIAL_SEED_DECREMENT as AIO_SPECIAL_SEED_DECREMENT,
+        AIO_SPECIAL_SEED_INCREMENT as AIO_SPECIAL_SEED_INCREMENT,
+        AIO_SPECIAL_SEED_RANDOM as AIO_SPECIAL_SEED_RANDOM,
         _bind_aio_generation_normalization_runtime as _bind_aio_generation_normalization_runtime,
         _merge_versioned_settings as _merge_versioned_settings,
         _normalize_aio_dit_corrections_settings as _normalize_aio_dit_corrections_settings,
         _normalize_aio_generation_settings as _normalize_aio_generation_settings,
+        _normalize_aio_seed as _normalize_aio_seed,
         _normalize_aio_spectrum_settings as _normalize_aio_spectrum_settings,
     )
     from easyuse_anima.aio.generation_settings import (
@@ -1106,14 +1116,6 @@ ANIMA_UNET_WEIGHT_DTYPES = (
     "fp8_e5m2",
 )
 ANIMA_CLIP_DEVICES = ("default", "cpu")
-AIO_SPECIAL_SEED_RANDOM = -1
-AIO_SPECIAL_SEED_INCREMENT = -2
-AIO_SPECIAL_SEED_DECREMENT = -3
-AIO_SPECIAL_SEEDS = {
-    AIO_SPECIAL_SEED_RANDOM,
-    AIO_SPECIAL_SEED_INCREMENT,
-    AIO_SPECIAL_SEED_DECREMENT,
-}
 AIO_INPUT_DEFAULT_SETTINGS = {
     "schema": EASY_USE_ANIMA_INPUT_SCHEMA,
     "version": EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
@@ -1555,10 +1557,6 @@ AIO_RESHIFT_DTYPES = ("bf16", "fp32")
 
 
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
-
-
-def _normalize_aio_seed(value, default: int = AIO_SPECIAL_SEED_RANDOM) -> int:
-    return max(AIO_SPECIAL_SEED_DECREMENT, min(MAX_SEED, _as_int(value, default)))
 
 
 def _new_aio_random_seed() -> int:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14535,6 +14535,130 @@
         "target": "easyuse_anima/aio/legacy_generation.py"
       },
       {
+        "alias": "AIO_SPECIAL_SEEDS",
+        "bound_name": "AIO_SPECIAL_SEEDS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AIO_SPECIAL_SEEDS",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
+        "kind": "static_from",
+        "line": 27,
+        "name": "AIO_SPECIAL_SEEDS",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": "AIO_SPECIAL_SEED_DECREMENT",
+        "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
+        "kind": "static_from",
+        "line": 27,
+        "name": "AIO_SPECIAL_SEED_DECREMENT",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": "AIO_SPECIAL_SEED_INCREMENT",
+        "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
+        "kind": "static_from",
+        "line": 27,
+        "name": "AIO_SPECIAL_SEED_INCREMENT",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": "AIO_SPECIAL_SEED_RANDOM",
+        "bound_name": "AIO_SPECIAL_SEED_RANDOM",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AIO_SPECIAL_SEED_RANDOM",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
+        "kind": "static_from",
+        "line": 27,
+        "name": "AIO_SPECIAL_SEED_RANDOM",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
         "alias": "_bind_aio_generation_normalization_runtime",
         "bound_name": "_bind_aio_generation_normalization_runtime",
         "branch_context": [
@@ -14659,6 +14783,37 @@
         "target": "easyuse_anima/aio/generation_normalization.py"
       },
       {
+        "alias": "_normalize_aio_seed",
+        "bound_name": "_normalize_aio_seed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_aio_seed",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_normalize_aio_seed",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
         "alias": "_normalize_aio_spectrum_settings",
         "bound_name": "_normalize_aio_spectrum_settings",
         "branch_context": [
@@ -14711,7 +14866,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 34,
+        "line": 39,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -14742,7 +14897,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 37,
+        "line": 42,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14773,7 +14928,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 37,
+        "line": 42,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14804,7 +14959,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 37,
+        "line": 42,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14835,7 +14990,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 37,
+        "line": 42,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14866,7 +15021,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14897,7 +15052,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14928,7 +15083,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14959,7 +15114,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14990,7 +15145,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15021,7 +15176,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15052,7 +15207,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15083,7 +15238,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15114,7 +15269,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15145,7 +15300,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15176,7 +15331,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15207,7 +15362,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15238,7 +15393,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 43,
+        "line": 48,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15269,7 +15424,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 58,
+        "line": 63,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15300,7 +15455,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 58,
+        "line": 63,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15331,7 +15486,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 58,
+        "line": 63,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15362,7 +15517,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 58,
+        "line": 63,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15393,7 +15548,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 58,
+        "line": 63,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15424,7 +15579,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 58,
+        "line": 63,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15455,7 +15610,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 58,
+        "line": 63,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15486,7 +15641,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 58,
+        "line": 63,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15517,7 +15672,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 58,
+        "line": 63,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15548,7 +15703,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 58,
+        "line": 63,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15579,7 +15734,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 70,
+        "line": 75,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15610,7 +15765,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 70,
+        "line": 75,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15641,7 +15796,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 70,
+        "line": 75,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15672,7 +15827,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 70,
+        "line": 75,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15703,7 +15858,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 70,
+        "line": 75,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15734,7 +15889,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 70,
+        "line": 75,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15765,7 +15920,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 70,
+        "line": 75,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15796,7 +15951,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 70,
+        "line": 75,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15827,7 +15982,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 70,
+        "line": 75,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15858,7 +16013,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 70,
+        "line": 75,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15889,7 +16044,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 82,
+        "line": 87,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15920,7 +16075,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 82,
+        "line": 87,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15951,7 +16106,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 82,
+        "line": 87,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15982,7 +16137,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 82,
+        "line": 87,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16013,7 +16168,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 82,
+        "line": 87,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16044,7 +16199,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 82,
+        "line": 87,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16075,7 +16230,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 82,
+        "line": 87,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16106,7 +16261,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 82,
+        "line": 87,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16137,7 +16292,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 82,
+        "line": 87,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16168,7 +16323,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 82,
+        "line": 87,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16199,7 +16354,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 94,
+        "line": 99,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16230,7 +16385,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 94,
+        "line": 99,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16261,7 +16416,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 94,
+        "line": 99,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16292,7 +16447,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 94,
+        "line": 99,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16323,7 +16478,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 94,
+        "line": 99,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16354,7 +16509,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 94,
+        "line": 99,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16385,7 +16540,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 94,
+        "line": 99,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16416,7 +16571,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 94,
+        "line": 99,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16447,7 +16602,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 94,
+        "line": 99,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16478,7 +16633,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 94,
+        "line": 99,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16509,7 +16664,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 94,
+        "line": 99,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16540,7 +16695,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 107,
+        "line": 112,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16571,7 +16726,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 107,
+        "line": 112,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16602,7 +16757,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 107,
+        "line": 112,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16633,7 +16788,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 112,
+        "line": 117,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16664,7 +16819,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 112,
+        "line": 117,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16695,7 +16850,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 112,
+        "line": 117,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16726,7 +16881,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 112,
+        "line": 117,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16757,7 +16912,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 112,
+        "line": 117,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16788,7 +16943,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 119,
+        "line": 124,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -16819,7 +16974,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 120,
+        "line": 125,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16850,7 +17005,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 120,
+        "line": 125,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16881,7 +17036,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 120,
+        "line": 125,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16912,7 +17067,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 120,
+        "line": 125,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16943,7 +17098,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 126,
+        "line": 131,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16974,7 +17129,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 126,
+        "line": 131,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17005,7 +17160,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 126,
+        "line": 131,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17036,7 +17191,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 126,
+        "line": 131,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17067,7 +17222,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 126,
+        "line": 131,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17098,7 +17253,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 126,
+        "line": 131,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17129,7 +17284,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 126,
+        "line": 131,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17160,7 +17315,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 126,
+        "line": 131,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17191,7 +17346,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 126,
+        "line": 131,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17222,7 +17377,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 126,
+        "line": 131,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17253,7 +17408,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 140,
+        "line": 145,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17284,7 +17439,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 140,
+        "line": 145,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17315,7 +17470,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 140,
+        "line": 145,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17346,7 +17501,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 140,
+        "line": 145,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17377,7 +17532,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 140,
+        "line": 145,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17408,7 +17563,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 140,
+        "line": 145,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17439,7 +17594,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 140,
+        "line": 145,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17470,7 +17625,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17501,7 +17656,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17532,7 +17687,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17563,7 +17718,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17594,7 +17749,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17625,7 +17780,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17656,7 +17811,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17687,7 +17842,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17718,7 +17873,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17749,7 +17904,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17780,7 +17935,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17811,7 +17966,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17842,7 +17997,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17873,7 +18028,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17904,7 +18059,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17935,7 +18090,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17966,7 +18121,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17997,7 +18152,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18028,7 +18183,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18059,7 +18214,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18090,7 +18245,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18121,7 +18276,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 158,
+        "line": 163,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18152,7 +18307,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18183,7 +18338,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18214,7 +18369,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18245,7 +18400,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18276,7 +18431,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18307,7 +18462,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18338,7 +18493,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18369,7 +18524,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18400,7 +18555,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18431,7 +18586,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18462,7 +18617,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18493,7 +18648,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18524,7 +18679,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18555,7 +18710,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 194,
+        "line": 199,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18586,7 +18741,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 222,
+        "line": 227,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18617,7 +18772,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 222,
+        "line": 227,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18648,7 +18803,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 222,
+        "line": 227,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18679,7 +18834,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 222,
+        "line": 227,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18710,7 +18865,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 222,
+        "line": 227,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18741,7 +18896,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 222,
+        "line": 227,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18772,7 +18927,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 222,
+        "line": 227,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18803,7 +18958,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 222,
+        "line": 227,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18834,7 +18989,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 222,
+        "line": 227,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18865,7 +19020,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18896,7 +19051,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18927,7 +19082,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18958,7 +19113,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18989,7 +19144,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19020,7 +19175,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19051,7 +19206,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19082,7 +19237,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19113,7 +19268,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19144,7 +19299,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19175,7 +19330,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19206,7 +19361,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19237,7 +19392,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19268,7 +19423,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19299,7 +19454,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19330,7 +19485,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19361,7 +19516,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19392,7 +19547,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19423,7 +19578,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19454,7 +19609,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19485,7 +19640,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19516,7 +19671,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19547,7 +19702,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19578,7 +19733,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19609,7 +19764,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 238,
+        "line": 243,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19640,7 +19795,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 318,
+        "line": 323,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19671,7 +19826,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 318,
+        "line": 323,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19702,7 +19857,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 318,
+        "line": 323,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19733,7 +19888,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 318,
+        "line": 323,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19764,7 +19919,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 324,
+        "line": 329,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19795,7 +19950,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 324,
+        "line": 329,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19826,7 +19981,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 324,
+        "line": 329,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19857,7 +20012,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 329,
+        "line": 334,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19888,7 +20043,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 329,
+        "line": 334,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19919,7 +20074,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 329,
+        "line": 334,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -19950,7 +20105,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 335,
+        "line": 340,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -19981,7 +20136,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 335,
+        "line": 340,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20012,7 +20167,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 335,
+        "line": 340,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20043,7 +20198,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 335,
+        "line": 340,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20074,7 +20229,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 335,
+        "line": 340,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20105,7 +20260,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 342,
+        "line": 347,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20136,7 +20291,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 342,
+        "line": 347,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20167,7 +20322,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 342,
+        "line": 347,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20198,7 +20353,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 353,
+        "line": 358,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20229,7 +20384,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 353,
+        "line": 358,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20260,7 +20415,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 353,
+        "line": 358,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20291,7 +20446,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 353,
+        "line": 358,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20322,7 +20477,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 366,
+        "line": 371,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20353,7 +20508,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 366,
+        "line": 371,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20384,7 +20539,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 374,
+        "line": 379,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20415,7 +20570,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 374,
+        "line": 379,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20446,7 +20601,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 374,
+        "line": 379,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20477,7 +20632,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 374,
+        "line": 379,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20508,7 +20663,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 374,
+        "line": 379,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20539,7 +20694,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 374,
+        "line": 379,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20570,7 +20725,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 374,
+        "line": 379,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20601,7 +20756,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 374,
+        "line": 379,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20632,7 +20787,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 385,
+        "line": 390,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20663,7 +20818,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 385,
+        "line": 390,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20694,7 +20849,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 385,
+        "line": 390,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20725,7 +20880,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 385,
+        "line": 390,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20756,7 +20911,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 391,
+        "line": 396,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20787,7 +20942,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 391,
+        "line": 396,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20818,7 +20973,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 391,
+        "line": 396,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20849,7 +21004,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 391,
+        "line": 396,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20880,7 +21035,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 391,
+        "line": 396,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20911,7 +21066,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 399,
+        "line": 404,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20942,7 +21097,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 399,
+        "line": 404,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -20973,7 +21128,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 403,
+        "line": 408,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21004,7 +21159,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 407,
+        "line": 412,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21035,7 +21190,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 407,
+        "line": 412,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21066,7 +21221,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 407,
+        "line": 412,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21097,7 +21252,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 412,
+        "line": 417,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21128,7 +21283,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 412,
+        "line": 417,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21159,7 +21314,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 412,
+        "line": 417,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21190,7 +21345,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 412,
+        "line": 417,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21221,7 +21376,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 412,
+        "line": 417,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21252,7 +21407,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 419,
+        "line": 424,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21283,7 +21438,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 419,
+        "line": 424,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21314,7 +21469,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 419,
+        "line": 424,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21345,7 +21500,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 424,
+        "line": 429,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21376,7 +21531,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 424,
+        "line": 429,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21407,7 +21562,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 424,
+        "line": 429,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21438,7 +21593,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 442,
+        "line": 447,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21469,7 +21624,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 442,
+        "line": 447,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21500,7 +21655,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 442,
+        "line": 447,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21531,7 +21686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 442,
+        "line": 447,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21562,7 +21717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 442,
+        "line": 447,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21593,7 +21748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 465,
+        "line": 470,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21624,7 +21779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 465,
+        "line": 470,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21655,7 +21810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 469,
+        "line": 474,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21686,7 +21841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 469,
+        "line": 474,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21717,7 +21872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21748,7 +21903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21779,7 +21934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21810,7 +21965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21841,7 +21996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21872,7 +22027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21903,7 +22058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21934,7 +22089,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21965,7 +22120,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21996,7 +22151,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22027,7 +22182,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22058,7 +22213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22089,7 +22244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22120,7 +22275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22151,7 +22306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 474,
+        "line": 479,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22182,7 +22337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 491,
+        "line": 496,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22213,7 +22368,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 491,
+        "line": 496,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22244,7 +22399,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 491,
+        "line": 496,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22275,7 +22430,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 491,
+        "line": 496,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22306,7 +22461,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 491,
+        "line": 496,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22337,7 +22492,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 491,
+        "line": 496,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22368,7 +22523,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 491,
+        "line": 496,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22399,7 +22554,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 491,
+        "line": 496,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22430,7 +22585,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 501,
+        "line": 506,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22461,7 +22616,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 501,
+        "line": 506,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22492,7 +22647,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 505,
+        "line": 510,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22523,7 +22678,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 505,
+        "line": 510,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22554,7 +22709,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 506,
+        "line": 511,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -22585,7 +22740,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 507,
+        "line": 512,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -22616,7 +22771,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 507,
+        "line": 512,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -22647,7 +22802,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 507,
+        "line": 512,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -22678,7 +22833,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 512,
+        "line": 517,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22709,7 +22864,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 512,
+        "line": 517,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22740,7 +22895,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22771,7 +22926,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22802,7 +22957,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22833,7 +22988,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22864,7 +23019,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22895,7 +23050,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22926,7 +23081,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22957,7 +23112,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22988,7 +23143,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23019,7 +23174,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23050,7 +23205,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23081,7 +23236,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23112,7 +23267,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23143,7 +23298,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23174,7 +23329,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23205,7 +23360,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23236,7 +23391,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23267,7 +23422,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23298,7 +23453,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 513,
+        "line": 518,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23317,7 +23472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23332,7 +23487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23351,7 +23506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23366,7 +23521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23385,7 +23540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23400,7 +23555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23419,7 +23574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23434,7 +23589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23453,7 +23608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23468,7 +23623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23487,7 +23642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23502,7 +23657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23521,7 +23676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23536,7 +23691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23555,7 +23710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23570,7 +23725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23589,7 +23744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23604,7 +23759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 546,
+        "line": 551,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23623,7 +23778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23638,7 +23793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 546,
+        "line": 551,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23646,6 +23801,142 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": "AIO_SPECIAL_SEEDS",
+        "bound_name": "AIO_SPECIAL_SEEDS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 539,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AIO_SPECIAL_SEEDS",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
+        "kind": "static_from",
+        "line": 555,
+        "name": "AIO_SPECIAL_SEEDS",
+        "optional": false,
+        "requested": "easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": "AIO_SPECIAL_SEED_DECREMENT",
+        "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 539,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
+        "kind": "static_from",
+        "line": 555,
+        "name": "AIO_SPECIAL_SEED_DECREMENT",
+        "optional": false,
+        "requested": "easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": "AIO_SPECIAL_SEED_INCREMENT",
+        "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 539,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
+        "kind": "static_from",
+        "line": 555,
+        "name": "AIO_SPECIAL_SEED_INCREMENT",
+        "optional": false,
+        "requested": "easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": "AIO_SPECIAL_SEED_RANDOM",
+        "bound_name": "AIO_SPECIAL_SEED_RANDOM",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 539,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AIO_SPECIAL_SEED_RANDOM",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
+        "kind": "static_from",
+        "line": 555,
+        "name": "AIO_SPECIAL_SEED_RANDOM",
+        "optional": false,
+        "requested": "easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
       },
       {
         "alias": "_bind_aio_generation_normalization_runtime",
@@ -23657,7 +23948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23672,7 +23963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 550,
+        "line": 555,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23691,7 +23982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23706,7 +23997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 550,
+        "line": 555,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23725,7 +24016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23740,7 +24031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 550,
+        "line": 555,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23759,7 +24050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23774,8 +24065,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 550,
+        "line": 555,
         "name": "_normalize_aio_generation_settings",
+        "optional": false,
+        "requested": "easyuse_anima.aio.generation_normalization",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": "_normalize_aio_seed",
+        "bound_name": "_normalize_aio_seed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 539,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_aio_seed",
+          "target": "easyuse_anima/aio/generation_normalization.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
+        "kind": "static_from",
+        "line": 555,
+        "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
         "role": "compatibility_fallback",
@@ -23793,7 +24118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23808,7 +24133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 550,
+        "line": 555,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23827,7 +24152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23842,7 +24167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 567,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -23861,7 +24186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23876,7 +24201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 560,
+        "line": 570,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23895,7 +24220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23910,7 +24235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 560,
+        "line": 570,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23929,7 +24254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23944,7 +24269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 560,
+        "line": 570,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23963,7 +24288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -23978,7 +24303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 560,
+        "line": 570,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -23997,7 +24322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24012,7 +24337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24031,7 +24356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24046,7 +24371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24065,7 +24390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24080,7 +24405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24099,7 +24424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24114,7 +24439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24133,7 +24458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24148,7 +24473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24167,7 +24492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24182,7 +24507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24201,7 +24526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24216,7 +24541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24235,7 +24560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24250,7 +24575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24269,7 +24594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24284,7 +24609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24303,7 +24628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24318,7 +24643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24337,7 +24662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24352,7 +24677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24371,7 +24696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24386,7 +24711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24405,7 +24730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24420,7 +24745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24439,7 +24764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24454,7 +24779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24473,7 +24798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24488,7 +24813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24507,7 +24832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24522,7 +24847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24541,7 +24866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24556,7 +24881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24575,7 +24900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24590,7 +24915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24609,7 +24934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24624,7 +24949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24643,7 +24968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24658,7 +24983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24677,7 +25002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24692,7 +25017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24711,7 +25036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24726,7 +25051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24745,7 +25070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24760,7 +25085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24779,7 +25104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24794,7 +25119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24813,7 +25138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24828,7 +25153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24847,7 +25172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24862,7 +25187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24881,7 +25206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24896,7 +25221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24915,7 +25240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24930,7 +25255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24949,7 +25274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24964,7 +25289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -24983,7 +25308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -24998,7 +25323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25017,7 +25342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25032,7 +25357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25051,7 +25376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25066,7 +25391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25085,7 +25410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25100,7 +25425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25119,7 +25444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25134,7 +25459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25153,7 +25478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25168,7 +25493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25187,7 +25512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25202,7 +25527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25221,7 +25546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25236,7 +25561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25255,7 +25580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25270,7 +25595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25289,7 +25614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25304,7 +25629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25323,7 +25648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25338,7 +25663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25357,7 +25682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25372,7 +25697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25391,7 +25716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25406,7 +25731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25425,7 +25750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25440,7 +25765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25459,7 +25784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25474,7 +25799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25493,7 +25818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25508,7 +25833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25527,7 +25852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25542,7 +25867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25561,7 +25886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25576,7 +25901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25595,7 +25920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25610,7 +25935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25629,7 +25954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25644,7 +25969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25663,7 +25988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25678,7 +26003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25697,7 +26022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25712,7 +26037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25731,7 +26056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25746,7 +26071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25765,7 +26090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25780,7 +26105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25799,7 +26124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25814,7 +26139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25833,7 +26158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25848,7 +26173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 630,
+        "line": 640,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25867,7 +26192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25882,7 +26207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 630,
+        "line": 640,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25901,7 +26226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25916,7 +26241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 630,
+        "line": 640,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25935,7 +26260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25950,7 +26275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 635,
+        "line": 645,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25969,7 +26294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -25984,7 +26309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 635,
+        "line": 645,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26003,7 +26328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26018,7 +26343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 635,
+        "line": 645,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26037,7 +26362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26052,7 +26377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 635,
+        "line": 645,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26071,7 +26396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26086,7 +26411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 635,
+        "line": 645,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26105,7 +26430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26120,7 +26445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 642,
+        "line": 652,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -26139,7 +26464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26154,7 +26479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26173,7 +26498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26188,7 +26513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26207,7 +26532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26222,7 +26547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26241,7 +26566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26256,7 +26581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26275,7 +26600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26290,7 +26615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26309,7 +26634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26324,7 +26649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26343,7 +26668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26358,7 +26683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26377,7 +26702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26392,7 +26717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26411,7 +26736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26426,7 +26751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26445,7 +26770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26460,7 +26785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26479,7 +26804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26494,7 +26819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26513,7 +26838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26528,7 +26853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26547,7 +26872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26562,7 +26887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26581,7 +26906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26596,7 +26921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26615,7 +26940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26630,7 +26955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26649,7 +26974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26664,7 +26989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26683,7 +27008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26698,7 +27023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26717,7 +27042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26732,7 +27057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26751,7 +27076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26766,7 +27091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26785,7 +27110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26800,7 +27125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26819,7 +27144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26834,7 +27159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26853,7 +27178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26868,7 +27193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26887,7 +27212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26902,7 +27227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26921,7 +27246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26936,7 +27261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26955,7 +27280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -26970,7 +27295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -26989,7 +27314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27004,7 +27329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27023,7 +27348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27038,7 +27363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27057,7 +27382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27072,7 +27397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27091,7 +27416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27106,7 +27431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27125,7 +27450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27140,7 +27465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27159,7 +27484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27174,7 +27499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27193,7 +27518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27208,7 +27533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27227,7 +27552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27242,7 +27567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27261,7 +27586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27276,7 +27601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27295,7 +27620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27310,7 +27635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27329,7 +27654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27344,7 +27669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27363,7 +27688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27378,7 +27703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27397,7 +27722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27412,7 +27737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27431,7 +27756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27446,7 +27771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27465,7 +27790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27480,7 +27805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27499,7 +27824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27514,7 +27839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27533,7 +27858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27548,7 +27873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27567,7 +27892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27582,7 +27907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27601,7 +27926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27616,7 +27941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27635,7 +27960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27650,7 +27975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27669,7 +27994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27684,7 +28009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27703,7 +28028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27718,7 +28043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27737,7 +28062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27752,7 +28077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27771,7 +28096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27786,7 +28111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27805,7 +28130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27820,7 +28145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27839,7 +28164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27854,7 +28179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27873,7 +28198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27888,7 +28213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27907,7 +28232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27922,7 +28247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27941,7 +28266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27956,7 +28281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27975,7 +28300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -27990,7 +28315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28009,7 +28334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28024,7 +28349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28043,7 +28368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28058,7 +28383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28077,7 +28402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28092,7 +28417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28111,7 +28436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28126,7 +28451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28145,7 +28470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28160,7 +28485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28179,7 +28504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28194,7 +28519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28213,7 +28538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28228,7 +28553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28247,7 +28572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28262,7 +28587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28281,7 +28606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28296,7 +28621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28315,7 +28640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28330,7 +28655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28349,7 +28674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28364,7 +28689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28383,7 +28708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28398,7 +28723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28417,7 +28742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28432,7 +28757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28451,7 +28776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28466,7 +28791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28485,7 +28810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28500,7 +28825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28519,7 +28844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28534,7 +28859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28553,7 +28878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28568,7 +28893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28587,7 +28912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28602,7 +28927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28621,7 +28946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28636,7 +28961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28655,7 +28980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28670,7 +28995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28689,7 +29014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28704,7 +29029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28723,7 +29048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28738,7 +29063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28757,7 +29082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28772,7 +29097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28791,7 +29116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28806,7 +29131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28825,7 +29150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28840,7 +29165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28859,7 +29184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28874,7 +29199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28893,7 +29218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28908,7 +29233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28927,7 +29252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28942,7 +29267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28961,7 +29286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -28976,7 +29301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28995,7 +29320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29010,7 +29335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29029,7 +29354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29044,7 +29369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29063,7 +29388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29078,7 +29403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29097,7 +29422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29112,7 +29437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29131,7 +29456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29146,7 +29471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29165,7 +29490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29180,7 +29505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29199,7 +29524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29214,7 +29539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29233,7 +29558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29248,7 +29573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 841,
+        "line": 851,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29267,7 +29592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29282,7 +29607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 841,
+        "line": 851,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29301,7 +29626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29316,7 +29641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 841,
+        "line": 851,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29335,7 +29660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29350,7 +29675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 841,
+        "line": 851,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29369,7 +29694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29384,7 +29709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 847,
+        "line": 857,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29403,7 +29728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29418,7 +29743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 847,
+        "line": 857,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29437,7 +29762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29452,7 +29777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 847,
+        "line": 857,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29471,7 +29796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29486,7 +29811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 852,
+        "line": 862,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29505,7 +29830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29520,7 +29845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 852,
+        "line": 862,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29539,7 +29864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29554,7 +29879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 852,
+        "line": 862,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29573,7 +29898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29588,7 +29913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 858,
+        "line": 868,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29607,7 +29932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29622,7 +29947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 858,
+        "line": 868,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29641,7 +29966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29656,7 +29981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 858,
+        "line": 868,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29675,7 +30000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29690,7 +30015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 858,
+        "line": 868,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29709,7 +30034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29724,7 +30049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 858,
+        "line": 868,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29743,7 +30068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29758,7 +30083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 865,
+        "line": 875,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29777,7 +30102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29792,7 +30117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 865,
+        "line": 875,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29811,7 +30136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29826,7 +30151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 865,
+        "line": 875,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -29845,7 +30170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29860,7 +30185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 876,
+        "line": 886,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29879,7 +30204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29894,7 +30219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 876,
+        "line": 886,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29913,7 +30238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29928,7 +30253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 876,
+        "line": 886,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29947,7 +30272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29962,7 +30287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 876,
+        "line": 886,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -29981,7 +30306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -29996,7 +30321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 889,
+        "line": 899,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -30015,7 +30340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30030,7 +30355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 889,
+        "line": 899,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -30049,7 +30374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30064,7 +30389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30083,7 +30408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30098,7 +30423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30117,7 +30442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30132,7 +30457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30151,7 +30476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30166,7 +30491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30185,7 +30510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30200,7 +30525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30219,7 +30544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30234,7 +30559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30253,7 +30578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30268,7 +30593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30287,7 +30612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30302,7 +30627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30321,7 +30646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30336,7 +30661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 908,
+        "line": 918,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30355,7 +30680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30370,7 +30695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 908,
+        "line": 918,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30389,7 +30714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30404,7 +30729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 908,
+        "line": 918,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30423,7 +30748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30438,7 +30763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 908,
+        "line": 918,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30457,7 +30782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30472,7 +30797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 914,
+        "line": 924,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30491,7 +30816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30506,7 +30831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 914,
+        "line": 924,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30525,7 +30850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30540,7 +30865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 914,
+        "line": 924,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30559,7 +30884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30574,7 +30899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 914,
+        "line": 924,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30593,7 +30918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30608,7 +30933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 914,
+        "line": 924,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30627,7 +30952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30642,7 +30967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 922,
+        "line": 932,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30661,7 +30986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30676,7 +31001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 922,
+        "line": 932,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30695,7 +31020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30710,7 +31035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -30729,7 +31054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30744,7 +31069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 930,
+        "line": 940,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30763,7 +31088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30778,7 +31103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 930,
+        "line": 940,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30797,7 +31122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30812,7 +31137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 930,
+        "line": 940,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -30831,7 +31156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30846,7 +31171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 935,
+        "line": 945,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30865,7 +31190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30880,7 +31205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 935,
+        "line": 945,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30899,7 +31224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30914,7 +31239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 935,
+        "line": 945,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30933,7 +31258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30948,7 +31273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 935,
+        "line": 945,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -30967,7 +31292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -30982,7 +31307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 935,
+        "line": 945,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31001,7 +31326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31016,7 +31341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 942,
+        "line": 952,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31035,7 +31360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31050,7 +31375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 942,
+        "line": 952,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31069,7 +31394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31084,7 +31409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 942,
+        "line": 952,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31103,7 +31428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31118,7 +31443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 947,
+        "line": 957,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31137,7 +31462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31152,7 +31477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 947,
+        "line": 957,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31171,7 +31496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31186,7 +31511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 947,
+        "line": 957,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31205,7 +31530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31220,7 +31545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 965,
+        "line": 975,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31239,7 +31564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31254,7 +31579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 965,
+        "line": 975,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31273,7 +31598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31288,7 +31613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 965,
+        "line": 975,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31307,7 +31632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31322,7 +31647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 965,
+        "line": 975,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31341,7 +31666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31356,7 +31681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 965,
+        "line": 975,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31375,7 +31700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31390,7 +31715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 988,
+        "line": 998,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31409,7 +31734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31424,7 +31749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 988,
+        "line": 998,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31443,7 +31768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31458,7 +31783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 992,
+        "line": 1002,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31477,7 +31802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31492,7 +31817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 992,
+        "line": 1002,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31511,7 +31836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31526,7 +31851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31545,7 +31870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31560,7 +31885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31579,7 +31904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31594,7 +31919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31613,7 +31938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31628,7 +31953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31647,7 +31972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31662,7 +31987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31681,7 +32006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31696,7 +32021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31715,7 +32040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31730,7 +32055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31749,7 +32074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31764,7 +32089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31783,7 +32108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31798,7 +32123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31817,7 +32142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31832,7 +32157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31851,7 +32176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31866,7 +32191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31885,7 +32210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31900,7 +32225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31919,7 +32244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31934,7 +32259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31953,7 +32278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -31968,7 +32293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31987,7 +32312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32002,7 +32327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32021,7 +32346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32036,7 +32361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32055,7 +32380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32070,7 +32395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32089,7 +32414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32104,7 +32429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32123,7 +32448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32138,7 +32463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32157,7 +32482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32172,7 +32497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32191,7 +32516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32206,7 +32531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32225,7 +32550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32240,7 +32565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32259,7 +32584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32274,7 +32599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32293,7 +32618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32308,7 +32633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1034,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32327,7 +32652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32342,7 +32667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1034,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32361,7 +32686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32376,7 +32701,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1038,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -32395,7 +32720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32410,7 +32735,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1038,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -32429,7 +32754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32444,7 +32769,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1039,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -32463,7 +32788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32478,7 +32803,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1040,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -32497,7 +32822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32512,7 +32837,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1040,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -32531,7 +32856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32546,7 +32871,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1040,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -32565,7 +32890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32580,7 +32905,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1045,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32599,7 +32924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32614,7 +32939,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1045,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32633,7 +32958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32648,7 +32973,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32667,7 +32992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32682,7 +33007,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32701,7 +33026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32716,7 +33041,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32735,7 +33060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32750,7 +33075,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32769,7 +33094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32784,7 +33109,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32803,7 +33128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32818,7 +33143,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32837,7 +33162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32852,7 +33177,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32871,7 +33196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32886,7 +33211,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32905,7 +33230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32920,7 +33245,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32939,7 +33264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32954,7 +33279,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32973,7 +33298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -32988,7 +33313,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33007,7 +33332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -33022,7 +33347,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33041,7 +33366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -33056,7 +33381,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33075,7 +33400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -33090,7 +33415,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33109,7 +33434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -33124,7 +33449,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33143,7 +33468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -33158,7 +33483,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33177,7 +33502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -33192,7 +33517,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33211,7 +33536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -33226,7 +33551,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33245,7 +33570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -33260,7 +33585,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33278,7 +33603,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1659
+            "line": 1657
           }
         ],
         "classification": "external",
@@ -33286,7 +33611,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1660,
+        "line": 1658,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33303,7 +33628,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1696
+            "line": 1694
           }
         ],
         "classification": "external",
@@ -33311,7 +33636,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1697,
+        "line": 1695,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33328,7 +33653,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1704
+            "line": 1702
           }
         ],
         "classification": "external",
@@ -33336,7 +33661,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1705,
+        "line": 1703,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -36240,14 +36565,14 @@
       },
       {
         "is_package": false,
-        "loc": 980,
+        "loc": 997,
         "module": "easyuse_anima.aio.generation_normalization",
-        "normalized_git_blob_sha1": "a572e52e277e279cd20d1a519a8f13411cbf9431",
+        "normalized_git_blob_sha1": "d3ecbd94cf9656815bad5e24bb6905f2e9f14130",
         "path": "easyuse_anima/aio/generation_normalization.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 6,
-          "global_count": 3
+          "function_count": 7,
+          "global_count": 7
         }
       },
       {
@@ -36924,14 +37249,14 @@
       },
       {
         "is_package": false,
-        "loc": 2541,
+        "loc": 2539,
         "module": "nodes",
-        "normalized_git_blob_sha1": "2ee992eddb12f7e90269ce89cff2c4c8c372d7d0",
+        "normalized_git_blob_sha1": "2106ef1a676f053b3ab34f7579146681f640d82a",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 36,
-          "global_count": 32
+          "function_count": 35,
+          "global_count": 28
         }
       },
       {
@@ -38290,7 +38615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38299,7 +38624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38313,7 +38638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38322,7 +38647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38336,7 +38661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38345,7 +38670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38359,7 +38684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38368,7 +38693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38382,7 +38707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38391,7 +38716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38405,7 +38730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38414,7 +38739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38428,7 +38753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38437,7 +38762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38451,7 +38776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38460,7 +38785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 535,
+        "line": 540,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38474,7 +38799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38483,7 +38808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 546,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38497,7 +38822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38506,7 +38831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 546,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38520,7 +38845,99 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
+        "kind": "static_from",
+        "line": 555,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 539,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
+        "kind": "static_from",
+        "line": 555,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 539,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
+        "kind": "static_from",
+        "line": 555,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 539,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
+        "kind": "static_from",
+        "line": 555,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38529,7 +38946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 550,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38543,7 +38960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38552,7 +38969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 550,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38566,7 +38983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38575,7 +38992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 550,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38589,7 +39006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38598,7 +39015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 550,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38612,7 +39029,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
+        "kind": "static_from",
+        "line": 555,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38621,7 +39061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 550,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38635,7 +39075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38644,7 +39084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38658,7 +39098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38667,7 +39107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 560,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38681,7 +39121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38690,7 +39130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 560,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38704,7 +39144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38713,7 +39153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 560,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38727,7 +39167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38736,7 +39176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 560,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38750,7 +39190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38759,7 +39199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38773,7 +39213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38782,7 +39222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38796,7 +39236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38805,7 +39245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38819,7 +39259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38828,7 +39268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38842,7 +39282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38851,7 +39291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38865,7 +39305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38874,7 +39314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38888,7 +39328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38897,7 +39337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38911,7 +39351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38920,7 +39360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38934,7 +39374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38943,7 +39383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38957,7 +39397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38966,7 +39406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38980,7 +39420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -38989,7 +39429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39003,7 +39443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39012,7 +39452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39026,7 +39466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39035,7 +39475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 566,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39049,7 +39489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39058,7 +39498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39072,7 +39512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39081,7 +39521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39095,7 +39535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39104,7 +39544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39118,7 +39558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39127,7 +39567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39141,7 +39581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39150,7 +39590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39164,7 +39604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39173,7 +39613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39187,7 +39627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39196,7 +39636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39210,7 +39650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39219,7 +39659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39233,7 +39673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39242,7 +39682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39256,7 +39696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39265,7 +39705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 581,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39279,7 +39719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39288,7 +39728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39302,7 +39742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39311,7 +39751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39325,7 +39765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39334,7 +39774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39348,7 +39788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39357,7 +39797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39371,7 +39811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39380,7 +39820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39394,7 +39834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39403,7 +39843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39417,7 +39857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39426,7 +39866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39440,7 +39880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39449,7 +39889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39463,7 +39903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39472,7 +39912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39486,7 +39926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39495,7 +39935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 593,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39509,7 +39949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39518,7 +39958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39532,7 +39972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39541,7 +39981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39555,7 +39995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39564,7 +40004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39578,7 +40018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39587,7 +40027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39601,7 +40041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39610,7 +40050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39624,7 +40064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39633,7 +40073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39647,7 +40087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39656,7 +40096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39670,7 +40110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39679,7 +40119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39693,7 +40133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39702,7 +40142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39716,7 +40156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39725,7 +40165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39739,7 +40179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39748,7 +40188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39762,7 +40202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39771,7 +40211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39785,7 +40225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39794,7 +40234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39808,7 +40248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39817,7 +40257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39831,7 +40271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39840,7 +40280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39854,7 +40294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39863,7 +40303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39877,7 +40317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39886,7 +40326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39900,7 +40340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39909,7 +40349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39923,7 +40363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39932,7 +40372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39946,7 +40386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39955,7 +40395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39969,7 +40409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -39978,7 +40418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 617,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39992,7 +40432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40001,7 +40441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 630,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40015,7 +40455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40024,7 +40464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 630,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40038,7 +40478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40047,7 +40487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 630,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40061,7 +40501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40070,7 +40510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 635,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40084,7 +40524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40093,7 +40533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 635,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40107,7 +40547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40116,7 +40556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 635,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40130,7 +40570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40139,7 +40579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 635,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40153,7 +40593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40162,7 +40602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 635,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40176,7 +40616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40185,7 +40625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 642,
+        "line": 652,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40199,7 +40639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40208,7 +40648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40222,7 +40662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40231,7 +40671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40245,7 +40685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40254,7 +40694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40268,7 +40708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40277,7 +40717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40291,7 +40731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40300,7 +40740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40314,7 +40754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40323,7 +40763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40337,7 +40777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40346,7 +40786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40360,7 +40800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40369,7 +40809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40383,7 +40823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40392,7 +40832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40406,7 +40846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40415,7 +40855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40429,7 +40869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40438,7 +40878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40452,7 +40892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40461,7 +40901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40475,7 +40915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40484,7 +40924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40498,7 +40938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40507,7 +40947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 649,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40521,7 +40961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40530,7 +40970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40544,7 +40984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40553,7 +40993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40567,7 +41007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40576,7 +41016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40590,7 +41030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40599,7 +41039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40613,7 +41053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40622,7 +41062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40636,7 +41076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40645,7 +41085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40659,7 +41099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40668,7 +41108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 663,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40682,7 +41122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40691,7 +41131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40705,7 +41145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40714,7 +41154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40728,7 +41168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40737,7 +41177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40751,7 +41191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40760,7 +41200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40774,7 +41214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40783,7 +41223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40797,7 +41237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40806,7 +41246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40820,7 +41260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40829,7 +41269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40843,7 +41283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40852,7 +41292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40866,7 +41306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40875,7 +41315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40889,7 +41329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40898,7 +41338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40912,7 +41352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40921,7 +41361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40935,7 +41375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40944,7 +41384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40958,7 +41398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40967,7 +41407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40981,7 +41421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -40990,7 +41430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41004,7 +41444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41013,7 +41453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41027,7 +41467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41036,7 +41476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41050,7 +41490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41059,7 +41499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41073,7 +41513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41082,7 +41522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41096,7 +41536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41105,7 +41545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41119,7 +41559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41128,7 +41568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41142,7 +41582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41151,7 +41591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41165,7 +41605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41174,7 +41614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 681,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41188,7 +41628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41197,7 +41637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41211,7 +41651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41220,7 +41660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41234,7 +41674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41243,7 +41683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41257,7 +41697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41266,7 +41706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41280,7 +41720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41289,7 +41729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41303,7 +41743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41312,7 +41752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41326,7 +41766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41335,7 +41775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41349,7 +41789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41358,7 +41798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41372,7 +41812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41381,7 +41821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41395,7 +41835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41404,7 +41844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41418,7 +41858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41427,7 +41867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41441,7 +41881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41450,7 +41890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41464,7 +41904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41473,7 +41913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41487,7 +41927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41496,7 +41936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 717,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41510,7 +41950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41519,7 +41959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41533,7 +41973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41542,7 +41982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41556,7 +41996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41565,7 +42005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41579,7 +42019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41588,7 +42028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41602,7 +42042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41611,7 +42051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41625,7 +42065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41634,7 +42074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41648,7 +42088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41657,7 +42097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41671,7 +42111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41680,7 +42120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41694,7 +42134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41703,7 +42143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 745,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41717,7 +42157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41726,7 +42166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41740,7 +42180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41749,7 +42189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41763,7 +42203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41772,7 +42212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41786,7 +42226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41795,7 +42235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41809,7 +42249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41818,7 +42258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41832,7 +42272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41841,7 +42281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41855,7 +42295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41864,7 +42304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41878,7 +42318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41887,7 +42327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41901,7 +42341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41910,7 +42350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41924,7 +42364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41933,7 +42373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41947,7 +42387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41956,7 +42396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41970,7 +42410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -41979,7 +42419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41993,7 +42433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42002,7 +42442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42016,7 +42456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42025,7 +42465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42039,7 +42479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42048,7 +42488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42062,7 +42502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42071,7 +42511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42085,7 +42525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42094,7 +42534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42108,7 +42548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42117,7 +42557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42131,7 +42571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42140,7 +42580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42154,7 +42594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42163,7 +42603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42177,7 +42617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42186,7 +42626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42200,7 +42640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42209,7 +42649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42223,7 +42663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42232,7 +42672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42246,7 +42686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42255,7 +42695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42269,7 +42709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42278,7 +42718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 761,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42292,7 +42732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42301,7 +42741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 841,
+        "line": 851,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42315,7 +42755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42324,7 +42764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 841,
+        "line": 851,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42338,7 +42778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42347,7 +42787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 841,
+        "line": 851,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42361,7 +42801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42370,7 +42810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 841,
+        "line": 851,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42384,7 +42824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42393,7 +42833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 847,
+        "line": 857,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42407,7 +42847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42416,7 +42856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 847,
+        "line": 857,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42430,7 +42870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42439,7 +42879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 847,
+        "line": 857,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42453,7 +42893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42462,7 +42902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 852,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42476,7 +42916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42485,7 +42925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 852,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42499,7 +42939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42508,7 +42948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 852,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42522,7 +42962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42531,7 +42971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 858,
+        "line": 868,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42545,7 +42985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42554,7 +42994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 858,
+        "line": 868,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42568,7 +43008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42577,7 +43017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 858,
+        "line": 868,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42591,7 +43031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42600,7 +43040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 858,
+        "line": 868,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42614,7 +43054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42623,7 +43063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 858,
+        "line": 868,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42637,7 +43077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42646,7 +43086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 865,
+        "line": 875,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42660,7 +43100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42669,7 +43109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 865,
+        "line": 875,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42683,7 +43123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42692,7 +43132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 865,
+        "line": 875,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42706,7 +43146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42715,7 +43155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 876,
+        "line": 886,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42729,7 +43169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42738,7 +43178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 876,
+        "line": 886,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42752,7 +43192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42761,7 +43201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 876,
+        "line": 886,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42775,7 +43215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42784,7 +43224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 876,
+        "line": 886,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42798,7 +43238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42807,7 +43247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 889,
+        "line": 899,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42821,7 +43261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42830,7 +43270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 889,
+        "line": 899,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42844,7 +43284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42853,7 +43293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42867,7 +43307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42876,7 +43316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42890,7 +43330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42899,7 +43339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42913,7 +43353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42922,7 +43362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42936,7 +43376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42945,7 +43385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42959,7 +43399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42968,7 +43408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42982,7 +43422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -42991,7 +43431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43005,7 +43445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43014,7 +43454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 897,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43028,7 +43468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43037,7 +43477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 908,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43051,7 +43491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43060,7 +43500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 908,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43074,7 +43514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43083,7 +43523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 908,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43097,7 +43537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43106,7 +43546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 908,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43120,7 +43560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43129,7 +43569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 914,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43143,7 +43583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43152,7 +43592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 914,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43166,7 +43606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43175,7 +43615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 914,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43189,7 +43629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43198,7 +43638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 914,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43212,7 +43652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43221,7 +43661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 914,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43235,7 +43675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43244,7 +43684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 922,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43258,7 +43698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43267,7 +43707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 922,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43281,7 +43721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43290,7 +43730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43304,7 +43744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43313,7 +43753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 930,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43327,7 +43767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43336,7 +43776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 930,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43350,7 +43790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43359,7 +43799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 930,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43373,7 +43813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43382,7 +43822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 935,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43396,7 +43836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43405,7 +43845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 935,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43419,7 +43859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43428,7 +43868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 935,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43442,7 +43882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43451,7 +43891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 935,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43465,7 +43905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43474,7 +43914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 935,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43488,7 +43928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43497,7 +43937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 942,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43511,7 +43951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43520,7 +43960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 942,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43534,7 +43974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43543,7 +43983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 942,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43557,7 +43997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43566,7 +44006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 947,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43580,7 +44020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43589,7 +44029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 947,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43603,7 +44043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43612,7 +44052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 947,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43626,7 +44066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43635,7 +44075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 965,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43649,7 +44089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43658,7 +44098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 965,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43672,7 +44112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43681,7 +44121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 965,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43695,7 +44135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43704,7 +44144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 965,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43718,7 +44158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43727,7 +44167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 965,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43741,7 +44181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43750,7 +44190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 988,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43764,7 +44204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43773,7 +44213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 988,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43787,7 +44227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43796,7 +44236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 992,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43810,7 +44250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43819,7 +44259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 992,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43833,7 +44273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43842,7 +44282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43856,7 +44296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43865,7 +44305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43879,7 +44319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43888,7 +44328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43902,7 +44342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43911,7 +44351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43925,7 +44365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43934,7 +44374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43948,7 +44388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43957,7 +44397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43971,7 +44411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -43980,7 +44420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43994,7 +44434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44003,7 +44443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44017,7 +44457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44026,7 +44466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44040,7 +44480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44049,7 +44489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44063,7 +44503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44072,7 +44512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44086,7 +44526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44095,7 +44535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44109,7 +44549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44118,7 +44558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44132,7 +44572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44141,7 +44581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44155,7 +44595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44164,7 +44604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 997,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44178,7 +44618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44187,7 +44627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44201,7 +44641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44210,7 +44650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44224,7 +44664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44233,7 +44673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44247,7 +44687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44256,7 +44696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44270,7 +44710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44279,7 +44719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44293,7 +44733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44302,7 +44742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44316,7 +44756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44325,7 +44765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44339,7 +44779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44348,7 +44788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44362,7 +44802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44371,7 +44811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44385,7 +44825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44394,7 +44834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44408,7 +44848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44417,7 +44857,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44431,7 +44871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44440,7 +44880,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44454,7 +44894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44463,7 +44903,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1039,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44477,7 +44917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44486,7 +44926,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44500,7 +44940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44509,7 +44949,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44523,7 +44963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44532,7 +44972,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44546,7 +44986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44555,7 +44995,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44569,7 +45009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44578,7 +45018,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44592,7 +45032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44601,7 +45041,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44615,7 +45055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44624,7 +45064,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44638,7 +45078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44647,7 +45087,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44661,7 +45101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44670,7 +45110,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44684,7 +45124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44693,7 +45133,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44707,7 +45147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44716,7 +45156,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44730,7 +45170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44739,7 +45179,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44753,7 +45193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44762,7 +45202,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44776,7 +45216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44785,7 +45225,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44799,7 +45239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44808,7 +45248,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44822,7 +45262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44831,7 +45271,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44845,7 +45285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44854,7 +45294,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44868,7 +45308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44877,7 +45317,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44891,7 +45331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44900,7 +45340,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44914,7 +45354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44923,7 +45363,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44937,7 +45377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44946,7 +45386,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44960,7 +45400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44969,7 +45409,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44983,7 +45423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -44992,7 +45432,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45006,7 +45446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 534,
+            "handler_line": 539,
             "kind": "try",
             "line": 11
           }
@@ -45015,7 +45455,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48754,14 +49194,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1659
+            "line": 1657
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1660,
+        "line": 1658,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -48773,14 +49213,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1696
+            "line": 1694
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1697,
+        "line": 1695,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -48792,14 +49232,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1704
+            "line": 1702
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1705,
+        "line": 1703,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50174,14 +50614,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1659
+            "line": 1657
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1660,
+        "line": 1658,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50193,14 +50633,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1696
+            "line": 1694
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1697,
+        "line": 1695,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50212,14 +50652,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1704
+            "line": 1702
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1705,
+        "line": 1703,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51667,7 +52107,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1058,
+        "line": 1068,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51676,7 +52116,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1610,
+        "line": 1608,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51685,7 +52125,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2443,
+        "line": 2441,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51694,7 +52134,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2446,
+        "line": 2444,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51703,7 +52143,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2449,
+        "line": 2447,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51712,7 +52152,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2452,
+        "line": 2450,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51721,7 +52161,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2455,
+        "line": 2453,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51730,7 +52170,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2458,
+        "line": 2456,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51739,7 +52179,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2461,
+        "line": 2459,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51748,7 +52188,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2464,
+        "line": 2462,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51757,7 +52197,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2467,
+        "line": 2465,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51766,7 +52206,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2470,
+        "line": 2468,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51775,7 +52215,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2473,
+        "line": 2471,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51784,7 +52224,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2476,
+        "line": 2474,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51793,7 +52233,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2479,
+        "line": 2477,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51802,7 +52242,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2482,
+        "line": 2480,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51811,7 +52251,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2486,
+        "line": 2484,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51820,7 +52260,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2489,
+        "line": 2487,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51829,7 +52269,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2493,
+        "line": 2491,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51838,7 +52278,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2496,
+        "line": 2494,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51847,7 +52287,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2500,
+        "line": 2498,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51856,7 +52296,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2503,
+        "line": 2501,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51865,7 +52305,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2506,
+        "line": 2504,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51874,7 +52314,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2509,
+        "line": 2507,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51883,7 +52323,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2512,
+        "line": 2510,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51892,7 +52332,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2515,
+        "line": 2513,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51901,7 +52341,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2522,
+        "line": 2520,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51910,7 +52350,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2528,
+        "line": 2526,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51919,7 +52359,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2533,
+        "line": 2531,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -51928,7 +52368,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2537,
+        "line": 2535,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52279,6 +52719,12 @@
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
       {
+        "kind": "set",
+        "line": 32,
+        "module": "easyuse_anima/aio/generation_normalization.py",
+        "name": "AIO_SPECIAL_SEEDS"
+      },
+      {
         "kind": "dict",
         "line": 10,
         "module": "easyuse_anima/aio/preview.py",
@@ -52430,25 +52876,19 @@
       },
       {
         "kind": "dict",
-        "line": 1128,
+        "line": 1130,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1117,
+        "line": 1119,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1112,
-        "module": "nodes.py",
-        "name": "AIO_SPECIAL_SEEDS"
-      },
-      {
-        "kind": "set",
-        "line": 1609,
+        "line": 1607,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "617ea140b2f07d6d1a8c341d9145e05a613bed8c",
+    "base_commit": "bbca312b684f009aafbd1ed813a8f136e5520b3d",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -35,7 +35,8 @@
       "B-11c3",
       "B-11c4",
       "B-11c5",
-      "B-11c6"
+      "B-11c6",
+      "B-11c7a"
     ]
   },
   "enums": {
@@ -70,13 +71,13 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 266,
+    "nodes_canonical_bindings": 271,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 36,
+    "root_residual_functions": 35,
     "root_residual_classes": 0,
-    "root_residual_globals": 32,
+    "root_residual_globals": 28,
     "runtime_binders": 28,
     "direct_nodes_import_test_files": 21
   },
@@ -184,6 +185,9 @@
     "AIO_SPECIAL_SEEDS": [
       "easyuse_anima.nodes.aio_nodes"
     ],
+    "AIO_SPECIAL_SEED_DECREMENT": [
+      "easyuse_anima.aio.generation_normalization"
+    ],
     "AIO_USDU_MODE_TYPES": [
       "easyuse_anima.aio.generation_normalization"
     ],
@@ -269,6 +273,9 @@
       "easyuse_anima.aio.generation_normalization"
     ],
     "IMAGE_UPSCALE_METHODS": [
+      "easyuse_anima.aio.generation_normalization"
+    ],
+    "MAX_SEED": [
       "easyuse_anima.aio.generation_normalization"
     ],
     "PROMPT_DATA_TYPE": [
@@ -1877,10 +1884,14 @@
       "id": "nodes_canonical_bindings:easyuse_anima.aio.generation_normalization:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "AIO_SPECIAL_SEEDS": "AIO_SPECIAL_SEEDS",
+        "AIO_SPECIAL_SEED_DECREMENT": "AIO_SPECIAL_SEED_DECREMENT",
+        "AIO_SPECIAL_SEED_RANDOM": "AIO_SPECIAL_SEED_RANDOM",
         "_bind_aio_generation_normalization_runtime": "_bind_aio_generation_normalization_runtime",
         "_merge_versioned_settings": "_merge_versioned_settings",
         "_normalize_aio_dit_corrections_settings": "_normalize_aio_dit_corrections_settings",
         "_normalize_aio_generation_settings": "_normalize_aio_generation_settings",
+        "_normalize_aio_seed": "_normalize_aio_seed",
         "_normalize_aio_spectrum_settings": "_normalize_aio_spectrum_settings"
       },
       "classification": "transitional_private_seam",
@@ -1910,6 +1921,35 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.generation_normalization:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "AIO_SPECIAL_SEED_INCREMENT": "AIO_SPECIAL_SEED_INCREMENT"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.generation_normalization",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.generation_normalization",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.generation_settings:transitional_private_seam",
@@ -3946,7 +3986,6 @@
         "_is_aio_detailer_target_name": "_is_aio_detailer_target_name",
         "_new_aio_random_seed": "_new_aio_random_seed",
         "_normalize_aio_input_settings": "_normalize_aio_input_settings",
-        "_normalize_aio_seed": "_normalize_aio_seed",
         "_require_any_custom_node_class": "_require_any_custom_node_class",
         "_require_custom_node_class": "_require_custom_node_class",
         "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed",
@@ -3995,10 +4034,6 @@
         "AIO_INPUT_DEFAULT_SETTINGS": "AIO_INPUT_DEFAULT_SETTINGS",
         "AIO_RESHIFT_DTYPES": "AIO_RESHIFT_DTYPES",
         "AIO_RESHIFT_SCALES": "AIO_RESHIFT_SCALES",
-        "AIO_SPECIAL_SEEDS": "AIO_SPECIAL_SEEDS",
-        "AIO_SPECIAL_SEED_DECREMENT": "AIO_SPECIAL_SEED_DECREMENT",
-        "AIO_SPECIAL_SEED_INCREMENT": "AIO_SPECIAL_SEED_INCREMENT",
-        "AIO_SPECIAL_SEED_RANDOM": "AIO_SPECIAL_SEED_RANDOM",
         "AIO_USDU_MODE_TYPES": "AIO_USDU_MODE_TYPES",
         "AIO_USDU_PROMPT_FULL": "AIO_USDU_PROMPT_FULL",
         "AIO_USDU_PROMPT_MODES": "AIO_USDU_PROMPT_MODES",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -826,6 +826,54 @@ class AioDitNormalizationMoveContractTests(unittest.TestCase):
             self._assert_contract(package_nodes, package_generation_normalization)
 
 
+class AioSeedNormalizationMoveContractTests(unittest.TestCase):
+    CONSTANT_NAMES = (
+        "AIO_SPECIAL_SEED_RANDOM",
+        "AIO_SPECIAL_SEED_INCREMENT",
+        "AIO_SPECIAL_SEED_DECREMENT",
+        "AIO_SPECIAL_SEEDS",
+    )
+
+    def _assert_contract(self, root_module, canonical_module):
+        self.assertIs(
+            root_module._normalize_aio_seed,
+            canonical_module._normalize_aio_seed,
+        )
+        for name in self.CONSTANT_NAMES:
+            with self.subTest(name=name):
+                self.assertIs(getattr(root_module, name), getattr(canonical_module, name))
+
+        self.assertEqual(root_module.AIO_SPECIAL_SEED_RANDOM, -1)
+        self.assertEqual(root_module.AIO_SPECIAL_SEED_INCREMENT, -2)
+        self.assertEqual(root_module.AIO_SPECIAL_SEED_DECREMENT, -3)
+        self.assertIsInstance(root_module.AIO_SPECIAL_SEEDS, set)
+        self.assertEqual(root_module.AIO_SPECIAL_SEEDS, {-1, -2, -3})
+
+        with (
+            patch.object(root_module, "_as_int", side_effect=(99, -99)) as as_int,
+            patch.object(root_module, "MAX_SEED", 12),
+            patch.object(root_module, "AIO_SPECIAL_SEED_DECREMENT", -7),
+        ):
+            self.assertEqual(canonical_module._normalize_aio_seed("high"), 12)
+            self.assertEqual(canonical_module._normalize_aio_seed("low"), -7)
+
+        self.assertEqual(
+            as_int.call_args_list,
+            [call("high", -1), call("low", -1)],
+        )
+
+    def test_root_aliases_and_call_time_clamp_helpers(self):
+        self._assert_contract(nodes, aio_generation_normalization)
+
+    def test_package_aliases_and_call_time_clamp_helpers(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_generation_normalization = sys.modules[
+                f"{package_name}.easyuse_anima.aio.generation_normalization"
+            ]
+            self._assert_contract(package_nodes, package_generation_normalization)
+
+
 class ComfyAdapterMoveContractTests(unittest.TestCase):
     RETIRED_SAM3_SERVICE_HELPERS = (
         "_call_impact_detailer",

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "2ee992eddb12f7e90269ce89cff2c4c8c372d7d0")
-        # Issue #184 B-11c6 moves the AiO DiT correction normalizer while
-        # preserving the root alias and call-time coercion helper seams.
-        self.assertEqual(report["top_level"]["function_count"], 36)
+        self.assertEqual(report["git_blob_sha1"], "2106ef1a676f053b3ab34f7579146681f640d82a")
+        # Issue #184 B-11c7a moves the AiO special-seed constants and normalizer
+        # while preserving direct aliases and call-time clamp helper seams.
+        self.assertEqual(report["top_level"]["function_count"], 35)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_541)
+        self.assertEqual(report["line_count"], 2_539)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "617ea140b2f07d6d1a8c341d9145e05a613bed8c"
+BASE_COMMIT = "bbca312b684f009aafbd1ed813a8f136e5520b3d"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1309,6 +1309,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c4",
                 "B-11c5",
                 "B-11c6",
+                "B-11c7a",
             ],
         },
         "enums": {
@@ -1321,13 +1322,13 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 266,
+            "nodes_canonical_bindings": 271,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 36,
+            "root_residual_functions": 35,
             "root_residual_classes": 0,
-            "root_residual_globals": 32,
+            "root_residual_globals": 28,
             "runtime_binders": 28,
             "direct_nodes_import_test_files": 21,
         },


### PR DESCRIPTION
## 변경 요약

- B-11c7a에서 AiO 특수 시드 상수 4개와 `_normalize_aio_seed`의 소유권만 `easyuse_anima.aio.generation_normalization`으로 이동합니다.
- root `nodes.py`의 relative/flat import는 canonical 객체의 direct alias identity를 유지합니다.
- runtime RNG 생성과 실행 시드 해석은 B-11c7b로 분리하며 이 PR에서는 변경하지 않습니다.

## 작업 전 인벤토리

### Symbol

- root globals: `AIO_SPECIAL_SEED_RANDOM=-1`, `AIO_SPECIAL_SEED_INCREMENT=-2`, `AIO_SPECIAL_SEED_DECREMENT=-3`
- root mutable global: `AIO_SPECIAL_SEEDS` (`set`, 위 세 상수의 현재 객체)
- root function: `_normalize_aio_seed(value, default=-1)`; `_as_int` 후 `[-3, MAX_SEED]` clamp

### Caller

- root `_resolve_aio_runtime_seed`가 root `_normalize_aio_seed`와 `AIO_SPECIAL_SEEDS`를 호출합니다.
- `easyuse_anima.aio.generation_normalization._normalize_aio_generation_settings`가 기존 runtime resolver로 root `_normalize_aio_seed`를 호출합니다.
- `easyuse_anima.nodes.aio_nodes.IS_CHANGED`가 기존 runtime resolver로 root `AIO_SPECIAL_SEEDS`를 조회합니다.
- `AIO_GENERATION_DEFAULT_SETTINGS["sampler"]["seed"]`가 root 상수의 `-1` 값을 사용합니다.

### Alias / compatibility

- 작업 전 다섯 심볼은 모두 root definition이며 canonical alias가 없습니다.
- 작업 후 relative/flat root import가 동일한 canonical 함수와 네 상수 객체를 직접 가리켜야 합니다.
- mutable `AIO_SPECIAL_SEEDS`의 root/canonical identity를 보존합니다.
- canonical normalizer는 기존 runtime resolver로 root `_as_int`, `MAX_SEED`, 하한 상수를 호출 시점에 조회합니다.

### Global state

- `AIO_SPECIAL_SEEDS`의 mutable set identity와 멤버 값은 변경하지 않습니다.
- `MAX_SEED` 소유권은 legacy `wildcard_engine`에 유지합니다.
- Python process-wide `random` 상태, `_new_aio_random_seed`, `_resolve_aio_runtime_seed`는 이 PR에서 변경하지 않습니다.

## Allowed-file boundary

- `easyuse_anima/aio/generation_normalization.py`
- `nodes.py`
- `tests/test_node_contracts.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 금지 경계

- 특수 시드 숫자, set 형태/identity, 정수 변환, clamp 범위를 변경하지 않습니다.
- increment/decrement의 동작, `seed_after_generate`, 이전 시드, cache/change-key 정책을 변경하지 않습니다.
- RNG 종류·호출 횟수·순서·inclusive 범위를 변경하지 않습니다.
- `MAX_SEED` 소유권, runtime binder, canonical-to-root import, 소비자 호출부를 변경하지 않습니다.

## 검증 계획

- focused unittest: 새 Move contract, AiO 설정 저장/정규화, compatibility surface, nodes/backend analyzer
- `git diff --check`
- main-owned exact-head `tools/check_custom_node.ps1 -Profile full`

## 검증 결과

- focused (workspace `.venv`): 71 tests, OK
  - 새 flat/package alias 및 call-time helper contract
  - AiO 설정 저장/정규화
  - compatibility surface, nodes/backend analyzer, import boundary
- 공식 full (`tools/check_custom_node.ps1 -Profile full`): 통과
  - Python unittest: 896 tests, OK
  - Frontend: 114 JavaScript files, 통과
  - Pyright baseline ratchet / import-boundary gate / `git diff --check`: 통과
  - Ruff G-01 report-only: 기존 baseline 범위 105건, non-blocking
- 독립 읽기 전용 diff review: findings 없음
- 최초 focused 시도는 저장소 앵커 `.venv`에 NumPy가 없어 3개 모듈이 수집 단계에서 실패했습니다. 프로젝트 workspace `.venv`로 교정한 위 71개 실행은 통과했습니다.

## 테스트 표면

- ComfyUI Codex test infrastructure: repository-owned static/unit/full validation 완료
- Live ComfyUI smoke: 미실행 예정 (Move-only이며 Phase B exit checkpoint에서 수행)

## 남은 위험 / 미확인

- 실행 시 RNG와 특수 시드 해석은 의도적으로 root 소유 상태이며 B-11c7b에서 별도 이동합니다.
- GitHub Actions check는 별도 보고가 없으며, 공식 full과 독립 리뷰를 병합 근거로 사용합니다.

Closes no issue; tracks #184.
