### PR TITLE
refactor(backend): move AiO runtime seed ownership (B-11c7b)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `bbca312b684f009aafbd1ed813a8f136e5520b3d`
+- Integrated `dev` snapshot commit: `17343eb4fed55d05c349b145119539501f92ad47`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c6; B-11c7a seed-normalizer Move in PR #300 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c7a; B-11c7b runtime-seed Move in PR #301 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,9 +42,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,541
-  lines after B-11c6.
-- The mechanical extraction has removed 10,122
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,539
+  lines after B-11c7a.
+- The mechanical extraction has removed 10,124
   lines, approximately 79.9% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
@@ -62,8 +62,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   B-11c4 moved the AiO LoRA stack signature helper in PR #297 / `0980530`.
   B-11c5 moved the AiO Spectrum settings normalizer in PR #298 / `617ea14`.
   B-11c6 moved the AiO DiT correction normalizer in PR #299 / `bbca312`.
-  B-11c7a moves only the AiO special-seed constants and settings normalizer in
-  PR #300; runtime RNG generation and seed interpretation remain separate.
+  B-11c7a moved the AiO special-seed constants and settings normalizer in PR
+  #300 / `17343eb`. B-11c7b moves only runtime RNG generation and special-seed
+  interpretation in PR #301; reservation and increment/decrement behavior
+  remain separate.
 
 ### Current quality baseline
 
@@ -305,7 +307,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a seed-normalizer PR #300 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b runtime-seed PR #301 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -834,6 +836,12 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     lower-bound replacement. Runtime random seed generation, special-seed
     interpretation, increment/decrement behavior, and seed reservation remain
     separate.
+  - B-11c7b moves only `_new_aio_random_seed` and
+    `_resolve_aio_runtime_seed` to `easyuse_anima.aio.sampling`. PR #301 retains
+    direct root alias identity and call-time root `random`, `MAX_SEED`,
+    `_normalize_aio_seed`, mutable `AIO_SPECIAL_SEEDS`, and nested random-helper
+    replacement. RNG range/state/call order and backend seed reservation remain
+    unchanged.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `bbca312b684f009aafbd1ed813a8f136e5520b3d`
+  `17343eb4fed55d05c349b145119539501f92ad47`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c6 are integrated through PR #299. B-11c is
+- Current state: B-11a through B-11c7a are integrated through PR #300. B-11c is
   split into residual-owner and binder Moves before the final root shim;
-  B-11c7a AiO seed-normalizer ownership is tracked by PR #300.
+  B-11c7b AiO runtime-seed ownership is tracked by PR #301.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,8 +75,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 271 after
-  B-11c7a (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 273 after
+  B-11c7b (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -84,8 +84,8 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 35 functions, 0 classes, and 28 assigned
-  globals after B-11c7a (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 33 functions, 0 classes, and 28 assigned
+  globals after B-11c7b (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 256, including
   literal lookups and binder-owned helper-name/default collections;
@@ -250,6 +250,23 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - PR #300 does not move or alter `_new_aio_random_seed`,
   `_resolve_aio_runtime_seed`, Python RNG consumption, `seed_after_generate`,
   increment/decrement behavior, cache keys, or backend seed reservation.
+
+### B-11c7b AiO runtime-seed aliases
+
+- Canonical owner: `easyuse_anima.aio.sampling` for
+  `_new_aio_random_seed` and `_resolve_aio_runtime_seed`.
+- The private root names remain transitional direct aliases in both relative
+  package and flat import modes. Existing root stages and the legacy-generation,
+  output, sampling, and AiO-node runtime resolvers keep calling those root
+  names.
+- The moved functions resolve root `random`, `MAX_SEED`, `_normalize_aio_seed`,
+  mutable `AIO_SPECIAL_SEEDS`, and `_new_aio_random_seed` at call time through
+  the existing sampling runtime seam. Root binding replacement and in-place set
+  mutation therefore remain visible.
+- PR #301 preserves one inclusive `random.randint(0, MAX_SEED)` call for every
+  special seed and the existing non-special `[0, MAX_SEED]` clamp. It does not
+  add increment/decrement, previous-seed, queue reservation, cache, or browser
+  behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/sampling.py
+++ b/easyuse_anima/aio/sampling.py
@@ -25,6 +25,18 @@ def _runtime_helper(name: str) -> Any:
     return resolver(name)
 
 
+def _new_aio_random_seed() -> int:
+    random_module = _runtime_helper("random")
+    return random_module.randint(0, _runtime_helper("MAX_SEED"))
+
+
+def _resolve_aio_runtime_seed(value) -> int:
+    seed = _runtime_helper("_normalize_aio_seed")(value)
+    if seed in _runtime_helper("AIO_SPECIAL_SEEDS"):
+        return _runtime_helper("_new_aio_random_seed")()
+    return max(0, min(_runtime_helper("MAX_SEED"), seed))
+
+
 def _generate_empty_latent_with_comfy(width: int, height: int):
     latent_cls = _runtime_helper("_find_comfy_node_class")("EmptyLatentImage")
     if latent_cls is None:

--- a/nodes.py
+++ b/nodes.py
@@ -67,6 +67,8 @@ try:
         _decode_latent_with_comfy as _decode_latent_with_comfy,
         _encode_image_with_comfy_vae as _encode_image_with_comfy_vae,
         _generate_empty_latent_with_comfy as _generate_empty_latent_with_comfy,
+        _new_aio_random_seed as _new_aio_random_seed,
+        _resolve_aio_runtime_seed as _resolve_aio_runtime_seed,
         _sample_latent_with_aio_backend as _sample_latent_with_aio_backend,
         _sample_latent_with_comfy as _sample_latent_with_comfy,
         _sample_latent_with_spectrum_mod_guidance_advanced as _sample_latent_with_spectrum_mod_guidance_advanced,
@@ -595,6 +597,8 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _decode_latent_with_comfy as _decode_latent_with_comfy,
         _encode_image_with_comfy_vae as _encode_image_with_comfy_vae,
         _generate_empty_latent_with_comfy as _generate_empty_latent_with_comfy,
+        _new_aio_random_seed as _new_aio_random_seed,
+        _resolve_aio_runtime_seed as _resolve_aio_runtime_seed,
         _sample_latent_with_aio_backend as _sample_latent_with_aio_backend,
         _sample_latent_with_comfy as _sample_latent_with_comfy,
         _sample_latent_with_spectrum_mod_guidance_advanced as _sample_latent_with_spectrum_mod_guidance_advanced,
@@ -1557,21 +1561,6 @@ AIO_RESHIFT_DTYPES = ("bf16", "fp32")
 
 
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
-
-
-def _new_aio_random_seed() -> int:
-    return random.randint(0, MAX_SEED)
-
-
-def _resolve_aio_runtime_seed(value) -> int:
-    seed = _normalize_aio_seed(value)
-    if seed in AIO_SPECIAL_SEEDS:
-        return _new_aio_random_seed()
-    return max(0, min(MAX_SEED, seed))
-
-
-
-
 
 
 def _settings_json(defaults: dict[str, Any]) -> str:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -15589,6 +15589,68 @@
         "target": "easyuse_anima/aio/sampling.py"
       },
       {
+        "alias": "_new_aio_random_seed",
+        "bound_name": "_new_aio_random_seed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_new_aio_random_seed",
+          "target": "easyuse_anima/aio/sampling.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
+        "kind": "static_from",
+        "line": 63,
+        "name": "_new_aio_random_seed",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.sampling",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": "_resolve_aio_runtime_seed",
+        "bound_name": "_resolve_aio_runtime_seed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_aio_runtime_seed",
+          "target": "easyuse_anima/aio/sampling.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
+        "kind": "static_from",
+        "line": 63,
+        "name": "_resolve_aio_runtime_seed",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.sampling",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
         "alias": "_sample_latent_with_aio_backend",
         "bound_name": "_sample_latent_with_aio_backend",
         "branch_context": [
@@ -15734,7 +15796,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 75,
+        "line": 77,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15765,7 +15827,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 75,
+        "line": 77,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15796,7 +15858,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 75,
+        "line": 77,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15827,7 +15889,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 75,
+        "line": 77,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15858,7 +15920,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 75,
+        "line": 77,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15889,7 +15951,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 75,
+        "line": 77,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15920,7 +15982,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 75,
+        "line": 77,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15951,7 +16013,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 75,
+        "line": 77,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15982,7 +16044,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 75,
+        "line": 77,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16013,7 +16075,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 75,
+        "line": 77,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16044,7 +16106,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 87,
+        "line": 89,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16075,7 +16137,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 87,
+        "line": 89,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16106,7 +16168,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 87,
+        "line": 89,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16137,7 +16199,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 87,
+        "line": 89,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16168,7 +16230,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 87,
+        "line": 89,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16199,7 +16261,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 87,
+        "line": 89,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16230,7 +16292,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 87,
+        "line": 89,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16261,7 +16323,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 87,
+        "line": 89,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16292,7 +16354,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 87,
+        "line": 89,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16323,7 +16385,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 87,
+        "line": 89,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16354,7 +16416,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 99,
+        "line": 101,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16385,7 +16447,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 99,
+        "line": 101,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16416,7 +16478,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 99,
+        "line": 101,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16447,7 +16509,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 99,
+        "line": 101,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16478,7 +16540,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 99,
+        "line": 101,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16509,7 +16571,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 99,
+        "line": 101,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16540,7 +16602,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 99,
+        "line": 101,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16571,7 +16633,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 99,
+        "line": 101,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16602,7 +16664,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 99,
+        "line": 101,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16633,7 +16695,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 99,
+        "line": 101,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16664,7 +16726,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 99,
+        "line": 101,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16695,7 +16757,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 112,
+        "line": 114,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16726,7 +16788,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 112,
+        "line": 114,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16757,7 +16819,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 112,
+        "line": 114,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16788,7 +16850,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 117,
+        "line": 119,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16819,7 +16881,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 117,
+        "line": 119,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16850,7 +16912,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 117,
+        "line": 119,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16881,7 +16943,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 117,
+        "line": 119,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16912,7 +16974,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 117,
+        "line": 119,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16943,7 +17005,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 124,
+        "line": 126,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -16974,7 +17036,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 125,
+        "line": 127,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17005,7 +17067,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 125,
+        "line": 127,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17036,7 +17098,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 125,
+        "line": 127,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17067,7 +17129,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 125,
+        "line": 127,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17098,7 +17160,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 131,
+        "line": 133,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17129,7 +17191,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 131,
+        "line": 133,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17160,7 +17222,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 131,
+        "line": 133,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17191,7 +17253,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 131,
+        "line": 133,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17222,7 +17284,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 131,
+        "line": 133,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17253,7 +17315,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 131,
+        "line": 133,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17284,7 +17346,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 131,
+        "line": 133,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17315,7 +17377,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 131,
+        "line": 133,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17346,7 +17408,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 131,
+        "line": 133,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17377,7 +17439,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 131,
+        "line": 133,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17408,7 +17470,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 145,
+        "line": 147,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17439,7 +17501,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 145,
+        "line": 147,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17470,7 +17532,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 145,
+        "line": 147,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17501,7 +17563,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 145,
+        "line": 147,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17532,7 +17594,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 145,
+        "line": 147,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17563,7 +17625,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 145,
+        "line": 147,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17594,7 +17656,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 145,
+        "line": 147,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17625,7 +17687,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17656,7 +17718,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17687,7 +17749,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17718,7 +17780,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17749,7 +17811,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17780,7 +17842,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17811,7 +17873,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17842,7 +17904,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17873,7 +17935,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17904,7 +17966,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17935,7 +17997,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17966,7 +18028,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17997,7 +18059,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18028,7 +18090,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18059,7 +18121,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18090,7 +18152,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18121,7 +18183,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18152,7 +18214,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18183,7 +18245,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18214,7 +18276,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18245,7 +18307,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18276,7 +18338,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18307,7 +18369,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18338,7 +18400,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18369,7 +18431,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18400,7 +18462,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18431,7 +18493,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18462,7 +18524,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18493,7 +18555,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18524,7 +18586,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18555,7 +18617,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18586,7 +18648,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18617,7 +18679,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18648,7 +18710,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18679,7 +18741,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18710,7 +18772,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 199,
+        "line": 201,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18741,7 +18803,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 227,
+        "line": 229,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18772,7 +18834,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 227,
+        "line": 229,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18803,7 +18865,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 227,
+        "line": 229,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18834,7 +18896,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 227,
+        "line": 229,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18865,7 +18927,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 227,
+        "line": 229,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18896,7 +18958,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 227,
+        "line": 229,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18927,7 +18989,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 227,
+        "line": 229,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18958,7 +19020,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 227,
+        "line": 229,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18989,7 +19051,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 227,
+        "line": 229,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19020,7 +19082,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19051,7 +19113,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19082,7 +19144,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19113,7 +19175,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19144,7 +19206,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19175,7 +19237,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19206,7 +19268,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19237,7 +19299,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19268,7 +19330,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19299,7 +19361,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19330,7 +19392,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19361,7 +19423,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19392,7 +19454,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19423,7 +19485,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19454,7 +19516,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19485,7 +19547,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19516,7 +19578,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19547,7 +19609,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19578,7 +19640,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19609,7 +19671,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19640,7 +19702,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19671,7 +19733,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19702,7 +19764,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19733,7 +19795,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19764,7 +19826,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 243,
+        "line": 245,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19795,7 +19857,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 323,
+        "line": 325,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19826,7 +19888,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 323,
+        "line": 325,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19857,7 +19919,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 323,
+        "line": 325,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19888,7 +19950,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 323,
+        "line": 325,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19919,7 +19981,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 329,
+        "line": 331,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19950,7 +20012,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 329,
+        "line": 331,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -19981,7 +20043,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 329,
+        "line": 331,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20012,7 +20074,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 334,
+        "line": 336,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20043,7 +20105,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 334,
+        "line": 336,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20074,7 +20136,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 334,
+        "line": 336,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20105,7 +20167,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 340,
+        "line": 342,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20136,7 +20198,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 340,
+        "line": 342,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20167,7 +20229,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 340,
+        "line": 342,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20198,7 +20260,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 340,
+        "line": 342,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20229,7 +20291,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 340,
+        "line": 342,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20260,7 +20322,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 347,
+        "line": 349,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20291,7 +20353,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 347,
+        "line": 349,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20322,7 +20384,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 347,
+        "line": 349,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20353,7 +20415,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 358,
+        "line": 360,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20384,7 +20446,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 358,
+        "line": 360,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20415,7 +20477,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 358,
+        "line": 360,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20446,7 +20508,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 358,
+        "line": 360,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20477,7 +20539,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 371,
+        "line": 373,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20508,7 +20570,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 371,
+        "line": 373,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20539,7 +20601,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 379,
+        "line": 381,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20570,7 +20632,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 379,
+        "line": 381,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20601,7 +20663,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 379,
+        "line": 381,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20632,7 +20694,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 379,
+        "line": 381,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20663,7 +20725,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 379,
+        "line": 381,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20694,7 +20756,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 379,
+        "line": 381,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20725,7 +20787,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 379,
+        "line": 381,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20756,7 +20818,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 379,
+        "line": 381,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20787,7 +20849,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 390,
+        "line": 392,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20818,7 +20880,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 390,
+        "line": 392,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20849,7 +20911,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 390,
+        "line": 392,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20880,7 +20942,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 390,
+        "line": 392,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20911,7 +20973,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 396,
+        "line": 398,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20942,7 +21004,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 396,
+        "line": 398,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -20973,7 +21035,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 396,
+        "line": 398,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21004,7 +21066,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 396,
+        "line": 398,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21035,7 +21097,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 396,
+        "line": 398,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21066,7 +21128,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 404,
+        "line": 406,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21097,7 +21159,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 404,
+        "line": 406,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21128,7 +21190,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 408,
+        "line": 410,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21159,7 +21221,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 412,
+        "line": 414,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21190,7 +21252,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 412,
+        "line": 414,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21221,7 +21283,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 412,
+        "line": 414,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21252,7 +21314,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 417,
+        "line": 419,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21283,7 +21345,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 417,
+        "line": 419,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21314,7 +21376,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 417,
+        "line": 419,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21345,7 +21407,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 417,
+        "line": 419,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21376,7 +21438,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 417,
+        "line": 419,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21407,7 +21469,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 424,
+        "line": 426,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21438,7 +21500,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 424,
+        "line": 426,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21469,7 +21531,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 424,
+        "line": 426,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21500,7 +21562,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 429,
+        "line": 431,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21531,7 +21593,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 429,
+        "line": 431,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21562,7 +21624,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 429,
+        "line": 431,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21593,7 +21655,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 447,
+        "line": 449,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21624,7 +21686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 447,
+        "line": 449,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21655,7 +21717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 447,
+        "line": 449,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21686,7 +21748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 447,
+        "line": 449,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21717,7 +21779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 447,
+        "line": 449,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21748,7 +21810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 470,
+        "line": 472,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21779,7 +21841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 470,
+        "line": 472,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21810,7 +21872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 474,
+        "line": 476,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21841,7 +21903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 474,
+        "line": 476,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21872,7 +21934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21903,7 +21965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21934,7 +21996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21965,7 +22027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21996,7 +22058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22027,7 +22089,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22058,7 +22120,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22089,7 +22151,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22120,7 +22182,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22151,7 +22213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22182,7 +22244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22213,7 +22275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22244,7 +22306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22275,7 +22337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22306,7 +22368,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 479,
+        "line": 481,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22337,7 +22399,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 496,
+        "line": 498,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22368,7 +22430,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 496,
+        "line": 498,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22399,7 +22461,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 496,
+        "line": 498,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22430,7 +22492,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 496,
+        "line": 498,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22461,7 +22523,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 496,
+        "line": 498,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22492,7 +22554,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 496,
+        "line": 498,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22523,7 +22585,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 496,
+        "line": 498,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22554,7 +22616,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 496,
+        "line": 498,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22585,7 +22647,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 506,
+        "line": 508,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22616,7 +22678,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 506,
+        "line": 508,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22647,7 +22709,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 510,
+        "line": 512,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22678,7 +22740,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 510,
+        "line": 512,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22709,7 +22771,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 511,
+        "line": 513,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -22740,7 +22802,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 512,
+        "line": 514,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -22771,7 +22833,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 512,
+        "line": 514,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -22802,7 +22864,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 512,
+        "line": 514,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -22833,7 +22895,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 517,
+        "line": 519,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22864,7 +22926,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 517,
+        "line": 519,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22895,7 +22957,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22926,7 +22988,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22957,7 +23019,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22988,7 +23050,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23019,7 +23081,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23050,7 +23112,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23081,7 +23143,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23112,7 +23174,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23143,7 +23205,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23174,7 +23236,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23205,7 +23267,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23236,7 +23298,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23267,7 +23329,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23298,7 +23360,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23329,7 +23391,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23360,7 +23422,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23391,7 +23453,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23422,7 +23484,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23453,7 +23515,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 518,
+        "line": 520,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23472,7 +23534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23487,7 +23549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23506,7 +23568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23521,7 +23583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23540,7 +23602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23555,7 +23617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23574,7 +23636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23589,7 +23651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23608,7 +23670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23623,7 +23685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23642,7 +23704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23657,7 +23719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23676,7 +23738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23691,7 +23753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23710,7 +23772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23725,7 +23787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23744,7 +23806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23759,7 +23821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 551,
+        "line": 553,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23778,7 +23840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23793,7 +23855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 551,
+        "line": 553,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23812,7 +23874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23827,7 +23889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23846,7 +23908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23861,7 +23923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23880,7 +23942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23895,7 +23957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23914,7 +23976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23929,7 +23991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23948,7 +24010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23963,7 +24025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23982,7 +24044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -23997,7 +24059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24016,7 +24078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24031,7 +24093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24050,7 +24112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24065,7 +24127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24084,7 +24146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24099,7 +24161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24118,7 +24180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24133,7 +24195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24152,7 +24214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24167,7 +24229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 567,
+        "line": 569,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -24186,7 +24248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24201,7 +24263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 570,
+        "line": 572,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24220,7 +24282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24235,7 +24297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 570,
+        "line": 572,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24254,7 +24316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24269,7 +24331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 570,
+        "line": 572,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24288,7 +24350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24303,7 +24365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 572,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24322,7 +24384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24337,7 +24399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24356,7 +24418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24371,7 +24433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24390,7 +24452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24405,7 +24467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24424,7 +24486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24439,7 +24501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24458,7 +24520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24473,7 +24535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24492,7 +24554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24507,7 +24569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24526,7 +24588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24541,7 +24603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24560,7 +24622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24575,7 +24637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24594,7 +24656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24609,7 +24671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24628,7 +24690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24643,7 +24705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24662,7 +24724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24677,7 +24739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24696,7 +24758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24711,7 +24773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24730,7 +24792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24745,7 +24807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24764,7 +24826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24779,7 +24841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24798,7 +24860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24813,7 +24875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24832,7 +24894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24847,7 +24909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24866,7 +24928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24881,7 +24943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24900,7 +24962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24915,7 +24977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24934,7 +24996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24949,8 +25011,76 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_generate_empty_latent_with_comfy",
+        "optional": false,
+        "requested": "easyuse_anima.aio.sampling",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": "_new_aio_random_seed",
+        "bound_name": "_new_aio_random_seed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 541,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_new_aio_random_seed",
+          "target": "easyuse_anima/aio/sampling.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
+        "kind": "static_from",
+        "line": 593,
+        "name": "_new_aio_random_seed",
+        "optional": false,
+        "requested": "easyuse_anima.aio.sampling",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": "_resolve_aio_runtime_seed",
+        "bound_name": "_resolve_aio_runtime_seed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 541,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_aio_runtime_seed",
+          "target": "easyuse_anima/aio/sampling.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
+        "kind": "static_from",
+        "line": 593,
+        "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
         "role": "compatibility_fallback",
@@ -24968,7 +25098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -24983,7 +25113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25002,7 +25132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25017,7 +25147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25036,7 +25166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25051,7 +25181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25070,7 +25200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25085,7 +25215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25104,7 +25234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25119,7 +25249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25138,7 +25268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25153,7 +25283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25172,7 +25302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25187,7 +25317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25206,7 +25336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25221,7 +25351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25240,7 +25370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25255,7 +25385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25274,7 +25404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25289,7 +25419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25308,7 +25438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25323,7 +25453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25342,7 +25472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25357,7 +25487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25376,7 +25506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25391,7 +25521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25410,7 +25540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25425,7 +25555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25444,7 +25574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25459,7 +25589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25478,7 +25608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25493,7 +25623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25512,7 +25642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25527,7 +25657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25546,7 +25676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25561,7 +25691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25580,7 +25710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25595,7 +25725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25614,7 +25744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25629,7 +25759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25648,7 +25778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25663,7 +25793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25682,7 +25812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25697,7 +25827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25716,7 +25846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25731,7 +25861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25750,7 +25880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25765,7 +25895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25784,7 +25914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25799,7 +25929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25818,7 +25948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25833,7 +25963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25852,7 +25982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25867,7 +25997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25886,7 +26016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25901,7 +26031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25920,7 +26050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25935,7 +26065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25954,7 +26084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -25969,7 +26099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25988,7 +26118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26003,7 +26133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26022,7 +26152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26037,7 +26167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26056,7 +26186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26071,7 +26201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26090,7 +26220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26105,7 +26235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26124,7 +26254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26139,7 +26269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26158,7 +26288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26173,7 +26303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 640,
+        "line": 644,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -26192,7 +26322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26207,7 +26337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 640,
+        "line": 644,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -26226,7 +26356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26241,7 +26371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 640,
+        "line": 644,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -26260,7 +26390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26275,7 +26405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26294,7 +26424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26309,7 +26439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26328,7 +26458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26343,7 +26473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26362,7 +26492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26377,7 +26507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26396,7 +26526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26411,7 +26541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26430,7 +26560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26445,7 +26575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -26464,7 +26594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26479,7 +26609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 653,
+        "line": 657,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26498,7 +26628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26513,7 +26643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 653,
+        "line": 657,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26532,7 +26662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26547,7 +26677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 653,
+        "line": 657,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26566,7 +26696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26581,7 +26711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 653,
+        "line": 657,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26600,7 +26730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26615,7 +26745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26634,7 +26764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26649,7 +26779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26668,7 +26798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26683,7 +26813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26702,7 +26832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26717,7 +26847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26736,7 +26866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26751,7 +26881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26770,7 +26900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26785,7 +26915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26804,7 +26934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26819,7 +26949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26838,7 +26968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26853,7 +26983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26872,7 +27002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26887,7 +27017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26906,7 +27036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26921,7 +27051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26940,7 +27070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26955,7 +27085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26974,7 +27104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -26989,7 +27119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27008,7 +27138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27023,7 +27153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27042,7 +27172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27057,7 +27187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27076,7 +27206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27091,7 +27221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27110,7 +27240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27125,7 +27255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27144,7 +27274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27159,7 +27289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27178,7 +27308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27193,7 +27323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27212,7 +27342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27227,7 +27357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27246,7 +27376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27261,7 +27391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27280,7 +27410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27295,7 +27425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27314,7 +27444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27329,7 +27459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27348,7 +27478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27363,7 +27493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27382,7 +27512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27397,7 +27527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27416,7 +27546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27431,7 +27561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27450,7 +27580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27465,7 +27595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27484,7 +27614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27499,7 +27629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27518,7 +27648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27533,7 +27663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27552,7 +27682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27567,7 +27697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27586,7 +27716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27601,7 +27731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27620,7 +27750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27635,7 +27765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27654,7 +27784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27669,7 +27799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27688,7 +27818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27703,7 +27833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27722,7 +27852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27737,7 +27867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27756,7 +27886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27771,7 +27901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27790,7 +27920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27805,7 +27935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27824,7 +27954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27839,7 +27969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27858,7 +27988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27873,7 +28003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27892,7 +28022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27907,7 +28037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27926,7 +28056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27941,7 +28071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27960,7 +28090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -27975,7 +28105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -27994,7 +28124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28009,7 +28139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28028,7 +28158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28043,7 +28173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28062,7 +28192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28077,7 +28207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28096,7 +28226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28111,7 +28241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28130,7 +28260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28145,7 +28275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28164,7 +28294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28179,7 +28309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28198,7 +28328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28213,7 +28343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28232,7 +28362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28247,7 +28377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28266,7 +28396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28281,7 +28411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28300,7 +28430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28315,7 +28445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28334,7 +28464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28349,7 +28479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28368,7 +28498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28383,7 +28513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28402,7 +28532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28417,7 +28547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28436,7 +28566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28451,7 +28581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28470,7 +28600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28485,7 +28615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28504,7 +28634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28519,7 +28649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28538,7 +28668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28553,7 +28683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28572,7 +28702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28587,7 +28717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28606,7 +28736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28621,7 +28751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28640,7 +28770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28655,7 +28785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28674,7 +28804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28689,7 +28819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28708,7 +28838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28723,7 +28853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28742,7 +28872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28757,7 +28887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28776,7 +28906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28791,7 +28921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28810,7 +28940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28825,7 +28955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28844,7 +28974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28859,7 +28989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28878,7 +29008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28893,7 +29023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28912,7 +29042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28927,7 +29057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28946,7 +29076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28961,7 +29091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28980,7 +29110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -28995,7 +29125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29014,7 +29144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29029,7 +29159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29048,7 +29178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29063,7 +29193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29082,7 +29212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29097,7 +29227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29116,7 +29246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29131,7 +29261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29150,7 +29280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29165,7 +29295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29184,7 +29314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29199,7 +29329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29218,7 +29348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29233,7 +29363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29252,7 +29382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29267,7 +29397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29286,7 +29416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29301,7 +29431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29320,7 +29450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29335,7 +29465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29354,7 +29484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29369,7 +29499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29388,7 +29518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29403,7 +29533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29422,7 +29552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29437,7 +29567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29456,7 +29586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29471,7 +29601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29490,7 +29620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29505,7 +29635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29524,7 +29654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29539,7 +29669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29558,7 +29688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29573,7 +29703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 851,
+        "line": 855,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29592,7 +29722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29607,7 +29737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 851,
+        "line": 855,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29626,7 +29756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29641,7 +29771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 851,
+        "line": 855,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29660,7 +29790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29675,7 +29805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 851,
+        "line": 855,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29694,7 +29824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29709,7 +29839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 857,
+        "line": 861,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29728,7 +29858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29743,7 +29873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 857,
+        "line": 861,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29762,7 +29892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29777,7 +29907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 857,
+        "line": 861,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29796,7 +29926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29811,7 +29941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 862,
+        "line": 866,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29830,7 +29960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29845,7 +29975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 862,
+        "line": 866,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29864,7 +29994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29879,7 +30009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 862,
+        "line": 866,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29898,7 +30028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29913,7 +30043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 868,
+        "line": 872,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29932,7 +30062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29947,7 +30077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 868,
+        "line": 872,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -29966,7 +30096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -29981,7 +30111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 868,
+        "line": 872,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30000,7 +30130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30015,7 +30145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 868,
+        "line": 872,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30034,7 +30164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30049,7 +30179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 868,
+        "line": 872,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30068,7 +30198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30083,7 +30213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 875,
+        "line": 879,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -30102,7 +30232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30117,7 +30247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 875,
+        "line": 879,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -30136,7 +30266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30151,7 +30281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 875,
+        "line": 879,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -30170,7 +30300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30185,7 +30315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 886,
+        "line": 890,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30204,7 +30334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30219,7 +30349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 886,
+        "line": 890,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30238,7 +30368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30253,7 +30383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 886,
+        "line": 890,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30272,7 +30402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30287,7 +30417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 886,
+        "line": 890,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30306,7 +30436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30321,7 +30451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 899,
+        "line": 903,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -30340,7 +30470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30355,7 +30485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 899,
+        "line": 903,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -30374,7 +30504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30389,7 +30519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30408,7 +30538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30423,7 +30553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30442,7 +30572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30457,7 +30587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30476,7 +30606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30491,7 +30621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30510,7 +30640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30525,7 +30655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30544,7 +30674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30559,7 +30689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30578,7 +30708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30593,7 +30723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30612,7 +30742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30627,7 +30757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30646,7 +30776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30661,7 +30791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 918,
+        "line": 922,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30680,7 +30810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30695,7 +30825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 918,
+        "line": 922,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30714,7 +30844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30729,7 +30859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 918,
+        "line": 922,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30748,7 +30878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30763,7 +30893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 918,
+        "line": 922,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30782,7 +30912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30797,7 +30927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 924,
+        "line": 928,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30816,7 +30946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30831,7 +30961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 924,
+        "line": 928,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30850,7 +30980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30865,7 +30995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 924,
+        "line": 928,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30884,7 +31014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30899,7 +31029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 924,
+        "line": 928,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30918,7 +31048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30933,7 +31063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 924,
+        "line": 928,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30952,7 +31082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -30967,7 +31097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 932,
+        "line": 936,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -30986,7 +31116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31001,7 +31131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 932,
+        "line": 936,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -31020,7 +31150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31035,7 +31165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 936,
+        "line": 940,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -31054,7 +31184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31069,7 +31199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 940,
+        "line": 944,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -31088,7 +31218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31103,7 +31233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 940,
+        "line": 944,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -31122,7 +31252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31137,7 +31267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 940,
+        "line": 944,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -31156,7 +31286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31171,7 +31301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 945,
+        "line": 949,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31190,7 +31320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31205,7 +31335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 945,
+        "line": 949,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31224,7 +31354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31239,7 +31369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 945,
+        "line": 949,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31258,7 +31388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31273,7 +31403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 945,
+        "line": 949,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31292,7 +31422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31307,7 +31437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 945,
+        "line": 949,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31326,7 +31456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31341,7 +31471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 952,
+        "line": 956,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31360,7 +31490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31375,7 +31505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 952,
+        "line": 956,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31394,7 +31524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31409,7 +31539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 952,
+        "line": 956,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31428,7 +31558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31443,7 +31573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 957,
+        "line": 961,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31462,7 +31592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31477,7 +31607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 957,
+        "line": 961,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31496,7 +31626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31511,7 +31641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 957,
+        "line": 961,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31530,7 +31660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31545,7 +31675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 975,
+        "line": 979,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31564,7 +31694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31579,7 +31709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 975,
+        "line": 979,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31598,7 +31728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31613,7 +31743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 975,
+        "line": 979,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31632,7 +31762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31647,7 +31777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 975,
+        "line": 979,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31666,7 +31796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31681,7 +31811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 975,
+        "line": 979,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31700,7 +31830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31715,7 +31845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 998,
+        "line": 1002,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31734,7 +31864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31749,7 +31879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 998,
+        "line": 1002,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31768,7 +31898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31783,7 +31913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1006,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31802,7 +31932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31817,7 +31947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1006,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31836,7 +31966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31851,7 +31981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31870,7 +32000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31885,7 +32015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31904,7 +32034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31919,7 +32049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31938,7 +32068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31953,7 +32083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -31972,7 +32102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -31987,7 +32117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32006,7 +32136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32021,7 +32151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32040,7 +32170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32055,7 +32185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32074,7 +32204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32089,7 +32219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32108,7 +32238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32123,7 +32253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32142,7 +32272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32157,7 +32287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32176,7 +32306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32191,7 +32321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32210,7 +32340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32225,7 +32355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32244,7 +32374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32259,7 +32389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32278,7 +32408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32293,7 +32423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32312,7 +32442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32327,7 +32457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32346,7 +32476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32361,7 +32491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32380,7 +32510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32395,7 +32525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32414,7 +32544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32429,7 +32559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32448,7 +32578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32463,7 +32593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32482,7 +32612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32497,7 +32627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32516,7 +32646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32531,7 +32661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32550,7 +32680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32565,7 +32695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32584,7 +32714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32599,7 +32729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32618,7 +32748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32633,7 +32763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1038,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32652,7 +32782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32667,7 +32797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1038,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32686,7 +32816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32701,7 +32831,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -32720,7 +32850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32735,7 +32865,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -32754,7 +32884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32769,7 +32899,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1043,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -32788,7 +32918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32803,7 +32933,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1044,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -32822,7 +32952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32837,7 +32967,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1044,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -32856,7 +32986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32871,7 +33001,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1044,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -32890,7 +33020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32905,7 +33035,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1049,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32924,7 +33054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32939,7 +33069,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1049,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -32958,7 +33088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -32973,7 +33103,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -32992,7 +33122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33007,7 +33137,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33026,7 +33156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33041,7 +33171,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33060,7 +33190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33075,7 +33205,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33094,7 +33224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33109,7 +33239,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33128,7 +33258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33143,7 +33273,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33162,7 +33292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33177,7 +33307,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33196,7 +33326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33211,7 +33341,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33230,7 +33360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33245,7 +33375,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33264,7 +33394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33279,7 +33409,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33298,7 +33428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33313,7 +33443,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33332,7 +33462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33347,7 +33477,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33366,7 +33496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33381,7 +33511,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33400,7 +33530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33415,7 +33545,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33434,7 +33564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33449,7 +33579,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33468,7 +33598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33483,7 +33613,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33502,7 +33632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33517,7 +33647,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33536,7 +33666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33551,7 +33681,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33570,7 +33700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -33585,7 +33715,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33603,7 +33733,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1657
+            "line": 1646
           }
         ],
         "classification": "external",
@@ -33611,7 +33741,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1658,
+        "line": 1647,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33628,7 +33758,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1694
+            "line": 1683
           }
         ],
         "classification": "external",
@@ -33636,7 +33766,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1695,
+        "line": 1684,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33653,7 +33783,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1702
+            "line": 1691
           }
         ],
         "classification": "external",
@@ -33661,7 +33791,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1703,
+        "line": 1692,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -36685,13 +36815,13 @@
       },
       {
         "is_package": false,
-        "loc": 453,
+        "loc": 465,
         "module": "easyuse_anima.aio.sampling",
-        "normalized_git_blob_sha1": "4c4dd0592a60c4ab63fd6f38acb715064a1768c0",
+        "normalized_git_blob_sha1": "4fba4a918bbe345d973f02033a1e5e320c140256",
         "path": "easyuse_anima/aio/sampling.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 11,
+          "function_count": 13,
           "global_count": 3
         }
       },
@@ -37249,13 +37379,13 @@
       },
       {
         "is_package": false,
-        "loc": 2539,
+        "loc": 2528,
         "module": "nodes",
-        "normalized_git_blob_sha1": "2106ef1a676f053b3ab34f7579146681f640d82a",
+        "normalized_git_blob_sha1": "57af5ee6c0b8e183818f3c0eda3f80721eee2f5a",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 35,
+          "function_count": 33,
           "global_count": 28
         }
       },
@@ -38615,7 +38745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38624,7 +38754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38638,7 +38768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38647,7 +38777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38661,7 +38791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38670,7 +38800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38684,7 +38814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38693,7 +38823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38707,7 +38837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38716,7 +38846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38730,7 +38860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38739,7 +38869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38753,7 +38883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38762,7 +38892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38776,7 +38906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38785,7 +38915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 540,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38799,7 +38929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38808,7 +38938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 551,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38822,7 +38952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38831,7 +38961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 551,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38845,7 +38975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38854,7 +38984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38868,7 +38998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38877,7 +39007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38891,7 +39021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38900,7 +39030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38914,7 +39044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38923,7 +39053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38937,7 +39067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38946,7 +39076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38960,7 +39090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38969,7 +39099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38983,7 +39113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -38992,7 +39122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39006,7 +39136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39015,7 +39145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39029,7 +39159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39038,7 +39168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39052,7 +39182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39061,7 +39191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 555,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39075,7 +39205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39084,7 +39214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 567,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39098,7 +39228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39107,7 +39237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 570,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39121,7 +39251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39130,7 +39260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 570,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39144,7 +39274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39153,7 +39283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 570,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39167,7 +39297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39176,7 +39306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39190,7 +39320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39199,7 +39329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39213,7 +39343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39222,7 +39352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39236,7 +39366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39245,7 +39375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39259,7 +39389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39268,7 +39398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39282,7 +39412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39291,7 +39421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39305,7 +39435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39314,7 +39444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39328,7 +39458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39337,7 +39467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39351,7 +39481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39360,7 +39490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39374,7 +39504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39383,7 +39513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39397,7 +39527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39406,7 +39536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39420,7 +39550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39429,7 +39559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39443,7 +39573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39452,7 +39582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39466,7 +39596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39475,7 +39605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 576,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39489,7 +39619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39498,7 +39628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39512,7 +39642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39521,7 +39651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39535,7 +39665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39544,7 +39674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39558,7 +39688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39567,7 +39697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39581,7 +39711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39590,7 +39720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39604,7 +39734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39613,7 +39743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39627,7 +39757,53 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
+        "kind": "static_from",
+        "line": 593,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 541,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
+        "kind": "static_from",
+        "line": 593,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39636,7 +39812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39650,7 +39826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39659,7 +39835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39673,7 +39849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39682,7 +39858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39696,7 +39872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39705,7 +39881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39719,7 +39895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39728,7 +39904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39742,7 +39918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39751,7 +39927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39765,7 +39941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39774,7 +39950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39788,7 +39964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39797,7 +39973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39811,7 +39987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39820,7 +39996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39834,7 +40010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39843,7 +40019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39857,7 +40033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39866,7 +40042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39880,7 +40056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39889,7 +40065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39903,7 +40079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39912,7 +40088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39926,7 +40102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39935,7 +40111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 603,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39949,7 +40125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39958,7 +40134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39972,7 +40148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -39981,7 +40157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39995,7 +40171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40004,7 +40180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40018,7 +40194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40027,7 +40203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40041,7 +40217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40050,7 +40226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40064,7 +40240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40073,7 +40249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40087,7 +40263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40096,7 +40272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40110,7 +40286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40119,7 +40295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40133,7 +40309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40142,7 +40318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40156,7 +40332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40165,7 +40341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 615,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40179,7 +40355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40188,7 +40364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40202,7 +40378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40211,7 +40387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40225,7 +40401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40234,7 +40410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40248,7 +40424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40257,7 +40433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40271,7 +40447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40280,7 +40456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40294,7 +40470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40303,7 +40479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40317,7 +40493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40326,7 +40502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40340,7 +40516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40349,7 +40525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40363,7 +40539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40372,7 +40548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40386,7 +40562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40395,7 +40571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40409,7 +40585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40418,7 +40594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 627,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40432,7 +40608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40441,7 +40617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 640,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40455,7 +40631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40464,7 +40640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 640,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40478,7 +40654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40487,7 +40663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 640,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40501,7 +40677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40510,7 +40686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40524,7 +40700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40533,7 +40709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40547,7 +40723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40556,7 +40732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40570,7 +40746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40579,7 +40755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40593,7 +40769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40602,7 +40778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 645,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40616,7 +40792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40625,7 +40801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40639,7 +40815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40648,7 +40824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 653,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40662,7 +40838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40671,7 +40847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 653,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40685,7 +40861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40694,7 +40870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 653,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40708,7 +40884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40717,7 +40893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 653,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40731,7 +40907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40740,7 +40916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40754,7 +40930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40763,7 +40939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40777,7 +40953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40786,7 +40962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40800,7 +40976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40809,7 +40985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40823,7 +40999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40832,7 +41008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40846,7 +41022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40855,7 +41031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40869,7 +41045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40878,7 +41054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40892,7 +41068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40901,7 +41077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40915,7 +41091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40924,7 +41100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40938,7 +41114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40947,7 +41123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 659,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40961,7 +41137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40970,7 +41146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40984,7 +41160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -40993,7 +41169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41007,7 +41183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41016,7 +41192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41030,7 +41206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41039,7 +41215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41053,7 +41229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41062,7 +41238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41076,7 +41252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41085,7 +41261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41099,7 +41275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41108,7 +41284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 673,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41122,7 +41298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41131,7 +41307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41145,7 +41321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41154,7 +41330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41168,7 +41344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41177,7 +41353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41191,7 +41367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41200,7 +41376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41214,7 +41390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41223,7 +41399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41237,7 +41413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41246,7 +41422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41260,7 +41436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41269,7 +41445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41283,7 +41459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41292,7 +41468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41306,7 +41482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41315,7 +41491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41329,7 +41505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41338,7 +41514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41352,7 +41528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41361,7 +41537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41375,7 +41551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41384,7 +41560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41398,7 +41574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41407,7 +41583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41421,7 +41597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41430,7 +41606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41444,7 +41620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41453,7 +41629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41467,7 +41643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41476,7 +41652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41490,7 +41666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41499,7 +41675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41513,7 +41689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41522,7 +41698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41536,7 +41712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41545,7 +41721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41559,7 +41735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41568,7 +41744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41582,7 +41758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41591,7 +41767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41605,7 +41781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41614,7 +41790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 691,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41628,7 +41804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41637,7 +41813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41651,7 +41827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41660,7 +41836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41674,7 +41850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41683,7 +41859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41697,7 +41873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41706,7 +41882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41720,7 +41896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41729,7 +41905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41743,7 +41919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41752,7 +41928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41766,7 +41942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41775,7 +41951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41789,7 +41965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41798,7 +41974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41812,7 +41988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41821,7 +41997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41835,7 +42011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41844,7 +42020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41858,7 +42034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41867,7 +42043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41881,7 +42057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41890,7 +42066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41904,7 +42080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41913,7 +42089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41927,7 +42103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41936,7 +42112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 727,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41950,7 +42126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41959,7 +42135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41973,7 +42149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -41982,7 +42158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41996,7 +42172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42005,7 +42181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42019,7 +42195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42028,7 +42204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42042,7 +42218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42051,7 +42227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42065,7 +42241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42074,7 +42250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42088,7 +42264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42097,7 +42273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42111,7 +42287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42120,7 +42296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42134,7 +42310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42143,7 +42319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 755,
+        "line": 759,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42157,7 +42333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42166,7 +42342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42180,7 +42356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42189,7 +42365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42203,7 +42379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42212,7 +42388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42226,7 +42402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42235,7 +42411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42249,7 +42425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42258,7 +42434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42272,7 +42448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42281,7 +42457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42295,7 +42471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42304,7 +42480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42318,7 +42494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42327,7 +42503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42341,7 +42517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42350,7 +42526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42364,7 +42540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42373,7 +42549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42387,7 +42563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42396,7 +42572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42410,7 +42586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42419,7 +42595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42433,7 +42609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42442,7 +42618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42456,7 +42632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42465,7 +42641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42479,7 +42655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42488,7 +42664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42502,7 +42678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42511,7 +42687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42525,7 +42701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42534,7 +42710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42548,7 +42724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42557,7 +42733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42571,7 +42747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42580,7 +42756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42594,7 +42770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42603,7 +42779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42617,7 +42793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42626,7 +42802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42640,7 +42816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42649,7 +42825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42663,7 +42839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42672,7 +42848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42686,7 +42862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42695,7 +42871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42709,7 +42885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42718,7 +42894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 771,
+        "line": 775,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42732,7 +42908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42741,7 +42917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 851,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42755,7 +42931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42764,7 +42940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 851,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42778,7 +42954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42787,7 +42963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 851,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42801,7 +42977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42810,7 +42986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 851,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42824,7 +43000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42833,7 +43009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 857,
+        "line": 861,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42847,7 +43023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42856,7 +43032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 857,
+        "line": 861,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42870,7 +43046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42879,7 +43055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 857,
+        "line": 861,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42893,7 +43069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42902,7 +43078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 862,
+        "line": 866,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42916,7 +43092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42925,7 +43101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 862,
+        "line": 866,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42939,7 +43115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42948,7 +43124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 862,
+        "line": 866,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42962,7 +43138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42971,7 +43147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 868,
+        "line": 872,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42985,7 +43161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -42994,7 +43170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 868,
+        "line": 872,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43008,7 +43184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43017,7 +43193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 868,
+        "line": 872,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43031,7 +43207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43040,7 +43216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 868,
+        "line": 872,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43054,7 +43230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43063,7 +43239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 868,
+        "line": 872,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43077,7 +43253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43086,7 +43262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 875,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43100,7 +43276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43109,7 +43285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 875,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43123,7 +43299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43132,7 +43308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 875,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43146,7 +43322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43155,7 +43331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 886,
+        "line": 890,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43169,7 +43345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43178,7 +43354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 886,
+        "line": 890,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43192,7 +43368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43201,7 +43377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 886,
+        "line": 890,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43215,7 +43391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43224,7 +43400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 886,
+        "line": 890,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43238,7 +43414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43247,7 +43423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 899,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43261,7 +43437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43270,7 +43446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 899,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43284,7 +43460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43293,7 +43469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43307,7 +43483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43316,7 +43492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43330,7 +43506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43339,7 +43515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43353,7 +43529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43362,7 +43538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43376,7 +43552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43385,7 +43561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43399,7 +43575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43408,7 +43584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43422,7 +43598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43431,7 +43607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43445,7 +43621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43454,7 +43630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 907,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43468,7 +43644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43477,7 +43653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 918,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43491,7 +43667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43500,7 +43676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 918,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43514,7 +43690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43523,7 +43699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 918,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43537,7 +43713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43546,7 +43722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 918,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43560,7 +43736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43569,7 +43745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 924,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43583,7 +43759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43592,7 +43768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 924,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43606,7 +43782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43615,7 +43791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 924,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43629,7 +43805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43638,7 +43814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 924,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43652,7 +43828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43661,7 +43837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 924,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43675,7 +43851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43684,7 +43860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 932,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43698,7 +43874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43707,7 +43883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 932,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43721,7 +43897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43730,7 +43906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 936,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43744,7 +43920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43753,7 +43929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 940,
+        "line": 944,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43767,7 +43943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43776,7 +43952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 940,
+        "line": 944,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43790,7 +43966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43799,7 +43975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 940,
+        "line": 944,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43813,7 +43989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43822,7 +43998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 945,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43836,7 +44012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43845,7 +44021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 945,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43859,7 +44035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43868,7 +44044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 945,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43882,7 +44058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43891,7 +44067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 945,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43905,7 +44081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43914,7 +44090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 945,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43928,7 +44104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43937,7 +44113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 952,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43951,7 +44127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43960,7 +44136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 952,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43974,7 +44150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -43983,7 +44159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 952,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43997,7 +44173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44006,7 +44182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 957,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44020,7 +44196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44029,7 +44205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 957,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44043,7 +44219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44052,7 +44228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 957,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44066,7 +44242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44075,7 +44251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 975,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44089,7 +44265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44098,7 +44274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 975,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44112,7 +44288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44121,7 +44297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 975,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44135,7 +44311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44144,7 +44320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 975,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44158,7 +44334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44167,7 +44343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 975,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44181,7 +44357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44190,7 +44366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 998,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44204,7 +44380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44213,7 +44389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 998,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44227,7 +44403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44236,7 +44412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44250,7 +44426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44259,7 +44435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44273,7 +44449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44282,7 +44458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44296,7 +44472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44305,7 +44481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44319,7 +44495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44328,7 +44504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44342,7 +44518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44351,7 +44527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44365,7 +44541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44374,7 +44550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44388,7 +44564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44397,7 +44573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44411,7 +44587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44420,7 +44596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44434,7 +44610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44443,7 +44619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44457,7 +44633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44466,7 +44642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44480,7 +44656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44489,7 +44665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44503,7 +44679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44512,7 +44688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44526,7 +44702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44535,7 +44711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44549,7 +44725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44558,7 +44734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44572,7 +44748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44581,7 +44757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44595,7 +44771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44604,7 +44780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44618,7 +44794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44627,7 +44803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44641,7 +44817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44650,7 +44826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44664,7 +44840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44673,7 +44849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44687,7 +44863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44696,7 +44872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44710,7 +44886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44719,7 +44895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44733,7 +44909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44742,7 +44918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44756,7 +44932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44765,7 +44941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44779,7 +44955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44788,7 +44964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44802,7 +44978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44811,7 +44987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44825,7 +45001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44834,7 +45010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44848,7 +45024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44857,7 +45033,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44871,7 +45047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44880,7 +45056,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44894,7 +45070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44903,7 +45079,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1043,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44917,7 +45093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44926,7 +45102,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1044,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44940,7 +45116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44949,7 +45125,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1044,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44963,7 +45139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44972,7 +45148,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1044,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44986,7 +45162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -44995,7 +45171,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1049,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45009,7 +45185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45018,7 +45194,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1049,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45032,7 +45208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45041,7 +45217,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45055,7 +45231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45064,7 +45240,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45078,7 +45254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45087,7 +45263,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45101,7 +45277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45110,7 +45286,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45124,7 +45300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45133,7 +45309,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45147,7 +45323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45156,7 +45332,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45170,7 +45346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45179,7 +45355,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45193,7 +45369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45202,7 +45378,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45216,7 +45392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45225,7 +45401,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45239,7 +45415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45248,7 +45424,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45262,7 +45438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45271,7 +45447,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45285,7 +45461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45294,7 +45470,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45308,7 +45484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45317,7 +45493,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45331,7 +45507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45340,7 +45516,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45354,7 +45530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45363,7 +45539,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45377,7 +45553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45386,7 +45562,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45400,7 +45576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45409,7 +45585,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45423,7 +45599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45432,7 +45608,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45446,7 +45622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 539,
+            "handler_line": 541,
             "kind": "try",
             "line": 11
           }
@@ -45455,7 +45631,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49194,14 +49370,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1657
+            "line": 1646
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1658,
+        "line": 1647,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49213,14 +49389,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1694
+            "line": 1683
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1695,
+        "line": 1684,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49232,14 +49408,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1702
+            "line": 1691
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1703,
+        "line": 1692,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50614,14 +50790,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1657
+            "line": 1646
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1658,
+        "line": 1647,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50633,14 +50809,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1694
+            "line": 1683
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1695,
+        "line": 1684,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50652,14 +50828,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1702
+            "line": 1691
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1703,
+        "line": 1692,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52107,7 +52283,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1068,
+        "line": 1072,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52116,7 +52292,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1608,
+        "line": 1597,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52125,7 +52301,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2441,
+        "line": 2430,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52134,7 +52310,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2444,
+        "line": 2433,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52143,7 +52319,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2447,
+        "line": 2436,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52152,7 +52328,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2450,
+        "line": 2439,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52161,7 +52337,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2453,
+        "line": 2442,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52170,7 +52346,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2456,
+        "line": 2445,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52179,7 +52355,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2459,
+        "line": 2448,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52188,7 +52364,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2462,
+        "line": 2451,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52197,7 +52373,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2465,
+        "line": 2454,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52206,7 +52382,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2468,
+        "line": 2457,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52215,7 +52391,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2471,
+        "line": 2460,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52224,7 +52400,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2474,
+        "line": 2463,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52233,7 +52409,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2477,
+        "line": 2466,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52242,7 +52418,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2480,
+        "line": 2469,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52251,7 +52427,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2484,
+        "line": 2473,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52260,7 +52436,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2487,
+        "line": 2476,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52269,7 +52445,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2491,
+        "line": 2480,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52278,7 +52454,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2494,
+        "line": 2483,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52287,7 +52463,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2498,
+        "line": 2487,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52296,7 +52472,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2501,
+        "line": 2490,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52305,7 +52481,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2504,
+        "line": 2493,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52314,7 +52490,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2507,
+        "line": 2496,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52323,7 +52499,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2510,
+        "line": 2499,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52332,7 +52508,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2513,
+        "line": 2502,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52341,7 +52517,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2520,
+        "line": 2509,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52350,7 +52526,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2526,
+        "line": 2515,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52359,7 +52535,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2531,
+        "line": 2520,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52368,7 +52544,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2535,
+        "line": 2524,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52876,19 +53052,19 @@
       },
       {
         "kind": "dict",
-        "line": 1130,
+        "line": 1134,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1119,
+        "line": 1123,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1607,
+        "line": 1596,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "bbca312b684f009aafbd1ed813a8f136e5520b3d",
+    "base_commit": "17343eb4fed55d05c349b145119539501f92ad47",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -36,7 +36,8 @@
       "B-11c4",
       "B-11c5",
       "B-11c6",
-      "B-11c7a"
+      "B-11c7a",
+      "B-11c7b"
     ]
   },
   "enums": {
@@ -71,11 +72,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 271,
+    "nodes_canonical_bindings": 273,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 35,
+    "root_residual_functions": 33,
     "root_residual_classes": 0,
     "root_residual_globals": 28,
     "runtime_binders": 28,
@@ -183,6 +184,7 @@
       "easyuse_anima.aio.generation_normalization"
     ],
     "AIO_SPECIAL_SEEDS": [
+      "easyuse_anima.aio.sampling",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "AIO_SPECIAL_SEED_DECREMENT": [
@@ -276,7 +278,8 @@
       "easyuse_anima.aio.generation_normalization"
     ],
     "MAX_SEED": [
-      "easyuse_anima.aio.generation_normalization"
+      "easyuse_anima.aio.generation_normalization",
+      "easyuse_anima.aio.sampling"
     ],
     "PROMPT_DATA_TYPE": [
       "easyuse_anima.nodes.aio_nodes"
@@ -735,6 +738,9 @@
     "_missing_lora_display_name": [
       "easyuse_anima.nodes.lora_nodes"
     ],
+    "_new_aio_random_seed": [
+      "easyuse_anima.aio.sampling"
+    ],
     "_node_output_tuple": [
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.resources",
@@ -768,7 +774,8 @@
       "easyuse_anima.aio.model_preparation"
     ],
     "_normalize_aio_seed": [
-      "easyuse_anima.aio.generation_normalization"
+      "easyuse_anima.aio.generation_normalization",
+      "easyuse_anima.aio.sampling"
     ],
     "_normalize_aio_spectrum_settings": [
       "easyuse_anima.aio.generation_normalization"
@@ -1907,12 +1914,14 @@
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
+        "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
+        "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -2198,6 +2207,8 @@
         "_decode_latent_with_comfy": "_decode_latent_with_comfy",
         "_encode_image_with_comfy_vae": "_encode_image_with_comfy_vae",
         "_generate_empty_latent_with_comfy": "_generate_empty_latent_with_comfy",
+        "_new_aio_random_seed": "_new_aio_random_seed",
+        "_resolve_aio_runtime_seed": "_resolve_aio_runtime_seed",
         "_sample_latent_with_aio_backend": "_sample_latent_with_aio_backend",
         "_sample_latent_with_comfy": "_sample_latent_with_comfy",
         "_sample_latent_with_spectrum_mod_guidance_advanced": "_sample_latent_with_spectrum_mod_guidance_advanced",
@@ -2215,13 +2226,17 @@
       "known_consumers": [
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
+        "canonical runtime resolver: easyuse_anima.aio.output",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
+        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
+        "AST:easyuse_anima.aio.output string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
+        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -3984,12 +3999,10 @@
         "_find_comfy_node_mapping_class": "_find_comfy_node_mapping_class",
         "_find_loaded_node_class": "_find_loaded_node_class",
         "_is_aio_detailer_target_name": "_is_aio_detailer_target_name",
-        "_new_aio_random_seed": "_new_aio_random_seed",
         "_normalize_aio_input_settings": "_normalize_aio_input_settings",
         "_require_any_custom_node_class": "_require_any_custom_node_class",
         "_require_custom_node_class": "_require_custom_node_class",
         "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed",
-        "_resolve_aio_runtime_seed": "_resolve_aio_runtime_seed",
         "_run_aio_detailer_stage": "_run_aio_detailer_stage",
         "_run_aio_detailer_target": "_run_aio_detailer_target",
         "_run_aio_highres_stage": "_run_aio_highres_stage",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -21,6 +21,7 @@ import nodes
 from easyuse_anima import workflow
 from easyuse_anima.aio import (
     generation_normalization as aio_generation_normalization,
+    sampling as aio_sampling,
 )
 from easyuse_anima.aio import model_preparation as aio_model_preparation
 from easyuse_anima.common import serialization as common_serialization
@@ -872,6 +873,58 @@ class AioSeedNormalizationMoveContractTests(unittest.TestCase):
                 f"{package_name}.easyuse_anima.aio.generation_normalization"
             ]
             self._assert_contract(package_nodes, package_generation_normalization)
+
+
+class AioRuntimeSeedMoveContractTests(unittest.TestCase):
+    def _assert_contract(self, root_module, canonical_module):
+        self.assertIs(
+            root_module._new_aio_random_seed,
+            canonical_module._new_aio_random_seed,
+        )
+        self.assertIs(
+            root_module._resolve_aio_runtime_seed,
+            canonical_module._resolve_aio_runtime_seed,
+        )
+
+        randint_calls = []
+        random_module = types.SimpleNamespace(
+            randint=lambda lower, upper: randint_calls.append((lower, upper)) or 7
+        )
+        with (
+            patch.object(root_module, "random", random_module),
+            patch.object(root_module, "MAX_SEED", 12),
+        ):
+            self.assertEqual(canonical_module._new_aio_random_seed(), 7)
+        self.assertEqual(randint_calls, [(0, 12)])
+
+        with (
+            patch.object(
+                root_module,
+                "_normalize_aio_seed",
+                side_effect=(-1, 99, -99),
+            ) as normalize_seed,
+            patch.object(root_module, "AIO_SPECIAL_SEEDS", {-1}),
+            patch.object(root_module, "_new_aio_random_seed", return_value=777) as new_seed,
+            patch.object(root_module, "MAX_SEED", 12),
+        ):
+            self.assertEqual(canonical_module._resolve_aio_runtime_seed("special"), 777)
+            self.assertEqual(canonical_module._resolve_aio_runtime_seed("high"), 12)
+            self.assertEqual(canonical_module._resolve_aio_runtime_seed("low"), 0)
+
+        self.assertEqual(
+            normalize_seed.call_args_list,
+            [call("special"), call("high"), call("low")],
+        )
+        new_seed.assert_called_once_with()
+
+    def test_root_aliases_and_runtime_helper_replacements(self):
+        self._assert_contract(nodes, aio_sampling)
+
+    def test_package_aliases_and_runtime_helper_replacements(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_sampling = sys.modules[f"{package_name}.easyuse_anima.aio.sampling"]
+            self._assert_contract(package_nodes, package_sampling)
 
 
 class ComfyAdapterMoveContractTests(unittest.TestCase):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "2106ef1a676f053b3ab34f7579146681f640d82a")
-        # Issue #184 B-11c7a moves the AiO special-seed constants and normalizer
-        # while preserving direct aliases and call-time clamp helper seams.
-        self.assertEqual(report["top_level"]["function_count"], 35)
+        self.assertEqual(report["git_blob_sha1"], "57af5ee6c0b8e183818f3c0eda3f80721eee2f5a")
+        # Issue #184 B-11c7b moves runtime seed resolution and random generation
+        # while preserving direct aliases and call-time root helper seams.
+        self.assertEqual(report["top_level"]["function_count"], 33)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_539)
+        self.assertEqual(report["line_count"], 2_528)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "bbca312b684f009aafbd1ed813a8f136e5520b3d"
+BASE_COMMIT = "17343eb4fed55d05c349b145119539501f92ad47"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1310,6 +1310,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c5",
                 "B-11c6",
                 "B-11c7a",
+                "B-11c7b",
             ],
         },
         "enums": {
@@ -1322,11 +1323,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 271,
+            "nodes_canonical_bindings": 273,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 35,
+            "root_residual_functions": 33,
             "root_residual_classes": 0,
             "root_residual_globals": 28,
             "runtime_binders": 28,


### PR DESCRIPTION
## 변경 요약

- B-11c7b에서 `_new_aio_random_seed`와 `_resolve_aio_runtime_seed`의 소유권만 `easyuse_anima.aio.sampling`으로 이동합니다.
- root `nodes.py`의 relative/flat import는 canonical 함수의 direct alias identity를 유지합니다.
- 시드 상수/정규화, increment/decrement 정책, backend seed reservation은 변경하지 않습니다.

## 작업 전 인벤토리

### Symbol

- root `_new_aio_random_seed()`: process-wide `random.randint(0, MAX_SEED)`를 한 번 호출합니다.
- root `_resolve_aio_runtime_seed(value)`: root `_normalize_aio_seed`를 호출하고, 결과가 mutable `AIO_SPECIAL_SEEDS`에 있으면 root `_new_aio_random_seed`를 호출하며, 아니면 `[0, MAX_SEED]`로 clamp합니다.

### Caller

- `_new_aio_random_seed`: root `_resolve_aio_runtime_seed` 한 곳.
- `_resolve_aio_runtime_seed`: root highres/upscale stage 두 곳.
- runtime resolver 소비자: `easyuse_anima.aio.legacy_generation`, `easyuse_anima.aio.output`, `easyuse_anima.aio.sampling`, `easyuse_anima.nodes.aio_nodes`.

### Alias / compatibility

- 작업 전 두 함수는 root definition이며 canonical alias가 없습니다.
- 작업 후 relative/flat root import가 동일한 canonical 함수 객체를 직접 가리켜야 합니다.
- canonical 함수는 기존 sampling runtime resolver로 root `random`, `MAX_SEED`, `_normalize_aio_seed`, `AIO_SPECIAL_SEEDS`, `_new_aio_random_seed`를 호출 시점에 조회합니다.

### Global state

- Python process-wide `random` module state를 그대로 소비합니다.
- mutable `AIO_SPECIAL_SEEDS`의 root binding 교체 및 in-place mutation 가시성을 유지합니다.
- `MAX_SEED` 소유권은 legacy `wildcard_engine`에 유지합니다.
- 새 cache, lock, binder, RNG 객체를 만들지 않습니다.

## Allowed-file boundary

- `easyuse_anima/aio/sampling.py`
- `nodes.py`
- `tests/test_node_contracts.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 금지 경계

- RNG 종류, process-wide 상태, 호출 횟수·순서, `randint`의 양 끝 포함 범위를 변경하지 않습니다.
- 특수 시드 숫자/set, 정규화/clamp, increment/decrement, `seed_after_generate`, 이전 시드, cache/change-key를 변경하지 않습니다.
- backend seed reservation, queue/browser/headless 동작을 구현하지 않습니다.
- `MAX_SEED` 소유권, runtime binder, canonical-to-root import, 소비자 호출부를 변경하지 않습니다.

## 검증 계획

- focused unittest: 새 Move contract, AiO runtime seed, sampling resolver, compatibility/analyzer/import boundary
- `git diff --check`
- main-owned exact-head `tools/check_custom_node.ps1 -Profile full`

## 검증 결과

- focused (workspace `.venv`): 68 tests, OK
  - 새 flat/package alias 및 runtime helper replacement contract
  - AiO runtime seed와 sampling resolver
  - compatibility surface, nodes/backend analyzer, import boundary
- 공식 full (`tools/check_custom_node.ps1 -Profile full`): 통과
  - Python unittest: 898 tests, OK
  - Frontend: 114 JavaScript files, 통과
  - Pyright baseline ratchet / import-boundary gate / `git diff --check`: 통과
  - Ruff G-01 report-only: 107건, non-blocking. 이 Move에서 root runtime resolver seam으로 남긴 `random`/`MAX_SEED`의 정적 F401 2건이 추가되었습니다.
- 독립 읽기 전용 diff review: findings 없음

## 테스트 표면

- ComfyUI Codex test infrastructure: repository-owned static/unit/full validation 완료
- Live ComfyUI smoke: 미실행 예정 (Move-only이며 Phase B exit checkpoint에서 수행)

## 남은 위험 / 미확인

- `-1/-2/-3`에 대한 authoritative reservation/증가/감소 Behavior는 #167 후속 계약이며 이 Move에 포함하지 않습니다.
- GitHub Actions check는 별도 보고가 없으며, 공식 full과 독립 리뷰를 병합 근거로 사용합니다.

Closes no issue; tracks #184.
