### PR TITLE
refactor(backend): move AiO widget default serializers (B-11c8)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `17343eb4fed55d05c349b145119539501f92ad47`
+- Integrated `dev` snapshot commit: `68637353f55758d398c27f89be0ee7c1b52f7389`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c7a; B-11c7b runtime-seed Move in PR #301 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c7b; B-11c8 widget-default serializer Move in PR #302 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,539
-  lines after B-11c7a.
-- The mechanical extraction has removed 10,124
-  lines, approximately 79.9% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,528
+  lines after B-11c7b.
+- The mechanical extraction has removed 10,135
+  lines, approximately 80.0% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -64,8 +64,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   B-11c6 moved the AiO DiT correction normalizer in PR #299 / `bbca312`.
   B-11c7a moved the AiO special-seed constants and settings normalizer in PR
   #300 / `17343eb`. B-11c7b moves only runtime RNG generation and special-seed
-  interpretation in PR #301; reservation and increment/decrement behavior
-  remain separate.
+  interpretation in PR #301 / `6863735`. B-11c8 moves only the two hidden-widget
+  default JSON serializers in PR #302; mutable defaults and normalization stay
+  separate.
 
 ### Current quality baseline
 
@@ -307,7 +308,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b runtime-seed PR #301 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 widget serializers PR #302 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -842,6 +843,12 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     `_normalize_aio_seed`, mutable `AIO_SPECIAL_SEEDS`, and nested random-helper
     replacement. RNG range/state/call order and backend seed reservation remain
     unchanged.
+  - B-11c8 moves only `_aio_input_settings_json` and
+    `_aio_generation_settings_json` to `easyuse_anima.nodes.aio_nodes`. PR #302
+    retains direct root alias identity, the existing AiO node runtime resolver,
+    call-time root `json` and mutable default-dict replacement, compact Unicode
+    JSON options, insertion order, and hidden widget/workflow shape. Default
+    settings ownership and normalization remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `17343eb4fed55d05c349b145119539501f92ad47`
+  `68637353f55758d398c27f89be0ee7c1b52f7389`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c7a are integrated through PR #300. B-11c is
+- Current state: B-11a through B-11c7b are integrated through PR #301. B-11c is
   split into residual-owner and binder Moves before the final root shim;
-  B-11c7b AiO runtime-seed ownership is tracked by PR #301.
+  B-11c8 AiO widget-default serializer ownership is tracked by PR #302.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,8 +75,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 273 after
-  B-11c7b (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 275 after
+  B-11c8 (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -84,8 +84,8 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 33 functions, 0 classes, and 28 assigned
-  globals after B-11c7b (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 31 functions, 0 classes, and 28 assigned
+  globals after B-11c8 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 256, including
   literal lookups and binder-owned helper-name/default collections;
@@ -267,6 +267,20 @@ convenience-node compatibility; it remains unmapped and is not public support.
   special seed and the existing non-special `[0, MAX_SEED]` clamp. It does not
   add increment/decrement, previous-seed, queue reservation, cache, or browser
   behavior.
+
+### B-11c8 AiO hidden-widget JSON serializer aliases
+
+- Canonical owner: `easyuse_anima.nodes.aio_nodes` for
+  `_aio_input_settings_json` and `_aio_generation_settings_json`.
+- The private root names remain transitional direct aliases in both relative
+  package and flat import modes. The existing AiO node runtime resolver keeps
+  calling those root names from the two hidden multiline widget defaults.
+- The moved functions resolve root `json`, `AIO_INPUT_DEFAULT_SETTINGS`, and
+  `AIO_GENERATION_DEFAULT_SETTINGS` at call time. Root binding replacement and
+  in-place default-dict mutation remain visible without a new binder.
+- PR #302 preserves `ensure_ascii=False`, compact `(",", ":")` separators,
+  insertion order, and no indent/newline. It does not clone, normalize, mutate,
+  or move defaults, schemas, widget metadata, or workflow serialization.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/nodes/aio_nodes.py
+++ b/easyuse_anima/nodes/aio_nodes.py
@@ -25,6 +25,24 @@ def _runtime_helper(name: str) -> Any:
     return resolver(name)
 
 
+def _aio_input_settings_json() -> str:
+    json_module = _runtime_helper("json")
+    return json_module.dumps(
+        _runtime_helper("AIO_INPUT_DEFAULT_SETTINGS"),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _aio_generation_settings_json() -> str:
+    json_module = _runtime_helper("json")
+    return json_module.dumps(
+        _runtime_helper("AIO_GENERATION_DEFAULT_SETTINGS"),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
 class EasyUseAnimaInput:
     """Bundle prompt data and resource loader settings for the AiO generator."""
 

--- a/nodes.py
+++ b/nodes.py
@@ -342,6 +342,8 @@ try:
     from .easyuse_anima.nodes.aio_nodes import (
         EasyUseAnimaAIOGenerator as EasyUseAnimaAIOGenerator,
         EasyUseAnimaInput as EasyUseAnimaInput,
+        _aio_generation_settings_json as _aio_generation_settings_json,
+        _aio_input_settings_json as _aio_input_settings_json,
         _bind_aio_node_runtime as _bind_aio_node_runtime,
         _easy_use_anima_input_signature as _easy_use_anima_input_signature,
         _require_easy_use_anima_input as _require_easy_use_anima_input,
@@ -872,6 +874,8 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.nodes.aio_nodes import (
         EasyUseAnimaAIOGenerator as EasyUseAnimaAIOGenerator,
         EasyUseAnimaInput as EasyUseAnimaInput,
+        _aio_generation_settings_json as _aio_generation_settings_json,
+        _aio_input_settings_json as _aio_input_settings_json,
         _bind_aio_node_runtime as _bind_aio_node_runtime,
         _easy_use_anima_input_signature as _easy_use_anima_input_signature,
         _require_easy_use_anima_input as _require_easy_use_anima_input,
@@ -1632,14 +1636,6 @@ def _aio_detailer_target_order(detailer_settings: dict[str, Any]) -> list[str]:
     return output
 
 
-
-
-def _aio_input_settings_json() -> str:
-    return json.dumps(AIO_INPUT_DEFAULT_SETTINGS, ensure_ascii=False, separators=(",", ":"))
-
-
-def _aio_generation_settings_json() -> str:
-    return json.dumps(AIO_GENERATION_DEFAULT_SETTINGS, ensure_ascii=False, separators=(",", ":"))
 
 
 def _comfy_max_resolution() -> int:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -20208,6 +20208,68 @@
         "target": "easyuse_anima/nodes/aio_nodes.py"
       },
       {
+        "alias": "_aio_generation_settings_json",
+        "bound_name": "_aio_generation_settings_json",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_aio_generation_settings_json",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
+        "kind": "static_from",
+        "line": 342,
+        "name": "_aio_generation_settings_json",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "alias": "_aio_input_settings_json",
+        "bound_name": "_aio_input_settings_json",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_aio_input_settings_json",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
+        "kind": "static_from",
+        "line": 342,
+        "name": "_aio_input_settings_json",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
         "alias": "_bind_aio_node_runtime",
         "bound_name": "_bind_aio_node_runtime",
         "branch_context": [
@@ -20322,7 +20384,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 349,
+        "line": 351,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20353,7 +20415,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 349,
+        "line": 351,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20384,7 +20446,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 349,
+        "line": 351,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20415,7 +20477,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 360,
+        "line": 362,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20446,7 +20508,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 360,
+        "line": 362,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20477,7 +20539,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 360,
+        "line": 362,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20508,7 +20570,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 360,
+        "line": 362,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20539,7 +20601,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 373,
+        "line": 375,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20570,7 +20632,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 373,
+        "line": 375,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20601,7 +20663,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 381,
+        "line": 383,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20632,7 +20694,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 381,
+        "line": 383,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20663,7 +20725,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 381,
+        "line": 383,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20694,7 +20756,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 381,
+        "line": 383,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20725,7 +20787,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 381,
+        "line": 383,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20756,7 +20818,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 381,
+        "line": 383,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20787,7 +20849,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 381,
+        "line": 383,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20818,7 +20880,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 381,
+        "line": 383,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20849,7 +20911,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 392,
+        "line": 394,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20880,7 +20942,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 392,
+        "line": 394,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20911,7 +20973,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 392,
+        "line": 394,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20942,7 +21004,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 392,
+        "line": 394,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20973,7 +21035,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 398,
+        "line": 400,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21004,7 +21066,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 398,
+        "line": 400,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21035,7 +21097,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 398,
+        "line": 400,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21066,7 +21128,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 398,
+        "line": 400,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21097,7 +21159,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 398,
+        "line": 400,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21128,7 +21190,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 406,
+        "line": 408,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21159,7 +21221,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 406,
+        "line": 408,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21190,7 +21252,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 410,
+        "line": 412,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21221,7 +21283,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 414,
+        "line": 416,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21252,7 +21314,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 414,
+        "line": 416,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21283,7 +21345,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 414,
+        "line": 416,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21314,7 +21376,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 419,
+        "line": 421,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21345,7 +21407,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 419,
+        "line": 421,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21376,7 +21438,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 419,
+        "line": 421,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21407,7 +21469,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 419,
+        "line": 421,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21438,7 +21500,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 419,
+        "line": 421,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21469,7 +21531,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 426,
+        "line": 428,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21500,7 +21562,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 426,
+        "line": 428,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21531,7 +21593,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 426,
+        "line": 428,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21562,7 +21624,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 431,
+        "line": 433,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21593,7 +21655,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 431,
+        "line": 433,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21624,7 +21686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 431,
+        "line": 433,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21655,7 +21717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 449,
+        "line": 451,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21686,7 +21748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 449,
+        "line": 451,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21717,7 +21779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 449,
+        "line": 451,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21748,7 +21810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 449,
+        "line": 451,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21779,7 +21841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 449,
+        "line": 451,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21810,7 +21872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 472,
+        "line": 474,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21841,7 +21903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 472,
+        "line": 474,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21872,7 +21934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 476,
+        "line": 478,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21903,7 +21965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 476,
+        "line": 478,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21934,7 +21996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21965,7 +22027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -21996,7 +22058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22027,7 +22089,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22058,7 +22120,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22089,7 +22151,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22120,7 +22182,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22151,7 +22213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22182,7 +22244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22213,7 +22275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22244,7 +22306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22275,7 +22337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22306,7 +22368,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22337,7 +22399,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22368,7 +22430,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 481,
+        "line": 483,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22399,7 +22461,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 498,
+        "line": 500,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22430,7 +22492,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 498,
+        "line": 500,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22461,7 +22523,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 498,
+        "line": 500,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22492,7 +22554,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 498,
+        "line": 500,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22523,7 +22585,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 498,
+        "line": 500,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22554,7 +22616,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 498,
+        "line": 500,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22585,7 +22647,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 498,
+        "line": 500,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22616,7 +22678,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 498,
+        "line": 500,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22647,7 +22709,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 508,
+        "line": 510,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22678,7 +22740,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 508,
+        "line": 510,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22709,7 +22771,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 512,
+        "line": 514,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22740,7 +22802,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 512,
+        "line": 514,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22771,7 +22833,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 513,
+        "line": 515,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -22802,7 +22864,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 514,
+        "line": 516,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -22833,7 +22895,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 514,
+        "line": 516,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -22864,7 +22926,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 514,
+        "line": 516,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -22895,7 +22957,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 519,
+        "line": 521,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22926,7 +22988,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 519,
+        "line": 521,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22957,7 +23019,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -22988,7 +23050,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23019,7 +23081,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23050,7 +23112,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23081,7 +23143,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23112,7 +23174,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23143,7 +23205,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23174,7 +23236,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23205,7 +23267,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23236,7 +23298,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23267,7 +23329,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23298,7 +23360,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23329,7 +23391,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23360,7 +23422,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23391,7 +23453,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23422,7 +23484,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23453,7 +23515,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23484,7 +23546,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23515,7 +23577,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23534,7 +23596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23549,7 +23611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23568,7 +23630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23583,7 +23645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23602,7 +23664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23617,7 +23679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23636,7 +23698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23651,7 +23713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23670,7 +23732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23685,7 +23747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23704,7 +23766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23719,7 +23781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23738,7 +23800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23753,7 +23815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23772,7 +23834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23787,7 +23849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23806,7 +23868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23821,7 +23883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23840,7 +23902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23855,7 +23917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23874,7 +23936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23889,7 +23951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23908,7 +23970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23923,7 +23985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23942,7 +24004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23957,7 +24019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23976,7 +24038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -23991,7 +24053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24010,7 +24072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24025,7 +24087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24044,7 +24106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24059,7 +24121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24078,7 +24140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24093,7 +24155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24112,7 +24174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24127,7 +24189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24146,7 +24208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24161,7 +24223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24180,7 +24242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24195,7 +24257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24214,7 +24276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24229,7 +24291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 569,
+        "line": 571,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -24248,7 +24310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24263,7 +24325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 572,
+        "line": 574,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24282,7 +24344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24297,7 +24359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 572,
+        "line": 574,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24316,7 +24378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24331,7 +24393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 572,
+        "line": 574,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24350,7 +24412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24365,7 +24427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 572,
+        "line": 574,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24384,7 +24446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24399,7 +24461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24418,7 +24480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24433,7 +24495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24452,7 +24514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24467,7 +24529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24486,7 +24548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24501,7 +24563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24520,7 +24582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24535,7 +24597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24554,7 +24616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24569,7 +24631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24588,7 +24650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24603,7 +24665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24622,7 +24684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24637,7 +24699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24656,7 +24718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24671,7 +24733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24690,7 +24752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24705,7 +24767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24724,7 +24786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24739,7 +24801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24758,7 +24820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24773,7 +24835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24792,7 +24854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24807,7 +24869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24826,7 +24888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24841,7 +24903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24860,7 +24922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24875,7 +24937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24894,7 +24956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24909,7 +24971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24928,7 +24990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24943,7 +25005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24962,7 +25024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -24977,7 +25039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24996,7 +25058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25011,7 +25073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25030,7 +25092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25045,7 +25107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25064,7 +25126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25079,7 +25141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25098,7 +25160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25113,7 +25175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25132,7 +25194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25147,7 +25209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25166,7 +25228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25181,7 +25243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25200,7 +25262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25215,7 +25277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25234,7 +25296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25249,7 +25311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25268,7 +25330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25283,7 +25345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25302,7 +25364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25317,7 +25379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25336,7 +25398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25351,7 +25413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25370,7 +25432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25385,7 +25447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25404,7 +25466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25419,7 +25481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25438,7 +25500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25453,7 +25515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25472,7 +25534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25487,7 +25549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25506,7 +25568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25521,7 +25583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25540,7 +25602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25555,7 +25617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25574,7 +25636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25589,7 +25651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25608,7 +25670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25623,7 +25685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25642,7 +25704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25657,7 +25719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25676,7 +25738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25691,7 +25753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25710,7 +25772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25725,7 +25787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25744,7 +25806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25759,7 +25821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25778,7 +25840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25793,7 +25855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25812,7 +25874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25827,7 +25889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25846,7 +25908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25861,7 +25923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25880,7 +25942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25895,7 +25957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25914,7 +25976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25929,7 +25991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25948,7 +26010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25963,7 +26025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25982,7 +26044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -25997,7 +26059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26016,7 +26078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26031,7 +26093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26050,7 +26112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26065,7 +26127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26084,7 +26146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26099,7 +26161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26118,7 +26180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26133,7 +26195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26152,7 +26214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26167,7 +26229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26186,7 +26248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26201,7 +26263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26220,7 +26282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26235,7 +26297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26254,7 +26316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26269,7 +26331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26288,7 +26350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26303,7 +26365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 644,
+        "line": 646,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -26322,7 +26384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26337,7 +26399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 644,
+        "line": 646,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -26356,7 +26418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26371,7 +26433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 644,
+        "line": 646,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -26390,7 +26452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26405,7 +26467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26424,7 +26486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26439,7 +26501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26458,7 +26520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26473,7 +26535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26492,7 +26554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26507,7 +26569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26526,7 +26588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26541,7 +26603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26560,7 +26622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26575,7 +26637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 656,
+        "line": 658,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -26594,7 +26656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26609,7 +26671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26628,7 +26690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26643,7 +26705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26662,7 +26724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26677,7 +26739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26696,7 +26758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26711,7 +26773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26730,7 +26792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26745,7 +26807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26764,7 +26826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26779,7 +26841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26798,7 +26860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26813,7 +26875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26832,7 +26894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26847,7 +26909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26866,7 +26928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26881,7 +26943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26900,7 +26962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26915,7 +26977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26934,7 +26996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26949,7 +27011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26968,7 +27030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -26983,7 +27045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27002,7 +27064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27017,7 +27079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27036,7 +27098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27051,7 +27113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27070,7 +27132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27085,7 +27147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27104,7 +27166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27119,7 +27181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27138,7 +27200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27153,7 +27215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27172,7 +27234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27187,7 +27249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27206,7 +27268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27221,7 +27283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27240,7 +27302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27255,7 +27317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27274,7 +27336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27289,7 +27351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27308,7 +27370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27323,7 +27385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27342,7 +27404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27357,7 +27419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27376,7 +27438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27391,7 +27453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27410,7 +27472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27425,7 +27487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27444,7 +27506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27459,7 +27521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27478,7 +27540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27493,7 +27555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27512,7 +27574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27527,7 +27589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27546,7 +27608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27561,7 +27623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27580,7 +27642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27595,7 +27657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27614,7 +27676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27629,7 +27691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27648,7 +27710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27663,7 +27725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27682,7 +27744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27697,7 +27759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27716,7 +27778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27731,7 +27793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27750,7 +27812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27765,7 +27827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27784,7 +27846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27799,7 +27861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27818,7 +27880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27833,7 +27895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27852,7 +27914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27867,7 +27929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27886,7 +27948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27901,7 +27963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27920,7 +27982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27935,7 +27997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27954,7 +28016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -27969,7 +28031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27988,7 +28050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28003,7 +28065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28022,7 +28084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28037,7 +28099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28056,7 +28118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28071,7 +28133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28090,7 +28152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28105,7 +28167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28124,7 +28186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28139,7 +28201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28158,7 +28220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28173,7 +28235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28192,7 +28254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28207,7 +28269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28226,7 +28288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28241,7 +28303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28260,7 +28322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28275,7 +28337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28294,7 +28356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28309,7 +28371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28328,7 +28390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28343,7 +28405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28362,7 +28424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28377,7 +28439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28396,7 +28458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28411,7 +28473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28430,7 +28492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28445,7 +28507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28464,7 +28526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28479,7 +28541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28498,7 +28560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28513,7 +28575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28532,7 +28594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28547,7 +28609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28566,7 +28628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28581,7 +28643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28600,7 +28662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28615,7 +28677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28634,7 +28696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28649,7 +28711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28668,7 +28730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28683,7 +28745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28702,7 +28764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28717,7 +28779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28736,7 +28798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28751,7 +28813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28770,7 +28832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28785,7 +28847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28804,7 +28866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28819,7 +28881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28838,7 +28900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28853,7 +28915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28872,7 +28934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28887,7 +28949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28906,7 +28968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28921,7 +28983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28940,7 +29002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28955,7 +29017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28974,7 +29036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -28989,7 +29051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29008,7 +29070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29023,7 +29085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29042,7 +29104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29057,7 +29119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29076,7 +29138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29091,7 +29153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29110,7 +29172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29125,7 +29187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29144,7 +29206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29159,7 +29221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29178,7 +29240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29193,7 +29255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29212,7 +29274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29227,7 +29289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29246,7 +29308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29261,7 +29323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29280,7 +29342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29295,7 +29357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29314,7 +29376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29329,7 +29391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29348,7 +29410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29363,7 +29425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29382,7 +29444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29397,7 +29459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29416,7 +29478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29431,7 +29493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29450,7 +29512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29465,7 +29527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29484,7 +29546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29499,7 +29561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29518,7 +29580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29533,7 +29595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29552,7 +29614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29567,7 +29629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29586,7 +29648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29601,7 +29663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29620,7 +29682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29635,7 +29697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29654,7 +29716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29669,7 +29731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29688,7 +29750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29703,7 +29765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 855,
+        "line": 857,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29722,7 +29784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29737,7 +29799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 855,
+        "line": 857,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29756,7 +29818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29771,7 +29833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 855,
+        "line": 857,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29790,7 +29852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29805,7 +29867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 855,
+        "line": 857,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29824,7 +29886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29839,7 +29901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 861,
+        "line": 863,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29858,7 +29920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29873,7 +29935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 861,
+        "line": 863,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29892,7 +29954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29907,7 +29969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 861,
+        "line": 863,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29926,7 +29988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29941,7 +30003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29960,7 +30022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -29975,7 +30037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -29994,7 +30056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30009,7 +30071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -30028,7 +30090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30043,7 +30105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30062,7 +30124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30077,8 +30139,76 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "name": "EasyUseAnimaInput",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "alias": "_aio_generation_settings_json",
+        "bound_name": "_aio_generation_settings_json",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 543,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_aio_generation_settings_json",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
+        "kind": "static_from",
+        "line": 874,
+        "name": "_aio_generation_settings_json",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "alias": "_aio_input_settings_json",
+        "bound_name": "_aio_input_settings_json",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 543,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_aio_input_settings_json",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
+        "kind": "static_from",
+        "line": 874,
+        "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
         "role": "compatibility_fallback",
@@ -30096,7 +30226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30111,7 +30241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30130,7 +30260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30145,7 +30275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30164,7 +30294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30179,7 +30309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30198,7 +30328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30213,7 +30343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 879,
+        "line": 883,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -30232,7 +30362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30247,7 +30377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 879,
+        "line": 883,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -30266,7 +30396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30281,7 +30411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 879,
+        "line": 883,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -30300,7 +30430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30315,7 +30445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 890,
+        "line": 894,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30334,7 +30464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30349,7 +30479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 890,
+        "line": 894,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30368,7 +30498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30383,7 +30513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 890,
+        "line": 894,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30402,7 +30532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30417,7 +30547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 890,
+        "line": 894,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30436,7 +30566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30451,7 +30581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 903,
+        "line": 907,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -30470,7 +30600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30485,7 +30615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 903,
+        "line": 907,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -30504,7 +30634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30519,7 +30649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30538,7 +30668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30553,7 +30683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30572,7 +30702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30587,7 +30717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30606,7 +30736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30621,7 +30751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30640,7 +30770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30655,7 +30785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30674,7 +30804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30689,7 +30819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30708,7 +30838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30723,7 +30853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30742,7 +30872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30757,7 +30887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30776,7 +30906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30791,7 +30921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 922,
+        "line": 926,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30810,7 +30940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30825,7 +30955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 922,
+        "line": 926,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30844,7 +30974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30859,7 +30989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 922,
+        "line": 926,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30878,7 +31008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30893,7 +31023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 922,
+        "line": 926,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30912,7 +31042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30927,7 +31057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30946,7 +31076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30961,7 +31091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -30980,7 +31110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -30995,7 +31125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31014,7 +31144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31029,7 +31159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31048,7 +31178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31063,7 +31193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31082,7 +31212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31097,7 +31227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 936,
+        "line": 940,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -31116,7 +31246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31131,7 +31261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 936,
+        "line": 940,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -31150,7 +31280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31165,7 +31295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 940,
+        "line": 944,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -31184,7 +31314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31199,7 +31329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 944,
+        "line": 948,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -31218,7 +31348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31233,7 +31363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 944,
+        "line": 948,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -31252,7 +31382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31267,7 +31397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 944,
+        "line": 948,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -31286,7 +31416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31301,7 +31431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 949,
+        "line": 953,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31320,7 +31450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31335,7 +31465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 949,
+        "line": 953,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31354,7 +31484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31369,7 +31499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 949,
+        "line": 953,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31388,7 +31518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31403,7 +31533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 949,
+        "line": 953,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31422,7 +31552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31437,7 +31567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 949,
+        "line": 953,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31456,7 +31586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31471,7 +31601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 956,
+        "line": 960,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31490,7 +31620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31505,7 +31635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 956,
+        "line": 960,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31524,7 +31654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31539,7 +31669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 956,
+        "line": 960,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31558,7 +31688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31573,7 +31703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 961,
+        "line": 965,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31592,7 +31722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31607,7 +31737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 961,
+        "line": 965,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31626,7 +31756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31641,7 +31771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 961,
+        "line": 965,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31660,7 +31790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31675,7 +31805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 979,
+        "line": 983,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31694,7 +31824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31709,7 +31839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 979,
+        "line": 983,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31728,7 +31858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31743,7 +31873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 979,
+        "line": 983,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31762,7 +31892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31777,7 +31907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 979,
+        "line": 983,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31796,7 +31926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31811,7 +31941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 979,
+        "line": 983,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31830,7 +31960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31845,7 +31975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1006,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31864,7 +31994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31879,7 +32009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1006,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31898,7 +32028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31913,7 +32043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31932,7 +32062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31947,7 +32077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -31966,7 +32096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -31981,7 +32111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32000,7 +32130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32015,7 +32145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32034,7 +32164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32049,7 +32179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32068,7 +32198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32083,7 +32213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32102,7 +32232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32117,7 +32247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32136,7 +32266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32151,7 +32281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32170,7 +32300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32185,7 +32315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32204,7 +32334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32219,7 +32349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32238,7 +32368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32253,7 +32383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32272,7 +32402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32287,7 +32417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32306,7 +32436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32321,7 +32451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32340,7 +32470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32355,7 +32485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32374,7 +32504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32389,7 +32519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32408,7 +32538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32423,7 +32553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32442,7 +32572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32457,7 +32587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32476,7 +32606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32491,7 +32621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32510,7 +32640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32525,7 +32655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32544,7 +32674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32559,7 +32689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32578,7 +32708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32593,7 +32723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32612,7 +32742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32627,7 +32757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32646,7 +32776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32661,7 +32791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32680,7 +32810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32695,7 +32825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32714,7 +32844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32729,7 +32859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32748,7 +32878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32763,7 +32893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32782,7 +32912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32797,7 +32927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32816,7 +32946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32831,7 +32961,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1042,
+        "line": 1046,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -32850,7 +32980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32865,7 +32995,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1042,
+        "line": 1046,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -32884,7 +33014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32899,7 +33029,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1047,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -32918,7 +33048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32933,7 +33063,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1048,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -32952,7 +33082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -32967,7 +33097,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1048,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -32986,7 +33116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33001,7 +33131,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1048,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -33020,7 +33150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33035,7 +33165,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1049,
+        "line": 1053,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -33054,7 +33184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33069,7 +33199,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1049,
+        "line": 1053,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -33088,7 +33218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33103,7 +33233,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33122,7 +33252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33137,7 +33267,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33156,7 +33286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33171,7 +33301,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33190,7 +33320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33205,7 +33335,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33224,7 +33354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33239,7 +33369,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33258,7 +33388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33273,7 +33403,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33292,7 +33422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33307,7 +33437,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33326,7 +33456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33341,7 +33471,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33360,7 +33490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33375,7 +33505,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33394,7 +33524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33409,7 +33539,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33428,7 +33558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33443,7 +33573,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33462,7 +33592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33477,7 +33607,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33496,7 +33626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33511,7 +33641,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33530,7 +33660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33545,7 +33675,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33564,7 +33694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33579,7 +33709,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33598,7 +33728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33613,7 +33743,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33632,7 +33762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33647,7 +33777,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33666,7 +33796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33681,7 +33811,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33700,7 +33830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -33715,7 +33845,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33733,7 +33863,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1646
+            "line": 1642
           }
         ],
         "classification": "external",
@@ -33741,7 +33871,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1647,
+        "line": 1643,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33758,7 +33888,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1683
+            "line": 1679
           }
         ],
         "classification": "external",
@@ -33766,7 +33896,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1684,
+        "line": 1680,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33783,7 +33913,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1691
+            "line": 1687
           }
         ],
         "classification": "external",
@@ -33791,7 +33921,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1692,
+        "line": 1688,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -37079,13 +37209,13 @@
       },
       {
         "is_package": false,
-        "loc": 297,
+        "loc": 315,
         "module": "easyuse_anima.nodes.aio_nodes",
-        "normalized_git_blob_sha1": "0f3d1f7d20e88e4686ac9703423aae91e7010d37",
+        "normalized_git_blob_sha1": "ea047ddf85fe628031b20e4c5398b55c9c80706a",
         "path": "easyuse_anima/nodes/aio_nodes.py",
         "top_level": {
           "class_count": 2,
-          "function_count": 4,
+          "function_count": 6,
           "global_count": 3
         }
       },
@@ -37379,13 +37509,13 @@
       },
       {
         "is_package": false,
-        "loc": 2528,
+        "loc": 2524,
         "module": "nodes",
-        "normalized_git_blob_sha1": "57af5ee6c0b8e183818f3c0eda3f80721eee2f5a",
+        "normalized_git_blob_sha1": "854c9a489b82d613448a3de64f57f66f914d60e9",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 33,
+          "function_count": 31,
           "global_count": 28
         }
       },
@@ -38745,7 +38875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -38754,7 +38884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38768,7 +38898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -38777,7 +38907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38791,7 +38921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -38800,7 +38930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38814,7 +38944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -38823,7 +38953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38837,7 +38967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -38846,7 +38976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38860,7 +38990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -38869,7 +38999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38883,7 +39013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -38892,7 +39022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38906,7 +39036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -38915,7 +39045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 542,
+        "line": 544,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38929,7 +39059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -38938,7 +39068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38952,7 +39082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -38961,7 +39091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38975,7 +39105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -38984,7 +39114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38998,7 +39128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39007,7 +39137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39021,7 +39151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39030,7 +39160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39044,7 +39174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39053,7 +39183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39067,7 +39197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39076,7 +39206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39090,7 +39220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39099,7 +39229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39113,7 +39243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39122,7 +39252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39136,7 +39266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39145,7 +39275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39159,7 +39289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39168,7 +39298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39182,7 +39312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39191,7 +39321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39205,7 +39335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39214,7 +39344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 569,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39228,7 +39358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39237,7 +39367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 572,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39251,7 +39381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39260,7 +39390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 572,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39274,7 +39404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39283,7 +39413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 572,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39297,7 +39427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39306,7 +39436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 572,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39320,7 +39450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39329,7 +39459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39343,7 +39473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39352,7 +39482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39366,7 +39496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39375,7 +39505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39389,7 +39519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39398,7 +39528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39412,7 +39542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39421,7 +39551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39435,7 +39565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39444,7 +39574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39458,7 +39588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39467,7 +39597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39481,7 +39611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39490,7 +39620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39504,7 +39634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39513,7 +39643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39527,7 +39657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39536,7 +39666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39550,7 +39680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39559,7 +39689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39573,7 +39703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39582,7 +39712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39596,7 +39726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39605,7 +39735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 578,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39619,7 +39749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39628,7 +39758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39642,7 +39772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39651,7 +39781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39665,7 +39795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39674,7 +39804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39688,7 +39818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39697,7 +39827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39711,7 +39841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39720,7 +39850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39734,7 +39864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39743,7 +39873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39757,7 +39887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39766,7 +39896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39780,7 +39910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39789,7 +39919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39803,7 +39933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39812,7 +39942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39826,7 +39956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39835,7 +39965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39849,7 +39979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39858,7 +39988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39872,7 +40002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39881,7 +40011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 593,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39895,7 +40025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39904,7 +40034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39918,7 +40048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39927,7 +40057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39941,7 +40071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39950,7 +40080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39964,7 +40094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39973,7 +40103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39987,7 +40117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -39996,7 +40126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40010,7 +40140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40019,7 +40149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40033,7 +40163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40042,7 +40172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40056,7 +40186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40065,7 +40195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40079,7 +40209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40088,7 +40218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40102,7 +40232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40111,7 +40241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40125,7 +40255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40134,7 +40264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40148,7 +40278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40157,7 +40287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40171,7 +40301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40180,7 +40310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40194,7 +40324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40203,7 +40333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40217,7 +40347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40226,7 +40356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40240,7 +40370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40249,7 +40379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40263,7 +40393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40272,7 +40402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40286,7 +40416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40295,7 +40425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40309,7 +40439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40318,7 +40448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40332,7 +40462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40341,7 +40471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 619,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40355,7 +40485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40364,7 +40494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40378,7 +40508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40387,7 +40517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40401,7 +40531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40410,7 +40540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40424,7 +40554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40433,7 +40563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40447,7 +40577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40456,7 +40586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40470,7 +40600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40479,7 +40609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40493,7 +40623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40502,7 +40632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40516,7 +40646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40525,7 +40655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40539,7 +40669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40548,7 +40678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40562,7 +40692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40571,7 +40701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40585,7 +40715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40594,7 +40724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40608,7 +40738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40617,7 +40747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 644,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40631,7 +40761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40640,7 +40770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 644,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40654,7 +40784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40663,7 +40793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 644,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40677,7 +40807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40686,7 +40816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40700,7 +40830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40709,7 +40839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40723,7 +40853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40732,7 +40862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40746,7 +40876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40755,7 +40885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40769,7 +40899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40778,7 +40908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40792,7 +40922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40801,7 +40931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 656,
+        "line": 658,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40815,7 +40945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40824,7 +40954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40838,7 +40968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40847,7 +40977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40861,7 +40991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40870,7 +41000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40884,7 +41014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40893,7 +41023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40907,7 +41037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40916,7 +41046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40930,7 +41060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40939,7 +41069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40953,7 +41083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40962,7 +41092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40976,7 +41106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -40985,7 +41115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40999,7 +41129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41008,7 +41138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41022,7 +41152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41031,7 +41161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41045,7 +41175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41054,7 +41184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41068,7 +41198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41077,7 +41207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41091,7 +41221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41100,7 +41230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41114,7 +41244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41123,7 +41253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41137,7 +41267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41146,7 +41276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41160,7 +41290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41169,7 +41299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41183,7 +41313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41192,7 +41322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41206,7 +41336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41215,7 +41345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41229,7 +41359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41238,7 +41368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41252,7 +41382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41261,7 +41391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41275,7 +41405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41284,7 +41414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41298,7 +41428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41307,7 +41437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41321,7 +41451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41330,7 +41460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41344,7 +41474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41353,7 +41483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41367,7 +41497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41376,7 +41506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41390,7 +41520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41399,7 +41529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41413,7 +41543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41422,7 +41552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41436,7 +41566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41445,7 +41575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41459,7 +41589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41468,7 +41598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41482,7 +41612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41491,7 +41621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41505,7 +41635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41514,7 +41644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41528,7 +41658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41537,7 +41667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41551,7 +41681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41560,7 +41690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41574,7 +41704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41583,7 +41713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41597,7 +41727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41606,7 +41736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41620,7 +41750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41629,7 +41759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41643,7 +41773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41652,7 +41782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41666,7 +41796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41675,7 +41805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41689,7 +41819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41698,7 +41828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41712,7 +41842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41721,7 +41851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41735,7 +41865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41744,7 +41874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41758,7 +41888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41767,7 +41897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41781,7 +41911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41790,7 +41920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41804,7 +41934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41813,7 +41943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41827,7 +41957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41836,7 +41966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41850,7 +41980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41859,7 +41989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41873,7 +42003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41882,7 +42012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41896,7 +42026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41905,7 +42035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41919,7 +42049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41928,7 +42058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41942,7 +42072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41951,7 +42081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41965,7 +42095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41974,7 +42104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41988,7 +42118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -41997,7 +42127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42011,7 +42141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42020,7 +42150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42034,7 +42164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42043,7 +42173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42057,7 +42187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42066,7 +42196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42080,7 +42210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42089,7 +42219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42103,7 +42233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42112,7 +42242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 731,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42126,7 +42256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42135,7 +42265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42149,7 +42279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42158,7 +42288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42172,7 +42302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42181,7 +42311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42195,7 +42325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42204,7 +42334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42218,7 +42348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42227,7 +42357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42241,7 +42371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42250,7 +42380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42264,7 +42394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42273,7 +42403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42287,7 +42417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42296,7 +42426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42310,7 +42440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42319,7 +42449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 759,
+        "line": 761,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42333,7 +42463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42342,7 +42472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42356,7 +42486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42365,7 +42495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42379,7 +42509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42388,7 +42518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42402,7 +42532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42411,7 +42541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42425,7 +42555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42434,7 +42564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42448,7 +42578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42457,7 +42587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42471,7 +42601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42480,7 +42610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42494,7 +42624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42503,7 +42633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42517,7 +42647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42526,7 +42656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42540,7 +42670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42549,7 +42679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42563,7 +42693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42572,7 +42702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42586,7 +42716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42595,7 +42725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42609,7 +42739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42618,7 +42748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42632,7 +42762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42641,7 +42771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42655,7 +42785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42664,7 +42794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42678,7 +42808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42687,7 +42817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42701,7 +42831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42710,7 +42840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42724,7 +42854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42733,7 +42863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42747,7 +42877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42756,7 +42886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42770,7 +42900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42779,7 +42909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42793,7 +42923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42802,7 +42932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42816,7 +42946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42825,7 +42955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42839,7 +42969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42848,7 +42978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42862,7 +42992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42871,7 +43001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42885,7 +43015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42894,7 +43024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 775,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42908,7 +43038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42917,7 +43047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 855,
+        "line": 857,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42931,7 +43061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42940,7 +43070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 855,
+        "line": 857,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42954,7 +43084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42963,7 +43093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 855,
+        "line": 857,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42977,7 +43107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -42986,7 +43116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 855,
+        "line": 857,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43000,7 +43130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43009,7 +43139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 861,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43023,7 +43153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43032,7 +43162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 861,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43046,7 +43176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43055,7 +43185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 861,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43069,7 +43199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43078,7 +43208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43092,7 +43222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43101,7 +43231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43115,7 +43245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43124,7 +43254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 866,
+        "line": 868,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43138,7 +43268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43147,7 +43277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43161,7 +43291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43170,7 +43300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43184,7 +43314,53 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
+        "kind": "static_from",
+        "line": 874,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 543,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
+        "kind": "static_from",
+        "line": 874,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43193,7 +43369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43207,7 +43383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43216,7 +43392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43230,7 +43406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43239,7 +43415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 872,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43253,7 +43429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43262,7 +43438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 879,
+        "line": 883,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43276,7 +43452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43285,7 +43461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 879,
+        "line": 883,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43299,7 +43475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43308,7 +43484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 879,
+        "line": 883,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43322,7 +43498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43331,7 +43507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 890,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43345,7 +43521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43354,7 +43530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 890,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43368,7 +43544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43377,7 +43553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 890,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43391,7 +43567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43400,7 +43576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 890,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43414,7 +43590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43423,7 +43599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 903,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43437,7 +43613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43446,7 +43622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 903,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43460,7 +43636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43469,7 +43645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43483,7 +43659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43492,7 +43668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43506,7 +43682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43515,7 +43691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43529,7 +43705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43538,7 +43714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43552,7 +43728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43561,7 +43737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43575,7 +43751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43584,7 +43760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43598,7 +43774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43607,7 +43783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43621,7 +43797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43630,7 +43806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 911,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43644,7 +43820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43653,7 +43829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 922,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43667,7 +43843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43676,7 +43852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 922,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43690,7 +43866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43699,7 +43875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 922,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43713,7 +43889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43722,7 +43898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 922,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43736,7 +43912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43745,7 +43921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43759,7 +43935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43768,7 +43944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43782,7 +43958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43791,7 +43967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43805,7 +43981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43814,7 +43990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43828,7 +44004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43837,7 +44013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43851,7 +44027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43860,7 +44036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 936,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43874,7 +44050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43883,7 +44059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 936,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43897,7 +44073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43906,7 +44082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 940,
+        "line": 944,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43920,7 +44096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43929,7 +44105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 944,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43943,7 +44119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43952,7 +44128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 944,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43966,7 +44142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43975,7 +44151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 944,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43989,7 +44165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -43998,7 +44174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 949,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44012,7 +44188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44021,7 +44197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 949,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44035,7 +44211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44044,7 +44220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 949,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44058,7 +44234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44067,7 +44243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 949,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44081,7 +44257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44090,7 +44266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 949,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44104,7 +44280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44113,7 +44289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 956,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44127,7 +44303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44136,7 +44312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 956,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44150,7 +44326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44159,7 +44335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 956,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44173,7 +44349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44182,7 +44358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 961,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44196,7 +44372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44205,7 +44381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 961,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44219,7 +44395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44228,7 +44404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 961,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44242,7 +44418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44251,7 +44427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 979,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44265,7 +44441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44274,7 +44450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 979,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44288,7 +44464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44297,7 +44473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 979,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44311,7 +44487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44320,7 +44496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 979,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44334,7 +44510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44343,7 +44519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 979,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44357,7 +44533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44366,7 +44542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44380,7 +44556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44389,7 +44565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44403,7 +44579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44412,7 +44588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44426,7 +44602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44435,7 +44611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44449,7 +44625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44458,7 +44634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44472,7 +44648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44481,7 +44657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44495,7 +44671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44504,7 +44680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44518,7 +44694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44527,7 +44703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44541,7 +44717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44550,7 +44726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44564,7 +44740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44573,7 +44749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44587,7 +44763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44596,7 +44772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44610,7 +44786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44619,7 +44795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44633,7 +44809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44642,7 +44818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44656,7 +44832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44665,7 +44841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44679,7 +44855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44688,7 +44864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44702,7 +44878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44711,7 +44887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44725,7 +44901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44734,7 +44910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44748,7 +44924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44757,7 +44933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44771,7 +44947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44780,7 +44956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44794,7 +44970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44803,7 +44979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44817,7 +44993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44826,7 +45002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44840,7 +45016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44849,7 +45025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44863,7 +45039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44872,7 +45048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44886,7 +45062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44895,7 +45071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44909,7 +45085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44918,7 +45094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44932,7 +45108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44941,7 +45117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44955,7 +45131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44964,7 +45140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44978,7 +45154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -44987,7 +45163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45001,7 +45177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45010,7 +45186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45024,7 +45200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45033,7 +45209,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1042,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45047,7 +45223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45056,7 +45232,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1042,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45070,7 +45246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45079,7 +45255,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1047,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45093,7 +45269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45102,7 +45278,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45116,7 +45292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45125,7 +45301,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45139,7 +45315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45148,7 +45324,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45162,7 +45338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45171,7 +45347,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1049,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45185,7 +45361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45194,7 +45370,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1049,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45208,7 +45384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45217,7 +45393,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45231,7 +45407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45240,7 +45416,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45254,7 +45430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45263,7 +45439,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45277,7 +45453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45286,7 +45462,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45300,7 +45476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45309,7 +45485,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45323,7 +45499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45332,7 +45508,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45346,7 +45522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45355,7 +45531,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45369,7 +45545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45378,7 +45554,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45392,7 +45568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45401,7 +45577,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45415,7 +45591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45424,7 +45600,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45438,7 +45614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45447,7 +45623,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45461,7 +45637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45470,7 +45646,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45484,7 +45660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45493,7 +45669,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45507,7 +45683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45516,7 +45692,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45530,7 +45706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45539,7 +45715,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45553,7 +45729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45562,7 +45738,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45576,7 +45752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45585,7 +45761,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45599,7 +45775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45608,7 +45784,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45622,7 +45798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 541,
+            "handler_line": 543,
             "kind": "try",
             "line": 11
           }
@@ -45631,7 +45807,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49370,14 +49546,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1646
+            "line": 1642
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1647,
+        "line": 1643,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49389,14 +49565,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1683
+            "line": 1679
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1684,
+        "line": 1680,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49408,14 +49584,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1691
+            "line": 1687
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1692,
+        "line": 1688,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50790,14 +50966,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1646
+            "line": 1642
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1647,
+        "line": 1643,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50809,14 +50985,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1683
+            "line": 1679
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1684,
+        "line": 1680,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50828,14 +51004,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1691
+            "line": 1687
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1692,
+        "line": 1688,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52283,7 +52459,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1072,
+        "line": 1076,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52292,7 +52468,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1597,
+        "line": 1601,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52301,7 +52477,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2430,
+        "line": 2426,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52310,7 +52486,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2433,
+        "line": 2429,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52319,7 +52495,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2436,
+        "line": 2432,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52328,7 +52504,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2439,
+        "line": 2435,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52337,7 +52513,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2442,
+        "line": 2438,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52346,7 +52522,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2445,
+        "line": 2441,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52355,7 +52531,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2448,
+        "line": 2444,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52364,7 +52540,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2451,
+        "line": 2447,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52373,7 +52549,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2454,
+        "line": 2450,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52382,7 +52558,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2457,
+        "line": 2453,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52391,7 +52567,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2460,
+        "line": 2456,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52400,7 +52576,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2463,
+        "line": 2459,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52409,7 +52585,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2466,
+        "line": 2462,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52418,7 +52594,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2469,
+        "line": 2465,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52427,7 +52603,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2473,
+        "line": 2469,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52436,7 +52612,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2476,
+        "line": 2472,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52445,7 +52621,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2480,
+        "line": 2476,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52454,7 +52630,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2483,
+        "line": 2479,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52463,7 +52639,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2487,
+        "line": 2483,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52472,7 +52648,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2490,
+        "line": 2486,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52481,7 +52657,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2493,
+        "line": 2489,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52490,7 +52666,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2496,
+        "line": 2492,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52499,7 +52675,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2499,
+        "line": 2495,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52508,7 +52684,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2502,
+        "line": 2498,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52517,7 +52693,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2509,
+        "line": 2505,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52526,7 +52702,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2515,
+        "line": 2511,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52535,7 +52711,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2520,
+        "line": 2516,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52544,7 +52720,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2524,
+        "line": 2520,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53052,19 +53228,19 @@
       },
       {
         "kind": "dict",
-        "line": 1134,
+        "line": 1138,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1123,
+        "line": 1127,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1596,
+        "line": 1600,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "17343eb4fed55d05c349b145119539501f92ad47",
+    "base_commit": "68637353f55758d398c27f89be0ee7c1b52f7389",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -37,7 +37,8 @@
       "B-11c5",
       "B-11c6",
       "B-11c7a",
-      "B-11c7b"
+      "B-11c7b",
+      "B-11c8"
     ]
   },
   "enums": {
@@ -72,11 +73,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 273,
+    "nodes_canonical_bindings": 275,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 33,
+    "root_residual_functions": 31,
     "root_residual_classes": 0,
     "root_residual_globals": 28,
     "runtime_binders": 28,
@@ -157,13 +158,17 @@
     ],
     "AIO_GENERATION_DEFAULT_SETTINGS": [
       "easyuse_anima.aio.generation_normalization",
-      "easyuse_anima.aio.output"
+      "easyuse_anima.aio.output",
+      "easyuse_anima.nodes.aio_nodes"
     ],
     "AIO_GENERATION_SETTINGS_SCHEMA": [
       "easyuse_anima.aio.generation_normalization"
     ],
     "AIO_GENERATION_SETTINGS_VERSION": [
       "easyuse_anima.aio.generation_normalization"
+    ],
+    "AIO_INPUT_DEFAULT_SETTINGS": [
+      "easyuse_anima.nodes.aio_nodes"
     ],
     "AIO_PREVIEW_CACHE_FORMAT": [
       "easyuse_anima.aio.preview"
@@ -2756,6 +2761,8 @@
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.aio_nodes:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "_aio_generation_settings_json": "_aio_generation_settings_json",
+        "_aio_input_settings_json": "_aio_input_settings_json",
         "_bind_aio_node_runtime": "_bind_aio_node_runtime",
         "_easy_use_anima_input_signature": "_easy_use_anima_input_signature",
         "_require_easy_use_anima_input": "_require_easy_use_anima_input"
@@ -3982,8 +3989,6 @@
         "_aio_detailer_target_defaults": "_aio_detailer_target_defaults",
         "_aio_detailer_target_order": "_aio_detailer_target_order",
         "_aio_final_fit_size": "_aio_final_fit_size",
-        "_aio_generation_settings_json": "_aio_generation_settings_json",
-        "_aio_input_settings_json": "_aio_input_settings_json",
         "_aio_usdu_auto_tile_dimension": "_aio_usdu_auto_tile_dimension",
         "_aio_usdu_tile_plan": "_aio_usdu_tile_plan",
         "_aio_usdu_tile_size": "_aio_usdu_tile_size",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -37,6 +37,7 @@ from easyuse_anima.lora import preset as lora_preset
 from easyuse_anima.naia import client as naia_client
 from easyuse_anima.naia import resolution as naia_resolution
 from easyuse_anima.nodes import (
+    aio_nodes,
     image_nodes,
     impact_detailer_nodes,
     input_types,
@@ -925,6 +926,74 @@ class AioRuntimeSeedMoveContractTests(unittest.TestCase):
             package_name = package_nodes.__package__
             package_sampling = sys.modules[f"{package_name}.easyuse_anima.aio.sampling"]
             self._assert_contract(package_nodes, package_sampling)
+
+
+class AioWidgetDefaultSerializerMoveContractTests(unittest.TestCase):
+    def _assert_contract(self, root_module, canonical_module):
+        self.assertIs(
+            root_module._aio_input_settings_json,
+            canonical_module._aio_input_settings_json,
+        )
+        self.assertIs(
+            root_module._aio_generation_settings_json,
+            canonical_module._aio_generation_settings_json,
+        )
+
+        input_defaults = {"schema": "입력"}
+        generation_defaults = {"schema": "생성"}
+        dumps_calls = []
+
+        def dumps(value, *, ensure_ascii, separators):
+            dumps_calls.append((value, ensure_ascii, separators))
+            return "input-json" if value is input_defaults else "generation-json"
+
+        with (
+            patch.object(root_module, "json", types.SimpleNamespace(dumps=dumps)),
+            patch.object(root_module, "AIO_INPUT_DEFAULT_SETTINGS", input_defaults),
+            patch.object(
+                root_module,
+                "AIO_GENERATION_DEFAULT_SETTINGS",
+                generation_defaults,
+            ),
+        ):
+            self.assertEqual(canonical_module._aio_input_settings_json(), "input-json")
+            self.assertEqual(
+                canonical_module._aio_generation_settings_json(),
+                "generation-json",
+            )
+
+        self.assertEqual(
+            dumps_calls,
+            [
+                (input_defaults, False, (",", ":")),
+                (generation_defaults, False, (",", ":")),
+            ],
+        )
+
+        mutable_defaults = {"schema": "가"}
+        with patch.object(
+            root_module,
+            "AIO_INPUT_DEFAULT_SETTINGS",
+            mutable_defaults,
+        ):
+            self.assertEqual(
+                canonical_module._aio_input_settings_json(),
+                '{"schema":"가"}',
+            )
+            mutable_defaults["version"] = 1
+            self.assertEqual(
+                canonical_module._aio_input_settings_json(),
+                '{"schema":"가","version":1}',
+            )
+
+    def test_root_aliases_and_call_time_serialization_inputs(self):
+        self._assert_contract(nodes, aio_nodes)
+
+    def test_package_aliases_and_call_time_serialization_inputs(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_aio_nodes = sys.modules[f"{package_name}.easyuse_anima.nodes.aio_nodes"]
+            self._assert_contract(package_nodes, package_aio_nodes)
 
 
 class ComfyAdapterMoveContractTests(unittest.TestCase):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "57af5ee6c0b8e183818f3c0eda3f80721eee2f5a")
-        # Issue #184 B-11c7b moves runtime seed resolution and random generation
-        # while preserving direct aliases and call-time root helper seams.
-        self.assertEqual(report["top_level"]["function_count"], 33)
+        self.assertEqual(report["git_blob_sha1"], "854c9a489b82d613448a3de64f57f66f914d60e9")
+        # Issue #184 B-11c8 moves the two AiO hidden-widget JSON serializers
+        # while preserving direct aliases and call-time root default seams.
+        self.assertEqual(report["top_level"]["function_count"], 31)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_528)
+        self.assertEqual(report["line_count"], 2_524)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "17343eb4fed55d05c349b145119539501f92ad47"
+BASE_COMMIT = "68637353f55758d398c27f89be0ee7c1b52f7389"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1311,6 +1311,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c6",
                 "B-11c7a",
                 "B-11c7b",
+                "B-11c8",
             ],
         },
         "enums": {
@@ -1323,11 +1324,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 273,
+            "nodes_canonical_bindings": 275,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 33,
+            "root_residual_functions": 31,
             "root_residual_classes": 0,
             "root_residual_globals": 28,
             "runtime_binders": 28,


### PR DESCRIPTION
## 변경 요약

- B-11c8에서 `_aio_input_settings_json`과 `_aio_generation_settings_json`의 소유권만 `easyuse_anima.nodes.aio_nodes`로 이동합니다.
- root `nodes.py`의 relative/flat import는 canonical 함수의 direct alias identity를 유지합니다.
- mutable defaults, schema/version, normalizer, widget/workflow 구조는 변경하지 않습니다.

## 작업 전 인벤토리

### Symbol

- root `_aio_input_settings_json()`: 현재 root `AIO_INPUT_DEFAULT_SETTINGS`를 `ensure_ascii=False`, `separators=(",", ":")`로 compact JSON 직렬화합니다.
- root `_aio_generation_settings_json()`: 현재 root `AIO_GENERATION_DEFAULT_SETTINGS`를 같은 옵션으로 compact JSON 직렬화합니다.

### Caller

- `_aio_input_settings_json`: `easyuse_anima.nodes.aio_nodes.EasyUseAnimaInput.INPUT_TYPES`의 hidden multiline widget default 한 곳.
- `_aio_generation_settings_json`: `easyuse_anima.nodes.aio_nodes.EasyUseAnimaAIOGenerator.INPUT_TYPES`의 hidden multiline widget default 한 곳.
- 두 caller 모두 기존 `_runtime_helper("_aio_*_settings_json")()` 경로를 사용합니다.

### Alias / compatibility

- 작업 전 두 함수는 root definition이며 canonical alias가 없습니다.
- 작업 후 relative/flat root import가 동일한 canonical 함수 객체를 직접 가리켜야 합니다.
- canonical 함수는 기존 AiO node runtime resolver로 root `json`과 각 mutable default dict를 호출 시점에 조회합니다.

### Global state

- `AIO_INPUT_DEFAULT_SETTINGS`와 `AIO_GENERATION_DEFAULT_SETTINGS`의 root binding 교체 및 제자리 mutation이 매 호출에 반영됩니다.
- 함수는 상태를 변경하거나 clone/normalize하지 않습니다.
- 새 global, cache, binder, import side effect를 만들지 않습니다.

## Allowed-file boundary

- `easyuse_anima/nodes/aio_nodes.py`
- `nodes.py`
- `tests/test_node_contracts.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 금지 경계

- `ensure_ascii=False`, compact separators, dict insertion order, 줄바꿈/indent 부재를 변경하지 않습니다.
- default dict clone/normalize/deep-copy/mutation을 추가하지 않습니다.
- schema/version/default 값, widget hidden/multiline/tooltip, workflow serialization을 변경하지 않습니다.
- caller를 direct local call로 바꾸거나 default globals를 이동하지 않습니다.
- input/generation settings normalizer와 runtime Behavior를 변경하지 않습니다.

## 검증 결과

- focused unittest: 46개 통과
  - 새 Move contract
  - 기존 AiO widget/default JSON contract
  - compatibility/analyzer/import boundary
- `git diff --check`: 통과 (줄 끝 변환 안내만 출력)
- exact-head full (`836f52afc6c083a8812e3974c98c1ffe719b8948`): 통과
  - Python unittest: 900개 통과
  - frontend: JavaScript 114개 및 TypeScript 6.0.3 통과
  - Pyright baseline ratchet: 통과
  - Python import boundary gate: 통과
  - Ruff: 107건 report-only, G-01 비차단 부채
- 독립 read-only 코드 리뷰: 지적 사항 없음

## 테스트 표면

- ComfyUI Codex test infrastructure: repository-owned static/unit/full validation
- Live ComfyUI smoke: 미실행 (Move-only이며 Phase B exit checkpoint에서 수행)

## 남은 위험 / 미확인

- input/generation default settings의 canonical owner는 별도 Contract/Move로 남습니다.
- 생성 baseline은 변경 entry와 invariant count 중심으로 검토했으며 전체 줄을 수동 대조하지는 않았습니다.
- GitHub Actions check는 별도로 확인합니다.

Closes no issue; tracks #184.
