### PR TITLE
refactor: move AiO input settings normalizer

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `68637353f55758d398c27f89be0ee7c1b52f7389`
+- Integrated `dev` snapshot commit: `40e8d940483e265d5a46b2bce1bd8fea83672550`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c7b; B-11c8 widget-default serializer Move in PR #302 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c8 / `40e8d94`; B-11c9 input-settings normalizer Move in PR #303 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,528
-  lines after B-11c7b.
-- The mechanical extraction has removed 10,135
-  lines, approximately 80.0% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,524
+  lines after B-11c8.
+- The mechanical extraction has removed 10,139
+  lines, approximately 80.1% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -63,10 +63,11 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   B-11c5 moved the AiO Spectrum settings normalizer in PR #298 / `617ea14`.
   B-11c6 moved the AiO DiT correction normalizer in PR #299 / `bbca312`.
   B-11c7a moved the AiO special-seed constants and settings normalizer in PR
-  #300 / `17343eb`. B-11c7b moves only runtime RNG generation and special-seed
-  interpretation in PR #301 / `6863735`. B-11c8 moves only the two hidden-widget
-  default JSON serializers in PR #302; mutable defaults and normalization stay
-  separate.
+  #300 / `17343eb`. B-11c7b moved only runtime RNG generation and special-seed
+  interpretation in PR #301 / `6863735`. B-11c8 moved only the two hidden-widget
+  default JSON serializers in PR #302 / `40e8d94`. B-11c9 moves only the input-
+  settings normalizer to the existing resource owner in PR #303; mutable defaults
+  and schema ownership stay separate.
 
 ### Current quality baseline
 
@@ -308,7 +309,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 widget serializers PR #302 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 input normalizer PR #303 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -849,6 +850,12 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     call-time root `json` and mutable default-dict replacement, compact Unicode
     JSON options, insertion order, and hidden widget/workflow shape. Default
     settings ownership and normalization remain separate.
+  - B-11c9 moves only `_normalize_aio_input_settings` to
+    `easyuse_anima.aio.resources`. PR #303 retains direct root alias identity,
+    all three existing runtime-resolver callers, and call-time root settings
+    merge, schema/version, coercion helper, dtype, and device replacement.
+    Defaults/schema ownership, typed settings, widget serialization, and resource
+    loading behavior remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `68637353f55758d398c27f89be0ee7c1b52f7389`
+  `40e8d940483e265d5a46b2bce1bd8fea83672550`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c7b are integrated through PR #301. B-11c is
+- Current state: B-11a through B-11c8 are integrated through PR #302. B-11c is
   split into residual-owner and binder Moves before the final root shim;
-  B-11c8 AiO widget-default serializer ownership is tracked by PR #302.
+  B-11c9 AiO input-settings normalizer ownership is tracked by PR #303.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,8 +75,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 7 (`json`, `logging`, `random`,
   `re`, `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 275 after
-  B-11c8 (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 276 after
+  B-11c9 (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -84,10 +84,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 31 functions, 0 classes, and 28 assigned
-  globals after B-11c8 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 30 functions, 0 classes, and 28 assigned
+  globals after B-11c9 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 256, including
+- root names reached by those canonical runtime resolvers: 263, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -281,6 +281,22 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - PR #302 preserves `ensure_ascii=False`, compact `(",", ":")` separators,
   insertion order, and no indent/newline. It does not clone, normalize, mutate,
   or move defaults, schemas, widget metadata, or workflow serialization.
+
+### B-11c9 AiO input-settings normalizer alias
+
+- Canonical owner: `easyuse_anima.aio.resources` for
+  `_normalize_aio_input_settings`.
+- The private root name remains a transitional direct alias in both relative
+  package and flat import modes. The resource loader and both AiO Input adapter
+  callers keep resolving the root name at call time.
+- The moved function resolves root `_merge_versioned_settings`, mutable input
+  defaults, schema/version, `_as_int`, `_choice`, dtype choices, and device
+  choices through the existing resource runtime seam. Root binding replacement
+  therefore remains visible without a new binder.
+- PR #303 preserves unknown keys, merge-result mutation, `loader_mode="split"`,
+  the single clip-loader choice, and dtype/device fallback order. It does not
+  move defaults or schemas, add typed settings, or change widget, workflow,
+  resource-loading, cache, seed, or stage behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/resources.py
+++ b/easyuse_anima/aio/resources.py
@@ -25,6 +25,39 @@ def _runtime_helper(name: str) -> Any:
     return resolver(name)
 
 
+def _normalize_aio_input_settings(value) -> dict[str, Any]:
+    settings = _runtime_helper("_merge_versioned_settings")(
+        _runtime_helper("AIO_INPUT_DEFAULT_SETTINGS"),
+        value,
+    )
+    settings["schema"] = _runtime_helper("EASY_USE_ANIMA_INPUT_SCHEMA")
+    settings["version"] = _runtime_helper("_as_int")(
+        settings.get("version"),
+        _runtime_helper("EASY_USE_ANIMA_INPUT_SETTINGS_VERSION"),
+    )
+    resources = settings.setdefault("resources", {})
+    if not isinstance(resources, dict):
+        resources = {}
+        settings["resources"] = resources
+    resources["loader_mode"] = "split"
+    resources["clip_loader"] = _runtime_helper("_choice")(
+        resources.get("clip_loader"),
+        ("single",),
+        "single",
+    )
+    resources["unet_weight_dtype"] = _runtime_helper("_choice")(
+        resources.get("unet_weight_dtype"),
+        _runtime_helper("ANIMA_UNET_WEIGHT_DTYPES"),
+        "default",
+    )
+    resources["clip_device"] = _runtime_helper("_choice")(
+        resources.get("clip_device"),
+        _runtime_helper("ANIMA_CLIP_DEVICES"),
+        "default",
+    )
+    return settings
+
+
 def _preferred_name_default(names: list[str], candidates: tuple[str, ...]) -> str:
     if not names:
         return candidates[0] if candidates else ""

--- a/nodes.py
+++ b/nodes.py
@@ -107,6 +107,7 @@ try:
         _load_diffusion_model_with_comfy as _load_diffusion_model_with_comfy,
         _load_upscale_model_with_comfy as _load_upscale_model_with_comfy,
         _load_vae_with_comfy as _load_vae_with_comfy,
+        _normalize_aio_input_settings as _normalize_aio_input_settings,
         _preferred_checkpoint_default as _preferred_checkpoint_default,
         _preferred_clip_type_default as _preferred_clip_type_default,
         _preferred_name_default as _preferred_name_default,
@@ -639,6 +640,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _load_diffusion_model_with_comfy as _load_diffusion_model_with_comfy,
         _load_upscale_model_with_comfy as _load_upscale_model_with_comfy,
         _load_vae_with_comfy as _load_vae_with_comfy,
+        _normalize_aio_input_settings as _normalize_aio_input_settings,
         _preferred_checkpoint_default as _preferred_checkpoint_default,
         _preferred_clip_type_default as _preferred_clip_type_default,
         _preferred_name_default as _preferred_name_default,
@@ -1569,32 +1571,6 @@ _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activat
 
 def _settings_json(defaults: dict[str, Any]) -> str:
     return json.dumps(defaults, ensure_ascii=False, indent=2)
-
-
-def _normalize_aio_input_settings(value) -> dict[str, Any]:
-    settings = _merge_versioned_settings(AIO_INPUT_DEFAULT_SETTINGS, value)
-    settings["schema"] = EASY_USE_ANIMA_INPUT_SCHEMA
-    settings["version"] = _as_int(
-        settings.get("version"),
-        EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
-    )
-    resources = settings.setdefault("resources", {})
-    if not isinstance(resources, dict):
-        resources = {}
-        settings["resources"] = resources
-    resources["loader_mode"] = "split"
-    resources["clip_loader"] = _choice(resources.get("clip_loader"), ("single",), "single")
-    resources["unet_weight_dtype"] = _choice(
-        resources.get("unet_weight_dtype"),
-        ANIMA_UNET_WEIGHT_DTYPES,
-        "default",
-    )
-    resources["clip_device"] = _choice(
-        resources.get("clip_device"),
-        ANIMA_CLIP_DEVICES,
-        "default",
-    )
-    return settings
 
 
 _AIO_DETAILER_RESERVED_KEYS = {"enabled", "order", "sam3"}

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6698,7 +6698,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 135,
+            "line": 168,
             "type_checking": false
           },
           {
@@ -6706,7 +6706,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 136
+            "line": 169
           }
         ],
         "classification": "external",
@@ -6714,7 +6714,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 137,
+        "line": 170,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -16643,6 +16643,37 @@
         "target": "easyuse_anima/aio/resources.py"
       },
       {
+        "alias": "_normalize_aio_input_settings",
+        "bound_name": "_normalize_aio_input_settings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_aio_input_settings",
+          "target": "easyuse_anima/aio/resources.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
+        "kind": "static_from",
+        "line": 101,
+        "name": "_normalize_aio_input_settings",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.resources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
         "alias": "_preferred_checkpoint_default",
         "bound_name": "_preferred_checkpoint_default",
         "branch_context": [
@@ -16757,7 +16788,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 114,
+        "line": 115,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16788,7 +16819,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 114,
+        "line": 115,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16819,7 +16850,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 114,
+        "line": 115,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16850,7 +16881,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16881,7 +16912,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16912,7 +16943,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16943,7 +16974,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16974,7 +17005,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17005,7 +17036,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 126,
+        "line": 127,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17036,7 +17067,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 127,
+        "line": 128,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17067,7 +17098,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 127,
+        "line": 128,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17098,7 +17129,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 127,
+        "line": 128,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17129,7 +17160,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 127,
+        "line": 128,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17160,7 +17191,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17191,7 +17222,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17222,7 +17253,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17253,7 +17284,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17284,7 +17315,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17315,7 +17346,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17346,7 +17377,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17377,7 +17408,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17408,7 +17439,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17439,7 +17470,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17470,7 +17501,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 147,
+        "line": 148,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17501,7 +17532,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 147,
+        "line": 148,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17532,7 +17563,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 147,
+        "line": 148,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17563,7 +17594,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 147,
+        "line": 148,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17594,7 +17625,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 147,
+        "line": 148,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17625,7 +17656,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 147,
+        "line": 148,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17656,7 +17687,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 147,
+        "line": 148,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17687,7 +17718,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17718,7 +17749,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17749,7 +17780,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17780,7 +17811,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17811,7 +17842,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17842,7 +17873,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17873,7 +17904,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17904,7 +17935,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17935,7 +17966,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17966,7 +17997,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17997,7 +18028,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18028,7 +18059,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18059,7 +18090,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18090,7 +18121,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18121,7 +18152,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18152,7 +18183,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18183,7 +18214,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18214,7 +18245,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18245,7 +18276,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18276,7 +18307,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18307,7 +18338,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18338,7 +18369,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18369,7 +18400,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18400,7 +18431,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18431,7 +18462,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18462,7 +18493,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18493,7 +18524,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18524,7 +18555,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18555,7 +18586,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18586,7 +18617,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18617,7 +18648,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18648,7 +18679,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18679,7 +18710,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18710,7 +18741,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18741,7 +18772,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18772,7 +18803,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18803,7 +18834,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 229,
+        "line": 230,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18834,7 +18865,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 229,
+        "line": 230,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18865,7 +18896,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 229,
+        "line": 230,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18896,7 +18927,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 229,
+        "line": 230,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18927,7 +18958,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 229,
+        "line": 230,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18958,7 +18989,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 229,
+        "line": 230,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18989,7 +19020,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 229,
+        "line": 230,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19020,7 +19051,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 229,
+        "line": 230,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19051,7 +19082,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 229,
+        "line": 230,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19082,7 +19113,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19113,7 +19144,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19144,7 +19175,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19175,7 +19206,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19206,7 +19237,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19237,7 +19268,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19268,7 +19299,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19299,7 +19330,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19330,7 +19361,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19361,7 +19392,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19392,7 +19423,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19423,7 +19454,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19454,7 +19485,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19485,7 +19516,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19516,7 +19547,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19547,7 +19578,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19578,7 +19609,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19609,7 +19640,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19640,7 +19671,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19671,7 +19702,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19702,7 +19733,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19733,7 +19764,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19764,7 +19795,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19795,7 +19826,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19826,7 +19857,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19857,7 +19888,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 325,
+        "line": 326,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19888,7 +19919,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 325,
+        "line": 326,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19919,7 +19950,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 325,
+        "line": 326,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19950,7 +19981,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 325,
+        "line": 326,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19981,7 +20012,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 331,
+        "line": 332,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20012,7 +20043,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 331,
+        "line": 332,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20043,7 +20074,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 331,
+        "line": 332,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20074,7 +20105,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 336,
+        "line": 337,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20105,7 +20136,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 336,
+        "line": 337,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20136,7 +20167,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 336,
+        "line": 337,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20167,7 +20198,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 342,
+        "line": 343,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20198,7 +20229,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 342,
+        "line": 343,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20229,7 +20260,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 342,
+        "line": 343,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20260,7 +20291,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 342,
+        "line": 343,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20291,7 +20322,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 342,
+        "line": 343,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20322,7 +20353,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 342,
+        "line": 343,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20353,7 +20384,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 342,
+        "line": 343,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20384,7 +20415,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20415,7 +20446,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20446,7 +20477,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20477,7 +20508,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20508,7 +20539,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20539,7 +20570,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20570,7 +20601,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20601,7 +20632,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 375,
+        "line": 376,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20632,7 +20663,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 375,
+        "line": 376,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20663,7 +20694,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20694,7 +20725,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20725,7 +20756,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20756,7 +20787,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20787,7 +20818,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20818,7 +20849,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20849,7 +20880,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20880,7 +20911,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20911,7 +20942,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20942,7 +20973,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -20973,7 +21004,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21004,7 +21035,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21035,7 +21066,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21066,7 +21097,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21097,7 +21128,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21128,7 +21159,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21159,7 +21190,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21190,7 +21221,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21221,7 +21252,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21252,7 +21283,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 412,
+        "line": 413,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21283,7 +21314,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21314,7 +21345,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21345,7 +21376,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21376,7 +21407,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21407,7 +21438,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21438,7 +21469,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21469,7 +21500,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21500,7 +21531,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21531,7 +21562,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 428,
+        "line": 429,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21562,7 +21593,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 428,
+        "line": 429,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21593,7 +21624,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 428,
+        "line": 429,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21624,7 +21655,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 433,
+        "line": 434,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21655,7 +21686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 433,
+        "line": 434,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21686,7 +21717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 433,
+        "line": 434,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21717,7 +21748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 451,
+        "line": 452,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21748,7 +21779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 451,
+        "line": 452,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21779,7 +21810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 451,
+        "line": 452,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21810,7 +21841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 451,
+        "line": 452,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21841,7 +21872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 451,
+        "line": 452,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21872,7 +21903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21903,7 +21934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -21934,7 +21965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 478,
+        "line": 479,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21965,7 +21996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 478,
+        "line": 479,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -21996,7 +22027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22027,7 +22058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22058,7 +22089,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22089,7 +22120,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22120,7 +22151,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22151,7 +22182,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22182,7 +22213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22213,7 +22244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22244,7 +22275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22275,7 +22306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22306,7 +22337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22337,7 +22368,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22368,7 +22399,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22399,7 +22430,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22430,7 +22461,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 483,
+        "line": 484,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22461,7 +22492,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22492,7 +22523,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22523,7 +22554,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22554,7 +22585,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22585,7 +22616,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22616,7 +22647,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22647,7 +22678,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22678,7 +22709,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22709,7 +22740,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22740,7 +22771,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22771,7 +22802,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 514,
+        "line": 515,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22802,7 +22833,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 514,
+        "line": 515,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22833,7 +22864,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 515,
+        "line": 516,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -22864,7 +22895,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 516,
+        "line": 517,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -22895,7 +22926,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 516,
+        "line": 517,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -22926,7 +22957,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 516,
+        "line": 517,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -22957,7 +22988,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 521,
+        "line": 522,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -22988,7 +23019,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 521,
+        "line": 522,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23019,7 +23050,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23050,7 +23081,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23081,7 +23112,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23112,7 +23143,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23143,7 +23174,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23174,7 +23205,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23205,7 +23236,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23236,7 +23267,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23267,7 +23298,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23298,7 +23329,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23329,7 +23360,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23360,7 +23391,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23391,7 +23422,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23422,7 +23453,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23453,7 +23484,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23484,7 +23515,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23515,7 +23546,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23546,7 +23577,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23577,7 +23608,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23596,7 +23627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -23611,7 +23642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23630,7 +23661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -23645,7 +23676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23664,7 +23695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -23679,7 +23710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23698,7 +23729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23732,7 +23763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -23747,7 +23778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23766,7 +23797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -23781,7 +23812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23800,7 +23831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -23815,7 +23846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23834,7 +23865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -23849,7 +23880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23868,7 +23899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -23883,7 +23914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 555,
+        "line": 556,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23902,7 +23933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -23917,7 +23948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 555,
+        "line": 556,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -23936,7 +23967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -23951,7 +23982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -23970,7 +24001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -23985,7 +24016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24004,7 +24035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24019,7 +24050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24038,7 +24069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24053,7 +24084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24072,7 +24103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24087,7 +24118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24106,7 +24137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24121,7 +24152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24140,7 +24171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24155,7 +24186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24174,7 +24205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24189,7 +24220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24208,7 +24239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24223,7 +24254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24242,7 +24273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24257,7 +24288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24276,7 +24307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24291,7 +24322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -24310,7 +24341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24325,7 +24356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24344,7 +24375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24359,7 +24390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24378,7 +24409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24393,7 +24424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24412,7 +24443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24427,7 +24458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24446,7 +24477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24461,7 +24492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24480,7 +24511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24495,7 +24526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24514,7 +24545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24529,7 +24560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24548,7 +24579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24563,7 +24594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24582,7 +24613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24597,7 +24628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24616,7 +24647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24631,7 +24662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24650,7 +24681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24665,7 +24696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24684,7 +24715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24699,7 +24730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24718,7 +24749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24733,7 +24764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24752,7 +24783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24767,7 +24798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24786,7 +24817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24801,7 +24832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24820,7 +24851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24835,7 +24866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24854,7 +24885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24869,7 +24900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24888,7 +24919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24903,7 +24934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24922,7 +24953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24937,7 +24968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24956,7 +24987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -24971,7 +25002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -24990,7 +25021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25005,7 +25036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25024,7 +25055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25039,7 +25070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25058,7 +25089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25073,7 +25104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25092,7 +25123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25107,7 +25138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25126,7 +25157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25141,7 +25172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25160,7 +25191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25175,7 +25206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25194,7 +25225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25209,7 +25240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25228,7 +25259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25243,7 +25274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25262,7 +25293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25277,7 +25308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25296,7 +25327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25311,7 +25342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25330,7 +25361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25345,7 +25376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25364,7 +25395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25379,7 +25410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25398,7 +25429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25413,7 +25444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25432,7 +25463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25447,7 +25478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25466,7 +25497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25481,7 +25512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25500,7 +25531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25515,7 +25546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25534,7 +25565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25549,7 +25580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25568,7 +25599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25583,7 +25614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25602,7 +25633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25617,7 +25648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25636,7 +25667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25651,7 +25682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25670,7 +25701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25685,7 +25716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25704,7 +25735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25719,7 +25750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25738,7 +25769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25753,7 +25784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25772,7 +25803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25787,7 +25818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25806,7 +25837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25821,7 +25852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25840,7 +25871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25855,7 +25886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25874,7 +25905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25889,7 +25920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25908,7 +25939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25923,7 +25954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25942,7 +25973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25957,7 +25988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -25976,7 +26007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -25991,7 +26022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26010,7 +26041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26025,7 +26056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26044,7 +26075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26059,7 +26090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26078,7 +26109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26093,7 +26124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26112,7 +26143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26127,7 +26158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26146,7 +26177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26161,7 +26192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26180,7 +26211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26195,7 +26226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26214,7 +26245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26229,8 +26260,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "name": "_load_vae_with_comfy",
+        "optional": false,
+        "requested": "easyuse_anima.aio.resources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": "_normalize_aio_input_settings",
+        "bound_name": "_normalize_aio_input_settings",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 544,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_aio_input_settings",
+          "target": "easyuse_anima/aio/resources.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
+        "kind": "static_from",
+        "line": 634,
+        "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
         "role": "compatibility_fallback",
@@ -26248,7 +26313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26263,7 +26328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26282,7 +26347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26297,7 +26362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26316,7 +26381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26331,7 +26396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26350,7 +26415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26365,7 +26430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 646,
+        "line": 648,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -26384,7 +26449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26399,7 +26464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 646,
+        "line": 648,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -26418,7 +26483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26433,7 +26498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 646,
+        "line": 648,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -26452,7 +26517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26467,7 +26532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26486,7 +26551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26501,7 +26566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26520,7 +26585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26535,7 +26600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26554,7 +26619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26569,7 +26634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26588,7 +26653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26603,7 +26668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26622,7 +26687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26637,7 +26702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 658,
+        "line": 660,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -26656,7 +26721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26671,7 +26736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26690,7 +26755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26705,7 +26770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26724,7 +26789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26739,7 +26804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26758,7 +26823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26773,7 +26838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26792,7 +26857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26807,7 +26872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26826,7 +26891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26841,7 +26906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26860,7 +26925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26875,7 +26940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26894,7 +26959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26909,7 +26974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26928,7 +26993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26943,7 +27008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26962,7 +27027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -26977,7 +27042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26996,7 +27061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27011,7 +27076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27030,7 +27095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27045,7 +27110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27064,7 +27129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27079,7 +27144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27098,7 +27163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27113,7 +27178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27132,7 +27197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27147,7 +27212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27166,7 +27231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27181,7 +27246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27200,7 +27265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27215,7 +27280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27234,7 +27299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27249,7 +27314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27268,7 +27333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27283,7 +27348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27302,7 +27367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27317,7 +27382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27336,7 +27401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27351,7 +27416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27370,7 +27435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27385,7 +27450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27404,7 +27469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27419,7 +27484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27438,7 +27503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27453,7 +27518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27472,7 +27537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27487,7 +27552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27506,7 +27571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27521,7 +27586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27540,7 +27605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27555,7 +27620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27574,7 +27639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27589,7 +27654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27608,7 +27673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27623,7 +27688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27642,7 +27707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27657,7 +27722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27676,7 +27741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27691,7 +27756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27710,7 +27775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27725,7 +27790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27744,7 +27809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27759,7 +27824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27778,7 +27843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27793,7 +27858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27812,7 +27877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27827,7 +27892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27846,7 +27911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27861,7 +27926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27880,7 +27945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27895,7 +27960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27914,7 +27979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27929,7 +27994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27948,7 +28013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27963,7 +28028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27982,7 +28047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -27997,7 +28062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28016,7 +28081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28031,7 +28096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28050,7 +28115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28065,7 +28130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28084,7 +28149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28099,7 +28164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28118,7 +28183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28133,7 +28198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28152,7 +28217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28167,7 +28232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28186,7 +28251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28201,7 +28266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28220,7 +28285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28235,7 +28300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28254,7 +28319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28269,7 +28334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28288,7 +28353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28303,7 +28368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28322,7 +28387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28337,7 +28402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28356,7 +28421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28371,7 +28436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28390,7 +28455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28405,7 +28470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28424,7 +28489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28439,7 +28504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28458,7 +28523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28473,7 +28538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28492,7 +28557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28507,7 +28572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28526,7 +28591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28541,7 +28606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28560,7 +28625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28575,7 +28640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28594,7 +28659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28609,7 +28674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28628,7 +28693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28643,7 +28708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28662,7 +28727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28677,7 +28742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28696,7 +28761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28711,7 +28776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28730,7 +28795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28745,7 +28810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28764,7 +28829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28779,7 +28844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28798,7 +28863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28813,7 +28878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28832,7 +28897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28847,7 +28912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28866,7 +28931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28881,7 +28946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -28900,7 +28965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28915,7 +28980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28934,7 +28999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28949,7 +29014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -28968,7 +29033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -28983,7 +29048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29002,7 +29067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29017,7 +29082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29036,7 +29101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29051,7 +29116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29070,7 +29135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29085,7 +29150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29104,7 +29169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29119,7 +29184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29138,7 +29203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29153,7 +29218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29172,7 +29237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29187,7 +29252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29206,7 +29271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29221,7 +29286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29240,7 +29305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29255,7 +29320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29274,7 +29339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29289,7 +29354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29308,7 +29373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29323,7 +29388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29342,7 +29407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29357,7 +29422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29376,7 +29441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29391,7 +29456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29410,7 +29475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29425,7 +29490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29444,7 +29509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29459,7 +29524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29478,7 +29543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29493,7 +29558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29512,7 +29577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29527,7 +29592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29546,7 +29611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29561,7 +29626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29580,7 +29645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29595,7 +29660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29614,7 +29679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29629,7 +29694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29648,7 +29713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29663,7 +29728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29682,7 +29747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29697,7 +29762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29716,7 +29781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29731,7 +29796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29750,7 +29815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29765,7 +29830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 857,
+        "line": 859,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29784,7 +29849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29799,7 +29864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 857,
+        "line": 859,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29818,7 +29883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29833,7 +29898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 857,
+        "line": 859,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29852,7 +29917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29867,7 +29932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 857,
+        "line": 859,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -29886,7 +29951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29901,7 +29966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 863,
+        "line": 865,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29920,7 +29985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29935,7 +30000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 863,
+        "line": 865,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29954,7 +30019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -29969,7 +30034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 863,
+        "line": 865,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -29988,7 +30053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30003,7 +30068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -30022,7 +30087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30037,7 +30102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -30056,7 +30121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30071,7 +30136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -30090,7 +30155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30105,7 +30170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30124,7 +30189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30139,7 +30204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30158,7 +30223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30173,7 +30238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30192,7 +30257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30207,7 +30272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30226,7 +30291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30241,7 +30306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30260,7 +30325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30275,7 +30340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30294,7 +30359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30309,7 +30374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30328,7 +30393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30343,7 +30408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 883,
+        "line": 885,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -30362,7 +30427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30377,7 +30442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 883,
+        "line": 885,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -30396,7 +30461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30411,7 +30476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 883,
+        "line": 885,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -30430,7 +30495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30445,7 +30510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30464,7 +30529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30479,7 +30544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30498,7 +30563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30513,7 +30578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30532,7 +30597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30547,7 +30612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30566,7 +30631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30581,7 +30646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -30600,7 +30665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30615,7 +30680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -30634,7 +30699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30649,7 +30714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30668,7 +30733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30683,7 +30748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30702,7 +30767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30717,7 +30782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30736,7 +30801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30751,7 +30816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30770,7 +30835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30785,7 +30850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30804,7 +30869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30819,7 +30884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30838,7 +30903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30853,7 +30918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30872,7 +30937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30887,7 +30952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -30906,7 +30971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30921,7 +30986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30940,7 +31005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30955,7 +31020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -30974,7 +31039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -30989,7 +31054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31008,7 +31073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31023,7 +31088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31042,7 +31107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31057,7 +31122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31076,7 +31141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31091,7 +31156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31110,7 +31175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31125,7 +31190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31144,7 +31209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31159,7 +31224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31178,7 +31243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31193,7 +31258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31212,7 +31277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31227,7 +31292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -31246,7 +31311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31261,7 +31326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -31280,7 +31345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31295,7 +31360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 944,
+        "line": 946,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -31314,7 +31379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31329,7 +31394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -31348,7 +31413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31363,7 +31428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -31382,7 +31447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31397,7 +31462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -31416,7 +31481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31431,7 +31496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 953,
+        "line": 955,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31450,7 +31515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31465,7 +31530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 953,
+        "line": 955,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31484,7 +31549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31499,7 +31564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 953,
+        "line": 955,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31518,7 +31583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31533,7 +31598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 953,
+        "line": 955,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31552,7 +31617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31567,7 +31632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 953,
+        "line": 955,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31586,7 +31651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31601,7 +31666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31620,7 +31685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31635,7 +31700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31654,7 +31719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31669,7 +31734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -31688,7 +31753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31703,7 +31768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31722,7 +31787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31737,7 +31802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31756,7 +31821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31771,7 +31836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -31790,7 +31855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31805,7 +31870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31824,7 +31889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31839,7 +31904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31858,7 +31923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31873,7 +31938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31892,7 +31957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31907,7 +31972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31926,7 +31991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31941,7 +32006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -31960,7 +32025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -31975,7 +32040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -31994,7 +32059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32009,7 +32074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -32028,7 +32093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32043,7 +32108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -32062,7 +32127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32077,7 +32142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -32096,7 +32161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32111,7 +32176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32130,7 +32195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32145,7 +32210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32164,7 +32229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32179,7 +32244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32198,7 +32263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32213,7 +32278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32232,7 +32297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32247,7 +32312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32266,7 +32331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32281,7 +32346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32300,7 +32365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32315,7 +32380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32334,7 +32399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32349,7 +32414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32368,7 +32433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32383,7 +32448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32402,7 +32467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32417,7 +32482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32436,7 +32501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32451,7 +32516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32470,7 +32535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32485,7 +32550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32504,7 +32569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32519,7 +32584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32538,7 +32603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32553,7 +32618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32572,7 +32637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32587,7 +32652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32606,7 +32671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32621,7 +32686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32640,7 +32705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32655,7 +32720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32674,7 +32739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32689,7 +32754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32708,7 +32773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32723,7 +32788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32742,7 +32807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32757,7 +32822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32776,7 +32841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32791,7 +32856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32810,7 +32875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32825,7 +32890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32844,7 +32909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32859,7 +32924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -32878,7 +32943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32893,7 +32958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1042,
+        "line": 1044,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32912,7 +32977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32927,7 +32992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1042,
+        "line": 1044,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -32946,7 +33011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32961,7 +33026,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -32980,7 +33045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -32995,7 +33060,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -33014,7 +33079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33029,7 +33094,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1049,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -33048,7 +33113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33063,7 +33128,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -33082,7 +33147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33097,7 +33162,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -33116,7 +33181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33131,7 +33196,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -33150,7 +33215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33165,7 +33230,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1055,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -33184,7 +33249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33199,7 +33264,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1055,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -33218,7 +33283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33233,7 +33298,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33252,7 +33317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33267,7 +33332,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33286,7 +33351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33301,7 +33366,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33320,7 +33385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33335,7 +33400,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33354,7 +33419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33369,7 +33434,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33388,7 +33453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33403,7 +33468,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33422,7 +33487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33437,7 +33502,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33456,7 +33521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33471,7 +33536,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33490,7 +33555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33505,7 +33570,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33524,7 +33589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33539,7 +33604,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33558,7 +33623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33573,7 +33638,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33592,7 +33657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33607,7 +33672,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33626,7 +33691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33641,7 +33706,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33660,7 +33725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33675,7 +33740,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33694,7 +33759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33709,7 +33774,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33728,7 +33793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33743,7 +33808,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33762,7 +33827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33777,7 +33842,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33796,7 +33861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33811,7 +33876,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33830,7 +33895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -33845,7 +33910,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33863,7 +33928,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1642
+            "line": 1618
           }
         ],
         "classification": "external",
@@ -33871,7 +33936,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1643,
+        "line": 1619,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33888,7 +33953,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1679
+            "line": 1655
           }
         ],
         "classification": "external",
@@ -33896,7 +33961,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1680,
+        "line": 1656,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33913,7 +33978,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1687
+            "line": 1663
           }
         ],
         "classification": "external",
@@ -33921,7 +33986,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1688,
+        "line": 1664,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -36933,13 +36998,13 @@
       },
       {
         "is_package": false,
-        "loc": 218,
+        "loc": 251,
         "module": "easyuse_anima.aio.resources",
-        "normalized_git_blob_sha1": "096ce18c9f5de480b2a99606bbf603cadac78a7c",
+        "normalized_git_blob_sha1": "612ebcf6af82a8fad8feb2cddf646a1e6d88ab12",
         "path": "easyuse_anima/aio/resources.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 12,
+          "function_count": 13,
           "global_count": 3
         }
       },
@@ -37509,13 +37574,13 @@
       },
       {
         "is_package": false,
-        "loc": 2524,
+        "loc": 2500,
         "module": "nodes",
-        "normalized_git_blob_sha1": "854c9a489b82d613448a3de64f57f66f914d60e9",
+        "normalized_git_blob_sha1": "9be894acf8166835ea08863c3ea928120d573a0c",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 31,
+          "function_count": 30,
           "global_count": 28
         }
       },
@@ -38875,7 +38940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -38884,7 +38949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38898,7 +38963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -38907,7 +38972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38921,7 +38986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -38930,7 +38995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38944,7 +39009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -38953,7 +39018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38967,7 +39032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -38976,7 +39041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -38990,7 +39055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -38999,7 +39064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39013,7 +39078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39022,7 +39087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39036,7 +39101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39045,7 +39110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39059,7 +39124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39068,7 +39133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 555,
+        "line": 556,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39082,7 +39147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39091,7 +39156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 555,
+        "line": 556,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39105,7 +39170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39114,7 +39179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39128,7 +39193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39137,7 +39202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39151,7 +39216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39160,7 +39225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39174,7 +39239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39183,7 +39248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39197,7 +39262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39206,7 +39271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39220,7 +39285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39229,7 +39294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39243,7 +39308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39252,7 +39317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39266,7 +39331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39275,7 +39340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39289,7 +39354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39298,7 +39363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39312,7 +39377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39321,7 +39386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39335,7 +39400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39344,7 +39409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39358,7 +39423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39367,7 +39432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39381,7 +39446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39390,7 +39455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39404,7 +39469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39413,7 +39478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39427,7 +39492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39436,7 +39501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39450,7 +39515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39459,7 +39524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39473,7 +39538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39482,7 +39547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39496,7 +39561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39505,7 +39570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39519,7 +39584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39528,7 +39593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39542,7 +39607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39551,7 +39616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39565,7 +39630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39574,7 +39639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39588,7 +39653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39597,7 +39662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39611,7 +39676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39620,7 +39685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39634,7 +39699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39643,7 +39708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39657,7 +39722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39666,7 +39731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39680,7 +39745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39689,7 +39754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39703,7 +39768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39712,7 +39777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39726,7 +39791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39735,7 +39800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39749,7 +39814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39758,7 +39823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39772,7 +39837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39781,7 +39846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39795,7 +39860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39804,7 +39869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39818,7 +39883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39827,7 +39892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39841,7 +39906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39850,7 +39915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39864,7 +39929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39873,7 +39938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39887,7 +39952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39896,7 +39961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39910,7 +39975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39919,7 +39984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39933,7 +39998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39942,7 +40007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39956,7 +40021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39965,7 +40030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39979,7 +40044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -39988,7 +40053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40002,7 +40067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40011,7 +40076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40025,7 +40090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40034,7 +40099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40048,7 +40113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40057,7 +40122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40071,7 +40136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40080,7 +40145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40094,7 +40159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40103,7 +40168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40117,7 +40182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40126,7 +40191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40140,7 +40205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40149,7 +40214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40163,7 +40228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40172,7 +40237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40186,7 +40251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40195,7 +40260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40209,7 +40274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40218,7 +40283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40232,7 +40297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40241,7 +40306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40255,7 +40320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40264,7 +40329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40278,7 +40343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40287,7 +40352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40301,7 +40366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40310,7 +40375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40324,7 +40389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40333,7 +40398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40347,7 +40412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40356,7 +40421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40370,7 +40435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40379,7 +40444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40393,7 +40458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40402,7 +40467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40416,7 +40481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40425,7 +40490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40439,7 +40504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40448,7 +40513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40462,7 +40527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40471,7 +40536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 621,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40485,7 +40550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40494,7 +40559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40508,7 +40573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40517,7 +40582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40531,7 +40596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40540,7 +40605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40554,7 +40619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40563,7 +40628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40577,7 +40642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40586,7 +40651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40600,7 +40665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40609,7 +40674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40623,7 +40688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40632,7 +40697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40646,7 +40711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40655,7 +40720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40669,7 +40734,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
+        "kind": "static_from",
+        "line": 634,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40678,7 +40766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40692,7 +40780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40701,7 +40789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40715,7 +40803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40724,7 +40812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 633,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40738,7 +40826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40747,7 +40835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 646,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40761,7 +40849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40770,7 +40858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 646,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40784,7 +40872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40793,7 +40881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 646,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40807,7 +40895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40816,7 +40904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40830,7 +40918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40839,7 +40927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40853,7 +40941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40862,7 +40950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40876,7 +40964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40885,7 +40973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40899,7 +40987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40908,7 +40996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40922,7 +41010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40931,7 +41019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 658,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40945,7 +41033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40954,7 +41042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40968,7 +41056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -40977,7 +41065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40991,7 +41079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41000,7 +41088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41014,7 +41102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41023,7 +41111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41037,7 +41125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41046,7 +41134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41060,7 +41148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41069,7 +41157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41083,7 +41171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41092,7 +41180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41106,7 +41194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41115,7 +41203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41129,7 +41217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41138,7 +41226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41152,7 +41240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41161,7 +41249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41175,7 +41263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41184,7 +41272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41198,7 +41286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41207,7 +41295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41221,7 +41309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41230,7 +41318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41244,7 +41332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41253,7 +41341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41267,7 +41355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41276,7 +41364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41290,7 +41378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41299,7 +41387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41313,7 +41401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41322,7 +41410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41336,7 +41424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41345,7 +41433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41359,7 +41447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41368,7 +41456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41382,7 +41470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41391,7 +41479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41405,7 +41493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41414,7 +41502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41428,7 +41516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41437,7 +41525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41451,7 +41539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41460,7 +41548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41474,7 +41562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41483,7 +41571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41497,7 +41585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41506,7 +41594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41520,7 +41608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41529,7 +41617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41543,7 +41631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41552,7 +41640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41566,7 +41654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41575,7 +41663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41589,7 +41677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41598,7 +41686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41612,7 +41700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41621,7 +41709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41635,7 +41723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41644,7 +41732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41658,7 +41746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41667,7 +41755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41681,7 +41769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41690,7 +41778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41704,7 +41792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41713,7 +41801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41727,7 +41815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41736,7 +41824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41750,7 +41838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41759,7 +41847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41773,7 +41861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41782,7 +41870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41796,7 +41884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41805,7 +41893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41819,7 +41907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41828,7 +41916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41842,7 +41930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41851,7 +41939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41865,7 +41953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41874,7 +41962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41888,7 +41976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41897,7 +41985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41911,7 +41999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41920,7 +42008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41934,7 +42022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41943,7 +42031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41957,7 +42045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41966,7 +42054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41980,7 +42068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -41989,7 +42077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42003,7 +42091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42012,7 +42100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42026,7 +42114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42035,7 +42123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42049,7 +42137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42058,7 +42146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42072,7 +42160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42081,7 +42169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42095,7 +42183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42104,7 +42192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42118,7 +42206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42127,7 +42215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42141,7 +42229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42150,7 +42238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42164,7 +42252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42173,7 +42261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42187,7 +42275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42196,7 +42284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42210,7 +42298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42219,7 +42307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42233,7 +42321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42242,7 +42330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 733,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42256,7 +42344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42265,7 +42353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42279,7 +42367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42288,7 +42376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42302,7 +42390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42311,7 +42399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42325,7 +42413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42334,7 +42422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42348,7 +42436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42357,7 +42445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42371,7 +42459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42380,7 +42468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42394,7 +42482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42403,7 +42491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42417,7 +42505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42426,7 +42514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42440,7 +42528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42449,7 +42537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 761,
+        "line": 763,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42463,7 +42551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42472,7 +42560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42486,7 +42574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42495,7 +42583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42509,7 +42597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42518,7 +42606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42532,7 +42620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42541,7 +42629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42555,7 +42643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42564,7 +42652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42578,7 +42666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42587,7 +42675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42601,7 +42689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42610,7 +42698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42624,7 +42712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42633,7 +42721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42647,7 +42735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42656,7 +42744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42670,7 +42758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42679,7 +42767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42693,7 +42781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42702,7 +42790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42716,7 +42804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42725,7 +42813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42739,7 +42827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42748,7 +42836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42762,7 +42850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42771,7 +42859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42785,7 +42873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42794,7 +42882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42808,7 +42896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42817,7 +42905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42831,7 +42919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42840,7 +42928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42854,7 +42942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42863,7 +42951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42877,7 +42965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42886,7 +42974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42900,7 +42988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42909,7 +42997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42923,7 +43011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42932,7 +43020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42946,7 +43034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42955,7 +43043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42969,7 +43057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -42978,7 +43066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42992,7 +43080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43001,7 +43089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43015,7 +43103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43024,7 +43112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 777,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43038,7 +43126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43047,7 +43135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 857,
+        "line": 859,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43061,7 +43149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43070,7 +43158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 857,
+        "line": 859,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43084,7 +43172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43093,7 +43181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 857,
+        "line": 859,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43107,7 +43195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43116,7 +43204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 857,
+        "line": 859,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43130,7 +43218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43139,7 +43227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 863,
+        "line": 865,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43153,7 +43241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43162,7 +43250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 863,
+        "line": 865,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43176,7 +43264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43185,7 +43273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 863,
+        "line": 865,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43199,7 +43287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43208,7 +43296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43222,7 +43310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43231,7 +43319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43245,7 +43333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43254,7 +43342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 868,
+        "line": 870,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43268,7 +43356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43277,7 +43365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43291,7 +43379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43300,7 +43388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43314,7 +43402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43323,7 +43411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43337,7 +43425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43346,7 +43434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43360,7 +43448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43369,7 +43457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43383,7 +43471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43392,7 +43480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43406,7 +43494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43415,7 +43503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 874,
+        "line": 876,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43429,7 +43517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43438,7 +43526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 883,
+        "line": 885,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43452,7 +43540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43461,7 +43549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 883,
+        "line": 885,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43475,7 +43563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43484,7 +43572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 883,
+        "line": 885,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43498,7 +43586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43507,7 +43595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43521,7 +43609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43530,7 +43618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43544,7 +43632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43553,7 +43641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43567,7 +43655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43576,7 +43664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43590,7 +43678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43599,7 +43687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43613,7 +43701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43622,7 +43710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43636,7 +43724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43645,7 +43733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43659,7 +43747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43668,7 +43756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43682,7 +43770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43691,7 +43779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43705,7 +43793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43714,7 +43802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43728,7 +43816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43737,7 +43825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43751,7 +43839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43760,7 +43848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43774,7 +43862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43783,7 +43871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43797,7 +43885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43806,7 +43894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43820,7 +43908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43829,7 +43917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43843,7 +43931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43852,7 +43940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43866,7 +43954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43875,7 +43963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43889,7 +43977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43898,7 +43986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43912,7 +44000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43921,7 +44009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43935,7 +44023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43944,7 +44032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43958,7 +44046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43967,7 +44055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43981,7 +44069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -43990,7 +44078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44004,7 +44092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44013,7 +44101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44027,7 +44115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44036,7 +44124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44050,7 +44138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44059,7 +44147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44073,7 +44161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44082,7 +44170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 944,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44096,7 +44184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44105,7 +44193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44119,7 +44207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44128,7 +44216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44142,7 +44230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44151,7 +44239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44165,7 +44253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44174,7 +44262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 953,
+        "line": 955,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44188,7 +44276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44197,7 +44285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 953,
+        "line": 955,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44211,7 +44299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44220,7 +44308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 953,
+        "line": 955,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44234,7 +44322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44243,7 +44331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 953,
+        "line": 955,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44257,7 +44345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44266,7 +44354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 953,
+        "line": 955,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44280,7 +44368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44289,7 +44377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44303,7 +44391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44312,7 +44400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44326,7 +44414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44335,7 +44423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44349,7 +44437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44358,7 +44446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44372,7 +44460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44381,7 +44469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44395,7 +44483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44404,7 +44492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44418,7 +44506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44427,7 +44515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44441,7 +44529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44450,7 +44538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44464,7 +44552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44473,7 +44561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44487,7 +44575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44496,7 +44584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44510,7 +44598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44519,7 +44607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44533,7 +44621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44542,7 +44630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44556,7 +44644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44565,7 +44653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44579,7 +44667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44588,7 +44676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44602,7 +44690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44611,7 +44699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44625,7 +44713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44634,7 +44722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44648,7 +44736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44657,7 +44745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44671,7 +44759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44680,7 +44768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44694,7 +44782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44703,7 +44791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44717,7 +44805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44726,7 +44814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44740,7 +44828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44749,7 +44837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44763,7 +44851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44772,7 +44860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44786,7 +44874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44795,7 +44883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44809,7 +44897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44818,7 +44906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44832,7 +44920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44841,7 +44929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44855,7 +44943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44864,7 +44952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44878,7 +44966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44887,7 +44975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44901,7 +44989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44910,7 +44998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44924,7 +45012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44933,7 +45021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44947,7 +45035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44956,7 +45044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44970,7 +45058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -44979,7 +45067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44993,7 +45081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45002,7 +45090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45016,7 +45104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45025,7 +45113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45039,7 +45127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45048,7 +45136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45062,7 +45150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45071,7 +45159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45085,7 +45173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45094,7 +45182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45108,7 +45196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45117,7 +45205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45131,7 +45219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45140,7 +45228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45154,7 +45242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45163,7 +45251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1042,
+        "line": 1044,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45177,7 +45265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45186,7 +45274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1042,
+        "line": 1044,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45200,7 +45288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45209,7 +45297,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45223,7 +45311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45232,7 +45320,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45246,7 +45334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45255,7 +45343,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1049,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45269,7 +45357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45278,7 +45366,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45292,7 +45380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45301,7 +45389,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45315,7 +45403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45324,7 +45412,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45338,7 +45426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45347,7 +45435,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1055,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45361,7 +45449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45370,7 +45458,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1055,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45384,7 +45472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45393,7 +45481,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45407,7 +45495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45416,7 +45504,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45430,7 +45518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45439,7 +45527,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45453,7 +45541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45462,7 +45550,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45476,7 +45564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45485,7 +45573,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45499,7 +45587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45508,7 +45596,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45522,7 +45610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45531,7 +45619,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45545,7 +45633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45554,7 +45642,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45568,7 +45656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45577,7 +45665,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45591,7 +45679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45600,7 +45688,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45614,7 +45702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45623,7 +45711,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45637,7 +45725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45646,7 +45734,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45660,7 +45748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45669,7 +45757,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45683,7 +45771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45692,7 +45780,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45706,7 +45794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45715,7 +45803,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45729,7 +45817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45738,7 +45826,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45752,7 +45840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45761,7 +45849,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45775,7 +45863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45784,7 +45872,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45798,7 +45886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 543,
+            "handler_line": 544,
             "kind": "try",
             "line": 11
           }
@@ -45807,7 +45895,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47607,7 +47695,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 135,
+            "line": 168,
             "type_checking": false
           },
           {
@@ -47615,14 +47703,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 136
+            "line": 169
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 137,
+        "line": 170,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -49546,14 +49634,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1642
+            "line": 1618
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1643,
+        "line": 1619,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49565,14 +49653,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1679
+            "line": 1655
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1680,
+        "line": 1656,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49584,14 +49672,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1687
+            "line": 1663
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1688,
+        "line": 1664,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50369,7 +50457,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 135,
+            "line": 168,
             "type_checking": false
           },
           {
@@ -50377,14 +50465,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 136
+            "line": 169
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 137,
+        "line": 170,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -50966,14 +51054,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1642
+            "line": 1618
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1643,
+        "line": 1619,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50985,14 +51073,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1679
+            "line": 1655
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1680,
+        "line": 1656,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51004,14 +51092,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1687
+            "line": 1663
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1688,
+        "line": 1664,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52459,7 +52547,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1076,
+        "line": 1078,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52468,7 +52556,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1601,
+        "line": 1577,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52477,7 +52565,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2426,
+        "line": 2402,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52486,7 +52574,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2429,
+        "line": 2405,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52495,7 +52583,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2432,
+        "line": 2408,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52504,7 +52592,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2435,
+        "line": 2411,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52513,7 +52601,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2438,
+        "line": 2414,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52522,7 +52610,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2441,
+        "line": 2417,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52531,7 +52619,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2444,
+        "line": 2420,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52540,7 +52628,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2447,
+        "line": 2423,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52549,7 +52637,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2450,
+        "line": 2426,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52558,7 +52646,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2453,
+        "line": 2429,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52567,7 +52655,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2456,
+        "line": 2432,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52576,7 +52664,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2459,
+        "line": 2435,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52585,7 +52673,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2462,
+        "line": 2438,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52594,7 +52682,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2465,
+        "line": 2441,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52603,7 +52691,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2469,
+        "line": 2445,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52612,7 +52700,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2472,
+        "line": 2448,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52621,7 +52709,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2476,
+        "line": 2452,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52630,7 +52718,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2479,
+        "line": 2455,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52639,7 +52727,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2483,
+        "line": 2459,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52648,7 +52736,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2486,
+        "line": 2462,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52657,7 +52745,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2489,
+        "line": 2465,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52666,7 +52754,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2492,
+        "line": 2468,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52675,7 +52763,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2495,
+        "line": 2471,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52684,7 +52772,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2498,
+        "line": 2474,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52693,7 +52781,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2505,
+        "line": 2481,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52702,7 +52790,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2511,
+        "line": 2487,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52711,7 +52799,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2516,
+        "line": 2492,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52720,7 +52808,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2520,
+        "line": 2496,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53228,19 +53316,19 @@
       },
       {
         "kind": "dict",
-        "line": 1138,
+        "line": 1140,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1127,
+        "line": 1129,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1600,
+        "line": 1576,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "68637353f55758d398c27f89be0ee7c1b52f7389",
+    "base_commit": "40e8d940483e265d5a46b2bce1bd8fea83672550",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -38,7 +38,8 @@
       "B-11c6",
       "B-11c7a",
       "B-11c7b",
-      "B-11c8"
+      "B-11c8",
+      "B-11c9"
     ]
   },
   "enums": {
@@ -73,11 +74,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 7,
-    "nodes_canonical_bindings": 275,
+    "nodes_canonical_bindings": 276,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 31,
+    "root_residual_functions": 30,
     "root_residual_classes": 0,
     "root_residual_globals": 28,
     "runtime_binders": 28,
@@ -168,6 +169,7 @@
       "easyuse_anima.aio.generation_normalization"
     ],
     "AIO_INPUT_DEFAULT_SETTINGS": [
+      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "AIO_PREVIEW_CACHE_FORMAT": [
@@ -211,6 +213,9 @@
     "AIO_USDU_SEAM_FIX_MODES": [
       "easyuse_anima.aio.generation_normalization"
     ],
+    "ANIMA_CLIP_DEVICES": [
+      "easyuse_anima.aio.resources"
+    ],
     "ANIMA_DEFAULT_CLIP_CANDIDATES": [
       "easyuse_anima.nodes.aio_nodes"
     ],
@@ -233,6 +238,9 @@
     "ANIMA_MOD_GUIDANCE_PROFILE_OFF": [
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.sampling"
+    ],
+    "ANIMA_UNET_WEIGHT_DTYPES": [
+      "easyuse_anima.aio.resources"
     ],
     "ARTIST_MIX_DEFAULT_CLUSTER_COUNT": [
       "easyuse_anima.aio.generation_normalization"
@@ -265,9 +273,11 @@
       "easyuse_anima.aio.generation_normalization"
     ],
     "EASY_USE_ANIMA_INPUT_SCHEMA": [
+      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION": [
+      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "EASY_USE_ANIMA_INPUT_TYPE": [
@@ -491,6 +501,7 @@
       "easyuse_anima.aio.generation_normalization",
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.output",
+      "easyuse_anima.aio.resources",
       "easyuse_anima.aio.sampling",
       "easyuse_anima.lora.preset",
       "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -730,6 +741,9 @@
     "_lora_stack_name": [
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.nodes.lora_nodes"
+    ],
+    "_merge_versioned_settings": [
+      "easyuse_anima.aio.resources"
     ],
     "_metadata_filter_key": [
       "easyuse_anima.prompt.fields"
@@ -1919,6 +1933,7 @@
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
+        "canonical runtime resolver: easyuse_anima.aio.resources",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
@@ -1926,6 +1941,7 @@
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
+        "AST:easyuse_anima.aio.resources string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
@@ -2168,6 +2184,7 @@
         "_load_diffusion_model_with_comfy": "_load_diffusion_model_with_comfy",
         "_load_upscale_model_with_comfy": "_load_upscale_model_with_comfy",
         "_load_vae_with_comfy": "_load_vae_with_comfy",
+        "_normalize_aio_input_settings": "_normalize_aio_input_settings",
         "_preferred_checkpoint_default": "_preferred_checkpoint_default",
         "_preferred_clip_type_default": "_preferred_clip_type_default",
         "_preferred_name_default": "_preferred_name_default"
@@ -4004,7 +4021,6 @@
         "_find_comfy_node_mapping_class": "_find_comfy_node_mapping_class",
         "_find_loaded_node_class": "_find_loaded_node_class",
         "_is_aio_detailer_target_name": "_is_aio_detailer_target_name",
-        "_normalize_aio_input_settings": "_normalize_aio_input_settings",
         "_require_any_custom_node_class": "_require_any_custom_node_class",
         "_require_custom_node_class": "_require_custom_node_class",
         "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -21,6 +21,7 @@ import nodes
 from easyuse_anima import workflow
 from easyuse_anima.aio import (
     generation_normalization as aio_generation_normalization,
+    resources as aio_resources,
     sampling as aio_sampling,
 )
 from easyuse_anima.aio import model_preparation as aio_model_preparation
@@ -994,6 +995,91 @@ class AioWidgetDefaultSerializerMoveContractTests(unittest.TestCase):
             package_name = package_nodes.__package__
             package_aio_nodes = sys.modules[f"{package_name}.easyuse_anima.nodes.aio_nodes"]
             self._assert_contract(package_nodes, package_aio_nodes)
+
+
+class AioInputSettingsNormalizerMoveContractTests(unittest.TestCase):
+    def _assert_contract(self, root_module, canonical_module):
+        self.assertIs(
+            root_module._normalize_aio_input_settings,
+            canonical_module._normalize_aio_input_settings,
+        )
+
+        defaults = {"default": "sentinel"}
+        merged = {
+            "version": "legacy-version",
+            "resources": {
+                "clip_loader": "legacy-loader",
+                "unet_weight_dtype": "legacy-dtype",
+                "clip_device": "legacy-device",
+            },
+            "future": {"kept": True},
+        }
+        merge_calls = []
+        as_int_calls = []
+        choice_calls = []
+
+        def merge_versioned_settings(current_defaults, value):
+            merge_calls.append((current_defaults, value))
+            return merged
+
+        def as_int(value, default):
+            as_int_calls.append((value, default))
+            return 9
+
+        def choice(value, choices, default):
+            choice_calls.append((value, choices, default))
+            return f"normalized:{value}"
+
+        with (
+            patch.object(
+                root_module,
+                "_merge_versioned_settings",
+                merge_versioned_settings,
+            ),
+            patch.object(root_module, "AIO_INPUT_DEFAULT_SETTINGS", defaults),
+            patch.object(root_module, "EASY_USE_ANIMA_INPUT_SCHEMA", "input-schema"),
+            patch.object(root_module, "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION", 7),
+            patch.object(root_module, "_as_int", as_int),
+            patch.object(root_module, "_choice", choice),
+            patch.object(root_module, "ANIMA_UNET_WEIGHT_DTYPES", ("dtype-a",)),
+            patch.object(root_module, "ANIMA_CLIP_DEVICES", ("device-a",)),
+        ):
+            result = canonical_module._normalize_aio_input_settings("payload")
+
+        self.assertIs(result, merged)
+        self.assertEqual(merge_calls, [(defaults, "payload")])
+        self.assertEqual(as_int_calls, [("legacy-version", 7)])
+        self.assertEqual(
+            choice_calls,
+            [
+                ("legacy-loader", ("single",), "single"),
+                ("legacy-dtype", ("dtype-a",), "default"),
+                ("legacy-device", ("device-a",), "default"),
+            ],
+        )
+        self.assertEqual(result["schema"], "input-schema")
+        self.assertEqual(result["version"], 9)
+        self.assertEqual(
+            result["resources"],
+            {
+                "loader_mode": "split",
+                "clip_loader": "normalized:legacy-loader",
+                "unet_weight_dtype": "normalized:legacy-dtype",
+                "clip_device": "normalized:legacy-device",
+            },
+        )
+        self.assertEqual(result["future"], {"kept": True})
+
+    def test_root_alias_and_call_time_input_contract(self):
+        self._assert_contract(nodes, aio_resources)
+
+    def test_package_alias_and_call_time_input_contract(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_resources = sys.modules[
+                f"{package_name}.easyuse_anima.aio.resources"
+            ]
+            self._assert_contract(package_nodes, package_resources)
 
 
 class ComfyAdapterMoveContractTests(unittest.TestCase):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "854c9a489b82d613448a3de64f57f66f914d60e9")
-        # Issue #184 B-11c8 moves the two AiO hidden-widget JSON serializers
-        # while preserving direct aliases and call-time root default seams.
-        self.assertEqual(report["top_level"]["function_count"], 31)
+        self.assertEqual(report["git_blob_sha1"], "9be894acf8166835ea08863c3ea928120d573a0c")
+        # Issue #184 B-11c9 moves the AiO input-settings normalizer while
+        # preserving direct alias identity and call-time root settings seams.
+        self.assertEqual(report["top_level"]["function_count"], 30)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_524)
+        self.assertEqual(report["line_count"], 2_500)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "68637353f55758d398c27f89be0ee7c1b52f7389"
+BASE_COMMIT = "40e8d940483e265d5a46b2bce1bd8fea83672550"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1312,6 +1312,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c7a",
                 "B-11c7b",
                 "B-11c8",
+                "B-11c9",
             ],
         },
         "enums": {
@@ -1324,11 +1325,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 7,
-            "nodes_canonical_bindings": 275,
+            "nodes_canonical_bindings": 276,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 31,
+            "root_residual_functions": 30,
             "root_residual_classes": 0,
             "root_residual_globals": 28,
             "runtime_binders": 28,


### PR DESCRIPTION
## 변경 요약

- B-11c9에서 `_normalize_aio_input_settings`의 소유권만 `easyuse_anima.aio.resources`로 이동합니다.
- root `nodes.py`의 relative/flat import는 canonical 함수의 direct alias identity를 유지합니다.
- input schema/default, dtype/device choice, caller, binder, widget/workflow 동작은 변경하지 않습니다.

## 작업 전 인벤토리

### Symbol

- root `_normalize_aio_input_settings(value)`: versioned defaults merge 후 input schema/version과 resource loader 선택값을 정규화합니다.
- I/O, cache, RNG, Comfy provider 호출은 수행하지 않습니다.

### Caller

- `easyuse_anima.aio.resources._load_aio_resources_from_input_context`
- `easyuse_anima.nodes.aio_nodes.EasyUseAnimaInput.IS_CHANGED`
- `easyuse_anima.nodes.aio_nodes.EasyUseAnimaInput.build`
- 세 caller 모두 기존 `_runtime_helper("_normalize_aio_input_settings")` 경로를 사용합니다.

### Alias / compatibility

- 작업 전 함수는 root definition이며 canonical alias가 없습니다.
- 작업 후 relative/flat `aio.resources` import가 동일한 canonical 함수 객체를 직접 가리켜야 합니다.
- 세 caller와 `_bind_aio_resource_runtime`/`_bind_aio_node_runtime`의 resolver signature는 변경하지 않습니다.

### Global state

- 호출 시 참조하는 root 이름은 `_merge_versioned_settings`, `AIO_INPUT_DEFAULT_SETTINGS`, `EASY_USE_ANIMA_INPUT_SCHEMA`, `EASY_USE_ANIMA_INPUT_SETTINGS_VERSION`, `_as_int`, `_choice`, `ANIMA_UNET_WEIGHT_DTYPES`, `ANIMA_CLIP_DEVICES`입니다.
- canonical 함수는 기존 resource runtime resolver로 이 이름들을 호출 시점에 조회합니다.
- mutable default dict는 읽기만 하며, merge 결과 dict만 정규화합니다. 새 global, cache, binder, import side effect는 만들지 않습니다.

## Allowed-file boundary

- `easyuse_anima/aio/resources.py`
- `nodes.py`
- `tests/test_node_contracts.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 금지 경계

- input schema/version/default 값과 unknown-key 보존을 변경하지 않습니다.
- `loader_mode="split"`, `clip_loader="single"`, dtype/device choice 목록 및 fallback 순서를 변경하지 않습니다.
- defaults를 이동·복제하거나 merge/copy/mutation 의미를 바꾸지 않습니다.
- caller를 direct canonical call로 바꾸거나 binder/resolver signature를 변경하지 않습니다.
- typed settings, widget/workflow serialization, generation settings, stage/cache/seed Behavior를 포함하지 않습니다.

## 검증 결과

- focused unittest: 51개 통과
  - 새 Move contract
  - 기존 AiO input settings/resource contract
  - compatibility/analyzer/import boundary
- `git diff --check`: 통과 (줄 끝 변환 안내만 출력)
- exact-head full (`0a1c2cd082b35850103612586609e47741282b93`): 통과
  - Python unittest: 902개 통과
  - frontend: JavaScript 114개 및 TypeScript 6.0.3 통과
  - Pyright baseline ratchet: 통과
  - Python import boundary gate: 통과
  - Ruff: 107건 report-only, G-01 비차단 부채
- 독립 read-only 코드 리뷰: production/test 지적 사항 없음
  - 문서의 runtime-resolver root-name 수치 256→263 보정 완료

## 테스트 표면

- ComfyUI Codex test infrastructure: repository-owned static/unit/full validation
- Live ComfyUI smoke: 미실행 (Move-only이며 Phase B exit checkpoint에서 수행)

## 남은 위험 / 미확인

- input/generation default settings의 canonical owner는 별도 Contract/Move로 남습니다.
- 생성 baseline은 변경 entry와 invariant count 중심으로 검토했으며 전체 줄을 수동 대조하지는 않았습니다.
- GitHub Actions check는 별도로 확인합니다.

Closes no issue; tracks #184.
