### PR TITLE
refactor: retire unused root settings JSON helper

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `40e8d940483e265d5a46b2bce1bd8fea83672550`
+- Integrated `dev` snapshot commit: `7222f7dda96be87749f008571d7d1d7237eb9ee9`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c8 / `40e8d94`; B-11c9 input-settings normalizer Move in PR #303 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c9 / `7222f7d`; B-11c10 dead root helper cleanup in PR #304 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,524
-  lines after B-11c8.
-- The mechanical extraction has removed 10,139
-  lines, approximately 80.1% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,500
+  lines after B-11c9.
+- The mechanical extraction has removed 10,163
+  lines, approximately 80.3% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -67,7 +67,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   interpretation in PR #301 / `6863735`. B-11c8 moved only the two hidden-widget
   default JSON serializers in PR #302 / `40e8d94`. B-11c9 moves only the input-
   settings normalizer to the existing resource owner in PR #303; mutable defaults
-  and schema ownership stay separate.
+  and schema ownership stay separate. B-11c10 removes only the unused private
+  root `_settings_json` definition in PR #304; live serializers remain unchanged.
 
 ### Current quality baseline
 
@@ -309,7 +310,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 input normalizer PR #303 | Move, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 dead helper cleanup PR #304 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -856,6 +857,11 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     merge, schema/version, coercion helper, dtype, and device replacement.
     Defaults/schema ownership, typed settings, widget serialization, and resource
     loading behavior remain separate.
+  - B-11c10 removes only the unused private root `_settings_json` definition.
+    PR #304 records an explicit absence contract instead of inventing a
+    canonical owner for a symbol with no production, resolver, test-import, or
+    documented compatibility consumer. Root `json` and both live hidden-widget
+    serializers remain unchanged.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,15 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `40e8d940483e265d5a46b2bce1bd8fea83672550`
+  `7222f7dda96be87749f008571d7d1d7237eb9ee9`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c8 are integrated through PR #302. B-11c is
-  split into residual-owner and binder Moves before the final root shim;
-  B-11c9 AiO input-settings normalizer ownership is tracked by PR #303.
+- Current state: B-11a through B-11c9 are integrated through PR #303. B-11c is
+  split into residual-owner Moves and explicit private-contract cleanup before
+  the final root shim; B-11c10 dead `_settings_json` retirement is tracked by
+  PR #304.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -84,8 +85,8 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 30 functions, 0 classes, and 28 assigned
-  globals after B-11c9 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 29 functions, 0 classes, and 28 assigned
+  globals after B-11c10 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 263, including
   literal lookups and binder-owned helper-name/default collections;
@@ -297,6 +298,18 @@ convenience-node compatibility; it remains unmapped and is not public support.
   the single clip-loader choice, and dtype/device fallback order. It does not
   move defaults or schemas, add typed settings, or change widget, workflow,
   resource-loading, cache, seed, or stage behavior.
+
+### B-11c10 dead root JSON helper retirement
+
+- `_settings_json` was a root-only private definition with no production caller,
+  runtime resolver, binder, test import, documented compatibility consumer, or
+  canonical target. It is therefore removed rather than promoted into the
+  canonical package.
+- The compatibility fixture and flat/package contract record its absence.
+  Root `json`, `_aio_input_settings_json`, and `_aio_generation_settings_json`
+  remain present and unchanged.
+- PR #304 changes no JSON shape, default, schema, widget/workflow serialization,
+  registration/bootstrap, stage, cache, seed, or resource behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/nodes.py
+++ b/nodes.py
@@ -1569,10 +1569,6 @@ AIO_RESHIFT_DTYPES = ("bf16", "fp32")
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
 
 
-def _settings_json(defaults: dict[str, Any]) -> str:
-    return json.dumps(defaults, ensure_ascii=False, indent=2)
-
-
 _AIO_DETAILER_RESERVED_KEYS = {"enabled", "order", "sam3"}
 _AIO_DETAILER_CUSTOM_RE = re.compile(r"^custom_\d+$")
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -33928,7 +33928,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1618
+            "line": 1614
           }
         ],
         "classification": "external",
@@ -33936,7 +33936,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1619,
+        "line": 1615,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33953,7 +33953,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1655
+            "line": 1651
           }
         ],
         "classification": "external",
@@ -33961,7 +33961,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1656,
+        "line": 1652,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -33978,7 +33978,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1663
+            "line": 1659
           }
         ],
         "classification": "external",
@@ -33986,7 +33986,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1664,
+        "line": 1660,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -37574,13 +37574,13 @@
       },
       {
         "is_package": false,
-        "loc": 2500,
+        "loc": 2496,
         "module": "nodes",
-        "normalized_git_blob_sha1": "9be894acf8166835ea08863c3ea928120d573a0c",
+        "normalized_git_blob_sha1": "b8e8016f22e7f4ee69aabd15491803b0126fd879",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 30,
+          "function_count": 29,
           "global_count": 28
         }
       },
@@ -49634,14 +49634,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1618
+            "line": 1614
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1619,
+        "line": 1615,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49653,14 +49653,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1655
+            "line": 1651
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1656,
+        "line": 1652,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -49672,14 +49672,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1663
+            "line": 1659
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1664,
+        "line": 1660,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51054,14 +51054,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1618
+            "line": 1614
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1619,
+        "line": 1615,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51073,14 +51073,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1655
+            "line": 1651
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1656,
+        "line": 1652,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51092,14 +51092,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1663
+            "line": 1659
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1664,
+        "line": 1660,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52556,7 +52556,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1577,
+        "line": 1573,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52565,7 +52565,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2402,
+        "line": 2398,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52574,7 +52574,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2405,
+        "line": 2401,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52583,7 +52583,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2408,
+        "line": 2404,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52592,7 +52592,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2411,
+        "line": 2407,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52601,7 +52601,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2414,
+        "line": 2410,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52610,7 +52610,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2417,
+        "line": 2413,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52619,7 +52619,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2420,
+        "line": 2416,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52628,7 +52628,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2423,
+        "line": 2419,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52637,7 +52637,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2426,
+        "line": 2422,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52646,7 +52646,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2429,
+        "line": 2425,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52655,7 +52655,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2432,
+        "line": 2428,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52664,7 +52664,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2435,
+        "line": 2431,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52673,7 +52673,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2438,
+        "line": 2434,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52682,7 +52682,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2441,
+        "line": 2437,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52691,7 +52691,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2445,
+        "line": 2441,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52700,7 +52700,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2448,
+        "line": 2444,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52709,7 +52709,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2452,
+        "line": 2448,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52718,7 +52718,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2455,
+        "line": 2451,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52727,7 +52727,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2459,
+        "line": 2455,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52736,7 +52736,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2462,
+        "line": 2458,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52745,7 +52745,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2465,
+        "line": 2461,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52754,7 +52754,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2468,
+        "line": 2464,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52763,7 +52763,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2471,
+        "line": 2467,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52772,7 +52772,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2474,
+        "line": 2470,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52781,7 +52781,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2481,
+        "line": 2477,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52790,7 +52790,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2487,
+        "line": 2483,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52799,7 +52799,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2492,
+        "line": 2488,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -52808,7 +52808,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2496,
+        "line": 2492,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53328,7 +53328,7 @@
       },
       {
         "kind": "set",
-        "line": 1576,
+        "line": 1572,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "40e8d940483e265d5a46b2bce1bd8fea83672550",
+    "base_commit": "7222f7dda96be87749f008571d7d1d7237eb9ee9",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -39,7 +39,8 @@
       "B-11c7a",
       "B-11c7b",
       "B-11c8",
-      "B-11c9"
+      "B-11c9",
+      "B-11c10"
     ]
   },
   "enums": {
@@ -78,7 +79,7 @@
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 30,
+    "root_residual_functions": 29,
     "root_residual_classes": 0,
     "root_residual_globals": 28,
     "runtime_binders": 28,
@@ -4030,8 +4031,7 @@
         "_run_aio_postprocess_stage": "_run_aio_postprocess_stage",
         "_run_aio_resshift_upscale_stage": "_run_aio_resshift_upscale_stage",
         "_run_aio_upscale_stage": "_run_aio_upscale_stage",
-        "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage",
-        "_settings_json": "_settings_json"
+        "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -997,6 +997,20 @@ class AioWidgetDefaultSerializerMoveContractTests(unittest.TestCase):
             self._assert_contract(package_nodes, package_aio_nodes)
 
 
+class AioSettingsJsonRetirementContractTests(unittest.TestCase):
+    def _assert_contract(self, root_module):
+        self.assertFalse(hasattr(root_module, "_settings_json"))
+        self.assertTrue(callable(root_module._aio_input_settings_json))
+        self.assertTrue(callable(root_module._aio_generation_settings_json))
+
+    def test_flat_root_has_no_dead_settings_json_helper(self):
+        self._assert_contract(nodes)
+
+    def test_package_root_has_no_dead_settings_json_helper(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            self._assert_contract(package_nodes)
+
+
 class AioInputSettingsNormalizerMoveContractTests(unittest.TestCase):
     def _assert_contract(self, root_module, canonical_module):
         self.assertIs(

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "9be894acf8166835ea08863c3ea928120d573a0c")
-        # Issue #184 B-11c9 moves the AiO input-settings normalizer while
-        # preserving direct alias identity and call-time root settings seams.
-        self.assertEqual(report["top_level"]["function_count"], 30)
+        self.assertEqual(report["git_blob_sha1"], "b8e8016f22e7f4ee69aabd15491803b0126fd879")
+        # Issue #184 B-11c10 retires the unused root-only _settings_json helper
+        # without changing either live hidden-widget JSON serializer.
+        self.assertEqual(report["top_level"]["function_count"], 29)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_500)
+        self.assertEqual(report["line_count"], 2_496)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "40e8d940483e265d5a46b2bce1bd8fea83672550"
+BASE_COMMIT = "7222f7dda96be87749f008571d7d1d7237eb9ee9"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1313,6 +1313,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c7b",
                 "B-11c8",
                 "B-11c9",
+                "B-11c10",
             ],
         },
         "enums": {
@@ -1329,7 +1330,7 @@ def _build_document() -> dict[str, Any]:
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 30,
+            "root_residual_functions": 29,
             "root_residual_classes": 0,
             "root_residual_globals": 28,
             "runtime_binders": 28,


### PR DESCRIPTION
## 변경 요약

- B-11c10에서 생산 caller가 없는 root residual `_settings_json`만 제거합니다.
- canonical module이나 새 alias를 만들지 않는 Contract/cleanup입니다.
- 실제 hidden-widget serializer와 JSON 형식, schema/default, registration/bootstrap은 변경하지 않습니다.

## 작업 전 인벤토리

### Symbol

- `nodes.py::_settings_json(defaults)`: `json.dumps(defaults, ensure_ascii=False, indent=2)`를 반환합니다.
- 최초 AiO draft에서 추가됐지만 호출 경로가 연결된 적이 없는 private root residual입니다.

### Caller

- production caller: 없음
- test direct caller/import: 없음
- runtime resolver/binder/monkeypatch seam: 없음
- 문서화된 외부 소비자 또는 public compatibility 근거: 없음

### Alias / compatibility

- root definition만 존재하며 canonical target과 relative/flat alias는 없습니다.
- machine-readable compatibility fixture의 `nodes_root_residuals:functions`에만 기록됩니다.
- 제거 후 fixture의 exact residual 목록과 별도 flat/package absence contract가 재도입을 차단합니다.

### Global state

- 읽는 이름은 root `json`뿐이며 상태를 변경하지 않습니다.
- root `json` import는 다른 잔여 구현이 사용하므로 유지합니다.
- mutable state, cache, I/O, RNG, optional dependency, import-time side effect가 없습니다.

## Allowed-file boundary

- `nodes.py`
- `tests/test_node_contracts.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 금지 경계

- `_settings_json`을 canonical module로 이동하거나 새 root alias로 바꾸지 않습니다.
- `_aio_input_settings_json`, `_aio_generation_settings_json`과 compact JSON 형식을 변경하지 않습니다.
- root `json` import, `__all__`, schema/default ownership, widget/workflow serialization을 변경하지 않습니다.
- registration/bootstrap, stage/cache/seed/resource 동작을 변경하지 않습니다.
- 테스트 import를 public compatibility 근거로 승격하지 않습니다.

## 검증 결과

- focused unittest: 44개 통과
  - flat/package absence contract
  - 기존 live widget serializer contract
  - compatibility/analyzer/import boundary
- repository-wide exact-word search: 생산 caller/import/resolver/alias 없음
- `git diff --check`: 통과 (줄 끝 변환 안내만 출력)
- exact-head full (`c6631c4b84d13bf622ac70fa6b454d8acd83c6da`): 통과
  - Python unittest: 904개 통과
  - frontend: JavaScript 114개 및 TypeScript 6.0.3 통과
  - Pyright baseline ratchet: 통과
  - Python import boundary gate: 통과
  - Ruff: 107건 report-only, G-01 비차단 부채
- 독립 read-only 코드 리뷰: 지적 사항 없음

## 테스트 표면

- ComfyUI Codex test infrastructure: repository-owned static/unit/full validation
- Live ComfyUI smoke: 미실행 (dead private Contract이며 Phase B exit checkpoint에서 수행)

## 남은 위험 / 미확인

- 외부 private import 근거는 확인되지 않았습니다. `_settings_json`은 공개 node/workflow/API 계약이 아닙니다.
- 생성 baseline은 변경 entry와 invariant count 중심으로 검토했으며 전체 줄을 수동 대조하지는 않았습니다.
- GitHub Actions check는 별도로 확인합니다.

Closes no issue; tracks #184.
