### PR TITLE
refactor: move USDU tile planning helpers

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `236a7f529f786c19a8bd0bcd34fd02d38b9d8af6`
+- Integrated `dev` snapshot commit: `98812ef070096e7416bba08750a7c089f8564d29`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c10 / `236a7f5`; B-11c11 Detailer normalization Move in PR #305 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c11 / `98812ef`; B-11c12 USDU tile-planning Move in PR #306 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,496
-  lines after B-11c10.
-- The mechanical extraction has removed 10,167
-  lines, approximately 80.3% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,464
+  lines after B-11c11.
+- The mechanical extraction has removed 10,199
+  lines, approximately 80.5% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -69,8 +69,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   settings normalizer to the existing resource owner in PR #303; mutable defaults
   and schema ownership stay separate. B-11c10 removed only the unused private
   root `_settings_json` definition in PR #304 / `236a7f5`; live serializers
-  remain unchanged. B-11c11 moves only the five Detailer target normalization
-  symbols to their existing generation-normalization owner in PR #305.
+  remain unchanged. B-11c11 moved only the five Detailer target normalization
+  symbols to their existing generation-normalization owner in PR #305 /
+  `98812ef`. B-11c12 moves only the two live USDU tile planners to a dedicated
+  owner in PR #306; the dead tile-size wrapper remains separate.
 
 ### Current quality baseline
 
@@ -312,7 +314,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 Detailer normalization Move PR #305 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 USDU tile-planning Move PR #306 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -872,6 +874,13 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     replacement, regex matching, trim/deduplication/order rules, deep cloning,
     and custom label suffix behavior. Detailer execution, enabled gating,
     schema/default ownership, SAM3, and Impact behavior remain separate.
+  - B-11c12 moves only `_aio_usdu_auto_tile_dimension` and
+    `_aio_usdu_tile_plan` to the dedicated `easyuse_anima.aio.usdu` owner. PR
+    #306 retains direct root alias identity and call-time root `ceil`, alignment,
+    image-size, coercion, and nested auto-dimension replacement. Tile clamp,
+    fallback, scale, rounding, dict order, and stage behavior remain unchanged.
+    The unused `_aio_usdu_tile_size` wrapper remains root-owned for a separate
+    Contract/cleanup decision.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,15 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `236a7f529f786c19a8bd0bcd34fd02d38b9d8af6`
+  `98812ef070096e7416bba08750a7c089f8564d29`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c10 are integrated through PR #304. B-11c is
+- Current state: B-11a through B-11c11 are integrated through PR #305. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c11 Detailer target normalization is tracked by PR
-  #305.
+  the final root shim; B-11c12 USDU tile planning is tracked by PR #306.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -76,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 281 in B-11c11
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 284 in B-11c12
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -85,10 +84,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 26 functions, 0 classes, and 26 assigned
-  globals in B-11c11 (41/2/33 at the integrated B-10b20 baseline).
-- import-time runtime binders: 28 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 266, including
+- root-owned residual implementation: 24 functions, 0 classes, and 26 assigned
+  globals in B-11c12 (41/2/33 at the integrated B-10b20 baseline).
+- import-time runtime binders: 29 exact top-level `_bind_*_runtime` calls;
+- root names reached by those canonical runtime resolvers: 268, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -329,6 +328,23 @@ convenience-node compatibility; it remains unmapped and is not public support.
   face/eye order, reserved/non-dict exclusion, deep cloning, and custom numeric
   label suffixes. It does not move or change Detailer execution/enabled gates,
   schema/default ownership, SAM3, Impact, USDU, or final-fit behavior.
+
+### B-11c12 AiO USDU tile-planning aliases
+
+- Canonical owner: `easyuse_anima.aio.usdu` for
+  `_aio_usdu_auto_tile_dimension` and `_aio_usdu_tile_plan`.
+- The two private root names remain transitional direct aliases in both
+  relative package and flat import modes. The root USDU stage and retained dead
+  tile-size wrapper keep calling the root tile-plan alias.
+- The dedicated USDU planning binder resolves root `ceil`, `_align_nearest`,
+  `_image_tensor_size`, `_as_bool`, `_as_int`, and the nested auto-dimension
+  helper at call time. Root binding replacement remains visible without
+  importing root `nodes` from the canonical package.
+- PR #306 preserves clamp and alignment order, the two `ceil` calls, image-size
+  fallback, scale floor and rounding, manual/auto return fields and insertion
+  order, and input non-mutation. It does not move USDU model loading,
+  conditioning, sampling, logging, metadata, or stage execution. The unused
+  `_aio_usdu_tile_size` stays root-owned pending separate cleanup.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/usdu.py
+++ b/easyuse_anima/aio/usdu.py
@@ -1,0 +1,108 @@
+"""Ultimate SD Upscale tile-planning policy."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeAlias
+
+_RuntimeResolver: TypeAlias = Callable[[str], Any]
+_RUNTIME_RESOLVER: _RuntimeResolver | None = None
+
+
+def _bind_aio_usdu_planning_runtime(*, resolve_helper: _RuntimeResolver) -> None:
+    """Bind root compatibility helpers without importing the root module."""
+
+    global _RUNTIME_RESOLVER
+    _RUNTIME_RESOLVER = resolve_helper
+
+
+def _runtime_helper(name: str) -> Any:
+    resolver = _RUNTIME_RESOLVER
+    if resolver is None:
+        raise RuntimeError(
+            f"[EasyUseAnima] AiO USDU planning runtime helper is not bound: {name}"
+        )
+    return resolver(name)
+
+
+def _aio_usdu_auto_tile_dimension(
+    target_size: int,
+    preferred_size: int = 1024,
+    min_size: int = 512,
+    max_size: int = 2048,
+) -> int:
+    target_size = max(1, int(target_size))
+    min_size = max(64, int(min_size))
+    max_size = max(min_size, int(max_size))
+    preferred = max(min_size, min(max_size, int(preferred_size)))
+    tile_count = max(1, _runtime_helper("ceil")(target_size / preferred))
+    tile_size = _runtime_helper("ceil")(target_size / tile_count)
+    tile_size = _runtime_helper("_align_nearest")(tile_size, 64)
+    return max(min_size, min(max_size, tile_size))
+
+
+def _aio_usdu_tile_plan(
+    image,
+    scale_by: float,
+    usdu_settings: dict[str, Any],
+) -> dict[str, Any]:
+    width, height = _runtime_helper("_image_tensor_size")(image, 512, 512)
+    target_width = max(1, int(round(width * max(0.05, float(scale_by)))))
+    target_height = max(1, int(round(height * max(0.05, float(scale_by)))))
+    auto_tile = _runtime_helper("_as_bool")(
+        usdu_settings.get("auto_tile_size"),
+        True,
+    )
+    if not auto_tile:
+        return {
+            "auto": False,
+            "input_width": int(width),
+            "input_height": int(height),
+            "target_width": int(target_width),
+            "target_height": int(target_height),
+            "tile_width": _runtime_helper("_as_int")(
+                usdu_settings.get("tile_width"),
+                512,
+            ),
+            "tile_height": _runtime_helper("_as_int")(
+                usdu_settings.get("tile_height"),
+                512,
+            ),
+        }
+    preferred = _runtime_helper("_as_int")(
+        usdu_settings.get("auto_tile_target"),
+        1024,
+    )
+    min_size = _runtime_helper("_as_int")(
+        usdu_settings.get("auto_tile_min"),
+        512,
+    )
+    max_size = _runtime_helper("_as_int")(
+        usdu_settings.get("auto_tile_max"),
+        2048,
+    )
+    return {
+        "auto": True,
+        "input_width": int(width),
+        "input_height": int(height),
+        "target_width": int(target_width),
+        "target_height": int(target_height),
+        "preferred": int(preferred),
+        "min": int(min_size),
+        "max": int(max_size),
+        "tile_width": _runtime_helper("_aio_usdu_auto_tile_dimension")(
+            target_width,
+            preferred,
+            min_size,
+            max_size,
+        ),
+        "tile_height": _runtime_helper("_aio_usdu_auto_tile_dimension")(
+            target_height,
+            preferred,
+            min_size,
+            max_size,
+        ),
+    }
+
+
+__all__ = ()

--- a/nodes.py
+++ b/nodes.py
@@ -43,6 +43,11 @@ try:
     from .easyuse_anima.aio.generation_settings import (
         round_trip_aio_generation_settings as _round_trip_aio_generation_settings,
     )
+    from .easyuse_anima.aio.usdu import (
+        _aio_usdu_auto_tile_dimension as _aio_usdu_auto_tile_dimension,
+        _aio_usdu_tile_plan as _aio_usdu_tile_plan,
+        _bind_aio_usdu_planning_runtime as _bind_aio_usdu_planning_runtime,
+    )
     from .easyuse_anima.aio.conditioning import (
         _aio_prompt_data_fields_for_usdu as _aio_prompt_data_fields_for_usdu,
         _aio_usdu_conditioning as _aio_usdu_conditioning,
@@ -580,6 +585,11 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     )
     from easyuse_anima.aio.generation_settings import (
         round_trip_aio_generation_settings as _round_trip_aio_generation_settings,
+    )
+    from easyuse_anima.aio.usdu import (
+        _aio_usdu_auto_tile_dimension as _aio_usdu_auto_tile_dimension,
+        _aio_usdu_tile_plan as _aio_usdu_tile_plan,
+        _bind_aio_usdu_planning_runtime as _bind_aio_usdu_planning_runtime,
     )
     from easyuse_anima.aio.conditioning import (
         _aio_prompt_data_fields_for_usdu as _aio_prompt_data_fields_for_usdu,
@@ -1751,54 +1761,6 @@ def _run_aio_highres_stage(
     }
 
 
-def _aio_usdu_auto_tile_dimension(
-    target_size: int,
-    preferred_size: int = 1024,
-    min_size: int = 512,
-    max_size: int = 2048,
-) -> int:
-    target_size = max(1, int(target_size))
-    min_size = max(64, int(min_size))
-    max_size = max(min_size, int(max_size))
-    preferred = max(min_size, min(max_size, int(preferred_size)))
-    tile_count = max(1, ceil(target_size / preferred))
-    tile_size = ceil(target_size / tile_count)
-    tile_size = _align_nearest(tile_size, 64)
-    return max(min_size, min(max_size, tile_size))
-
-
-def _aio_usdu_tile_plan(image, scale_by: float, usdu_settings: dict[str, Any]) -> dict[str, Any]:
-    width, height = _image_tensor_size(image, 512, 512)
-    target_width = max(1, int(round(width * max(0.05, float(scale_by)))))
-    target_height = max(1, int(round(height * max(0.05, float(scale_by)))))
-    auto_tile = _as_bool(usdu_settings.get("auto_tile_size"), True)
-    if not auto_tile:
-        return {
-            "auto": False,
-            "input_width": int(width),
-            "input_height": int(height),
-            "target_width": int(target_width),
-            "target_height": int(target_height),
-            "tile_width": _as_int(usdu_settings.get("tile_width"), 512),
-            "tile_height": _as_int(usdu_settings.get("tile_height"), 512),
-        }
-    preferred = _as_int(usdu_settings.get("auto_tile_target"), 1024)
-    min_size = _as_int(usdu_settings.get("auto_tile_min"), 512)
-    max_size = _as_int(usdu_settings.get("auto_tile_max"), 2048)
-    return {
-        "auto": True,
-        "input_width": int(width),
-        "input_height": int(height),
-        "target_width": int(target_width),
-        "target_height": int(target_height),
-        "preferred": int(preferred),
-        "min": int(min_size),
-        "max": int(max_size),
-        "tile_width": _aio_usdu_auto_tile_dimension(target_width, preferred, min_size, max_size),
-        "tile_height": _aio_usdu_auto_tile_dimension(target_height, preferred, min_size, max_size),
-    }
-
-
 def _aio_usdu_tile_size(image, scale_by: float, usdu_settings: dict[str, Any]) -> tuple[int, int]:
     tile_plan = _aio_usdu_tile_plan(image, scale_by, usdu_settings)
     return int(tile_plan["tile_width"]), int(tile_plan["tile_height"])
@@ -2370,6 +2332,9 @@ _bind_aio_legacy_generation_runtime(
     resolve_helper=lambda name: globals()[name],
 )
 _bind_aio_generation_normalization_runtime(
+    resolve_helper=lambda name: globals()[name],
+)
+_bind_aio_usdu_planning_runtime(
     resolve_helper=lambda name: globals()[name],
 )
 _bind_aio_resource_runtime(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6822,6 +6822,74 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TypeAlias",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TypeAlias",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/bootstrap.py"
       },
       {
@@ -15031,6 +15099,99 @@
         "target": "easyuse_anima/aio/generation_settings.py"
       },
       {
+        "alias": "_aio_usdu_auto_tile_dimension",
+        "bound_name": "_aio_usdu_auto_tile_dimension",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_aio_usdu_auto_tile_dimension",
+          "target": "easyuse_anima/aio/usdu.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
+        "kind": "static_from",
+        "line": 46,
+        "name": "_aio_usdu_auto_tile_dimension",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.usdu",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "alias": "_aio_usdu_tile_plan",
+        "bound_name": "_aio_usdu_tile_plan",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_aio_usdu_tile_plan",
+          "target": "easyuse_anima/aio/usdu.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
+        "kind": "static_from",
+        "line": 46,
+        "name": "_aio_usdu_tile_plan",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.usdu",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "alias": "_bind_aio_usdu_planning_runtime",
+        "bound_name": "_bind_aio_usdu_planning_runtime",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_aio_usdu_planning_runtime",
+          "target": "easyuse_anima/aio/usdu.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
+        "kind": "static_from",
+        "line": 46,
+        "name": "_bind_aio_usdu_planning_runtime",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.usdu",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/usdu.py"
+      },
+      {
         "alias": "_aio_prompt_data_fields_for_usdu",
         "bound_name": "_aio_prompt_data_fields_for_usdu",
         "branch_context": [
@@ -15052,7 +15213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 46,
+        "line": 51,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15083,7 +15244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 46,
+        "line": 51,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15114,7 +15275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 46,
+        "line": 51,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15145,7 +15306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 46,
+        "line": 51,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15176,7 +15337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15207,7 +15368,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15238,7 +15399,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15269,7 +15430,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15300,7 +15461,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15331,7 +15492,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15362,7 +15523,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15393,7 +15554,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15424,7 +15585,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15455,7 +15616,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15486,7 +15647,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15517,7 +15678,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15548,7 +15709,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 52,
+        "line": 57,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15579,7 +15740,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 67,
+        "line": 72,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15610,7 +15771,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 67,
+        "line": 72,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15641,7 +15802,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 67,
+        "line": 72,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15672,7 +15833,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 67,
+        "line": 72,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15703,7 +15864,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 67,
+        "line": 72,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15734,7 +15895,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 67,
+        "line": 72,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15765,7 +15926,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 67,
+        "line": 72,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15796,7 +15957,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 67,
+        "line": 72,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15827,7 +15988,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 67,
+        "line": 72,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15858,7 +16019,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 67,
+        "line": 72,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15889,7 +16050,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 67,
+        "line": 72,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15920,7 +16081,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 67,
+        "line": 72,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15951,7 +16112,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 81,
+        "line": 86,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15982,7 +16143,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 81,
+        "line": 86,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16013,7 +16174,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 81,
+        "line": 86,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16044,7 +16205,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 81,
+        "line": 86,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16075,7 +16236,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 81,
+        "line": 86,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16106,7 +16267,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 81,
+        "line": 86,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16137,7 +16298,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 81,
+        "line": 86,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16168,7 +16329,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 81,
+        "line": 86,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16199,7 +16360,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 81,
+        "line": 86,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16230,7 +16391,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 81,
+        "line": 86,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16261,7 +16422,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 93,
+        "line": 98,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16292,7 +16453,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 93,
+        "line": 98,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16323,7 +16484,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 93,
+        "line": 98,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16354,7 +16515,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 93,
+        "line": 98,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16385,7 +16546,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 93,
+        "line": 98,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16416,7 +16577,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 93,
+        "line": 98,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16447,7 +16608,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 93,
+        "line": 98,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16478,7 +16639,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 93,
+        "line": 98,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16509,7 +16670,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 93,
+        "line": 98,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16540,7 +16701,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 93,
+        "line": 98,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16571,7 +16732,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16602,7 +16763,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16633,7 +16794,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16664,7 +16825,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16695,7 +16856,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16726,7 +16887,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16757,7 +16918,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16788,7 +16949,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16819,7 +16980,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16850,7 +17011,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16881,7 +17042,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16912,7 +17073,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16943,7 +17104,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 119,
+        "line": 124,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -16974,7 +17135,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 119,
+        "line": 124,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17005,7 +17166,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 119,
+        "line": 124,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17036,7 +17197,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 124,
+        "line": 129,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17067,7 +17228,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 124,
+        "line": 129,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17098,7 +17259,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 124,
+        "line": 129,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17129,7 +17290,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 124,
+        "line": 129,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17160,7 +17321,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 124,
+        "line": 129,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17191,7 +17352,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 131,
+        "line": 136,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17222,7 +17383,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 132,
+        "line": 137,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17253,7 +17414,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 132,
+        "line": 137,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17284,7 +17445,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 132,
+        "line": 137,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17315,7 +17476,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 132,
+        "line": 137,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17346,7 +17507,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 138,
+        "line": 143,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17377,7 +17538,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 138,
+        "line": 143,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17408,7 +17569,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 138,
+        "line": 143,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17439,7 +17600,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 138,
+        "line": 143,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17470,7 +17631,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 138,
+        "line": 143,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17501,7 +17662,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 138,
+        "line": 143,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17532,7 +17693,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 138,
+        "line": 143,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17563,7 +17724,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 138,
+        "line": 143,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17594,7 +17755,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 138,
+        "line": 143,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17625,7 +17786,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 138,
+        "line": 143,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17656,7 +17817,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 152,
+        "line": 157,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17687,7 +17848,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 152,
+        "line": 157,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17718,7 +17879,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 152,
+        "line": 157,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17749,7 +17910,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 152,
+        "line": 157,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17780,7 +17941,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 152,
+        "line": 157,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17811,7 +17972,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 152,
+        "line": 157,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17842,7 +18003,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 152,
+        "line": 157,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17873,7 +18034,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17904,7 +18065,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17935,7 +18096,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17966,7 +18127,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17997,7 +18158,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18028,7 +18189,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18059,7 +18220,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18090,7 +18251,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18121,7 +18282,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18152,7 +18313,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18183,7 +18344,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18214,7 +18375,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18245,7 +18406,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18276,7 +18437,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18307,7 +18468,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18338,7 +18499,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18369,7 +18530,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18400,7 +18561,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18431,7 +18592,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18462,7 +18623,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18493,7 +18654,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18524,7 +18685,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 170,
+        "line": 175,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18555,7 +18716,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18586,7 +18747,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18617,7 +18778,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18648,7 +18809,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18679,7 +18840,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18710,7 +18871,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18741,7 +18902,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18772,7 +18933,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18803,7 +18964,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18834,7 +18995,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18865,7 +19026,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18896,7 +19057,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18927,7 +19088,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18958,7 +19119,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 206,
+        "line": 211,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18989,7 +19150,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 234,
+        "line": 239,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19020,7 +19181,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 234,
+        "line": 239,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19051,7 +19212,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 234,
+        "line": 239,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19082,7 +19243,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 234,
+        "line": 239,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19113,7 +19274,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 234,
+        "line": 239,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19144,7 +19305,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 234,
+        "line": 239,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19175,7 +19336,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 234,
+        "line": 239,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19206,7 +19367,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 234,
+        "line": 239,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19237,7 +19398,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 234,
+        "line": 239,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19268,7 +19429,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19299,7 +19460,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19330,7 +19491,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19361,7 +19522,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19392,7 +19553,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19423,7 +19584,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19454,7 +19615,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19485,7 +19646,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19516,7 +19677,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19547,7 +19708,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19578,7 +19739,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19609,7 +19770,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19640,7 +19801,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19671,7 +19832,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19702,7 +19863,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19733,7 +19894,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19764,7 +19925,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19795,7 +19956,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19826,7 +19987,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19857,7 +20018,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19888,7 +20049,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19919,7 +20080,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19950,7 +20111,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19981,7 +20142,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20012,7 +20173,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 250,
+        "line": 255,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20043,7 +20204,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 330,
+        "line": 335,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20074,7 +20235,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 330,
+        "line": 335,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20105,7 +20266,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 330,
+        "line": 335,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20136,7 +20297,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 330,
+        "line": 335,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20167,7 +20328,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 336,
+        "line": 341,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20198,7 +20359,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 336,
+        "line": 341,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20229,7 +20390,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 336,
+        "line": 341,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20260,7 +20421,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 341,
+        "line": 346,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20291,7 +20452,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 341,
+        "line": 346,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20322,7 +20483,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 341,
+        "line": 346,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20353,7 +20514,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 347,
+        "line": 352,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20384,7 +20545,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 347,
+        "line": 352,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20415,7 +20576,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 347,
+        "line": 352,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20446,7 +20607,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 347,
+        "line": 352,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20477,7 +20638,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 347,
+        "line": 352,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20508,7 +20669,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 347,
+        "line": 352,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20539,7 +20700,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 347,
+        "line": 352,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20570,7 +20731,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 356,
+        "line": 361,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20601,7 +20762,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 356,
+        "line": 361,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20632,7 +20793,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 356,
+        "line": 361,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20663,7 +20824,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 367,
+        "line": 372,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20694,7 +20855,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 367,
+        "line": 372,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20725,7 +20886,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 367,
+        "line": 372,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20756,7 +20917,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 367,
+        "line": 372,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20787,7 +20948,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 380,
+        "line": 385,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20818,7 +20979,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 380,
+        "line": 385,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20849,7 +21010,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 388,
+        "line": 393,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20880,7 +21041,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 388,
+        "line": 393,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20911,7 +21072,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 388,
+        "line": 393,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20942,7 +21103,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 388,
+        "line": 393,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20973,7 +21134,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 388,
+        "line": 393,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21004,7 +21165,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 388,
+        "line": 393,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21035,7 +21196,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 388,
+        "line": 393,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21066,7 +21227,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 388,
+        "line": 393,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21097,7 +21258,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 399,
+        "line": 404,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21128,7 +21289,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 399,
+        "line": 404,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21159,7 +21320,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 399,
+        "line": 404,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21190,7 +21351,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 399,
+        "line": 404,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21221,7 +21382,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 405,
+        "line": 410,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21252,7 +21413,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 405,
+        "line": 410,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21283,7 +21444,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 405,
+        "line": 410,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21314,7 +21475,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 405,
+        "line": 410,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21345,7 +21506,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 405,
+        "line": 410,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21376,7 +21537,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 413,
+        "line": 418,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21407,7 +21568,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 413,
+        "line": 418,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21438,7 +21599,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 417,
+        "line": 422,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21469,7 +21630,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 421,
+        "line": 426,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21500,7 +21661,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 421,
+        "line": 426,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21531,7 +21692,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 421,
+        "line": 426,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21562,7 +21723,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 426,
+        "line": 431,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21593,7 +21754,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 426,
+        "line": 431,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21624,7 +21785,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 426,
+        "line": 431,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21655,7 +21816,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 426,
+        "line": 431,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21686,7 +21847,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 426,
+        "line": 431,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21717,7 +21878,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 433,
+        "line": 438,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21748,7 +21909,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 433,
+        "line": 438,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21779,7 +21940,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 433,
+        "line": 438,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21810,7 +21971,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 438,
+        "line": 443,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21841,7 +22002,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 438,
+        "line": 443,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21872,7 +22033,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 438,
+        "line": 443,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21903,7 +22064,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 456,
+        "line": 461,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21934,7 +22095,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 456,
+        "line": 461,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21965,7 +22126,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 456,
+        "line": 461,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -21996,7 +22157,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 456,
+        "line": 461,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22027,7 +22188,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 456,
+        "line": 461,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22058,7 +22219,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 479,
+        "line": 484,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22089,7 +22250,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 479,
+        "line": 484,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22120,7 +22281,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 483,
+        "line": 488,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22151,7 +22312,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 483,
+        "line": 488,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22182,7 +22343,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22213,7 +22374,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22244,7 +22405,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22275,7 +22436,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22306,7 +22467,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22337,7 +22498,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22368,7 +22529,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22399,7 +22560,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22430,7 +22591,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22461,7 +22622,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22492,7 +22653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22523,7 +22684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22554,7 +22715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22585,7 +22746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22616,7 +22777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 488,
+        "line": 493,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22647,7 +22808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 505,
+        "line": 510,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22678,7 +22839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 505,
+        "line": 510,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22709,7 +22870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 505,
+        "line": 510,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22740,7 +22901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 505,
+        "line": 510,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22771,7 +22932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 505,
+        "line": 510,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22802,7 +22963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 505,
+        "line": 510,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22833,7 +22994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 505,
+        "line": 510,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22864,7 +23025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 505,
+        "line": 510,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22895,7 +23056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 515,
+        "line": 520,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22926,7 +23087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 515,
+        "line": 520,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -22957,7 +23118,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 519,
+        "line": 524,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -22988,7 +23149,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 519,
+        "line": 524,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23019,7 +23180,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 520,
+        "line": 525,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23050,7 +23211,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 521,
+        "line": 526,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23081,7 +23242,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 521,
+        "line": 526,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23112,7 +23273,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 521,
+        "line": 526,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23143,7 +23304,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 526,
+        "line": 531,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23174,7 +23335,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 526,
+        "line": 531,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23205,7 +23366,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23236,7 +23397,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23267,7 +23428,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23298,7 +23459,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23329,7 +23490,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23360,7 +23521,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23391,7 +23552,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23422,7 +23583,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23453,7 +23614,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23484,7 +23645,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23515,7 +23676,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23546,7 +23707,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23577,7 +23738,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23608,7 +23769,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23639,7 +23800,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23670,7 +23831,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23701,7 +23862,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23732,7 +23893,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23763,7 +23924,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 527,
+        "line": 532,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23782,7 +23943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -23797,7 +23958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23816,7 +23977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -23831,7 +23992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23850,7 +24011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -23865,7 +24026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23884,7 +24045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -23899,7 +24060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23918,7 +24079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -23933,7 +24094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23952,7 +24113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -23967,7 +24128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -23986,7 +24147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24001,7 +24162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24020,7 +24181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24035,7 +24196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24054,7 +24215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24069,7 +24230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 560,
+        "line": 565,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24088,7 +24249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24103,7 +24264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 560,
+        "line": 565,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24122,7 +24283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24137,7 +24298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24156,7 +24317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24171,7 +24332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24190,7 +24351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24205,7 +24366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24224,7 +24385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24239,7 +24400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24258,7 +24419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24273,7 +24434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24292,7 +24453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24307,7 +24468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24326,7 +24487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24341,7 +24502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24360,7 +24521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24375,7 +24536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24394,7 +24555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24409,7 +24570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24428,7 +24589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24443,7 +24604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24462,7 +24623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24477,7 +24638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24496,7 +24657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24511,7 +24672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24530,7 +24691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24545,7 +24706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24564,7 +24725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24579,7 +24740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24598,7 +24759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24613,7 +24774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24632,7 +24793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24647,7 +24808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -24655,6 +24816,108 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/aio/generation_settings.py"
+      },
+      {
+        "alias": "_aio_usdu_auto_tile_dimension",
+        "bound_name": "_aio_usdu_auto_tile_dimension",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 553,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_aio_usdu_auto_tile_dimension",
+          "target": "easyuse_anima/aio/usdu.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
+        "kind": "static_from",
+        "line": 589,
+        "name": "_aio_usdu_auto_tile_dimension",
+        "optional": false,
+        "requested": "easyuse_anima.aio.usdu",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "alias": "_aio_usdu_tile_plan",
+        "bound_name": "_aio_usdu_tile_plan",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 553,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_aio_usdu_tile_plan",
+          "target": "easyuse_anima/aio/usdu.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
+        "kind": "static_from",
+        "line": 589,
+        "name": "_aio_usdu_tile_plan",
+        "optional": false,
+        "requested": "easyuse_anima.aio.usdu",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "alias": "_bind_aio_usdu_planning_runtime",
+        "bound_name": "_bind_aio_usdu_planning_runtime",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 553,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_aio_usdu_planning_runtime",
+          "target": "easyuse_anima/aio/usdu.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
+        "kind": "static_from",
+        "line": 589,
+        "name": "_bind_aio_usdu_planning_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.aio.usdu",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/usdu.py"
       },
       {
         "alias": "_aio_prompt_data_fields_for_usdu",
@@ -24666,7 +24929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24681,7 +24944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 584,
+        "line": 594,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24700,7 +24963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24715,7 +24978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 584,
+        "line": 594,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24734,7 +24997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24749,7 +25012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 584,
+        "line": 594,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24768,7 +25031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24783,7 +25046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 584,
+        "line": 594,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24802,7 +25065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24817,7 +25080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24836,7 +25099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24851,7 +25114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24870,7 +25133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24885,7 +25148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24904,7 +25167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24919,7 +25182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24938,7 +25201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24953,7 +25216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -24972,7 +25235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -24987,7 +25250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25006,7 +25269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25021,7 +25284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25040,7 +25303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25055,7 +25318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25074,7 +25337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25089,7 +25352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25108,7 +25371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25123,7 +25386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25142,7 +25405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25157,7 +25420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25176,7 +25439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25191,7 +25454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25210,7 +25473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25225,7 +25488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25244,7 +25507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25259,7 +25522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25278,7 +25541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25293,7 +25556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25312,7 +25575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25327,7 +25590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25346,7 +25609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25361,7 +25624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25380,7 +25643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25395,7 +25658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25414,7 +25677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25429,7 +25692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25448,7 +25711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25463,7 +25726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25482,7 +25745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25497,7 +25760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25516,7 +25779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25531,7 +25794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25550,7 +25813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25565,7 +25828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25584,7 +25847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25599,7 +25862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25618,7 +25881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25633,7 +25896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25652,7 +25915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25667,7 +25930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25686,7 +25949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25701,7 +25964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25720,7 +25983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25735,7 +25998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25754,7 +26017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25769,7 +26032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25788,7 +26051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25803,7 +26066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25822,7 +26085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25837,7 +26100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25856,7 +26119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25871,7 +26134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25890,7 +26153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25905,7 +26168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25924,7 +26187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25939,7 +26202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25958,7 +26221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -25973,7 +26236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -25992,7 +26255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26007,7 +26270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26026,7 +26289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26041,7 +26304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26060,7 +26323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26075,7 +26338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26094,7 +26357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26109,7 +26372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26128,7 +26391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26143,7 +26406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26162,7 +26425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26177,7 +26440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26196,7 +26459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26211,7 +26474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26230,7 +26493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26245,7 +26508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26264,7 +26527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26279,7 +26542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26298,7 +26561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26313,7 +26576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26332,7 +26595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26347,7 +26610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26366,7 +26629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26381,7 +26644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26400,7 +26663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26415,7 +26678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26434,7 +26697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26449,7 +26712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26468,7 +26731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26483,7 +26746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26502,7 +26765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26517,7 +26780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26536,7 +26799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26551,7 +26814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26570,7 +26833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26585,7 +26848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26604,7 +26867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26619,7 +26882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26638,7 +26901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26653,7 +26916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26672,7 +26935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26687,7 +26950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26706,7 +26969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26721,7 +26984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26740,7 +27003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26755,7 +27018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 657,
+        "line": 667,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -26774,7 +27037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26789,7 +27052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 657,
+        "line": 667,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -26808,7 +27071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26823,7 +27086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 657,
+        "line": 667,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -26842,7 +27105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26857,7 +27120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 662,
+        "line": 672,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26876,7 +27139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26891,7 +27154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 662,
+        "line": 672,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26910,7 +27173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26925,7 +27188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 662,
+        "line": 672,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26944,7 +27207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26959,7 +27222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 662,
+        "line": 672,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -26978,7 +27241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -26993,7 +27256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 662,
+        "line": 672,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27012,7 +27275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27027,7 +27290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 669,
+        "line": 679,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -27046,7 +27309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27061,7 +27324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 670,
+        "line": 680,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27080,7 +27343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27095,7 +27358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 670,
+        "line": 680,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27114,7 +27377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27129,7 +27392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 670,
+        "line": 680,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27148,7 +27411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27163,7 +27426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 670,
+        "line": 680,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27182,7 +27445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27197,7 +27460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27216,7 +27479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27231,7 +27494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27250,7 +27513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27265,7 +27528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27284,7 +27547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27299,7 +27562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27318,7 +27581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27333,7 +27596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27352,7 +27615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27367,7 +27630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27386,7 +27649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27401,7 +27664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27420,7 +27683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27435,7 +27698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27454,7 +27717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27469,7 +27732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27488,7 +27751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27503,7 +27766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27522,7 +27785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27537,7 +27800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27556,7 +27819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27571,7 +27834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27590,7 +27853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27605,7 +27868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27624,7 +27887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27639,7 +27902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27658,7 +27921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27673,7 +27936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27692,7 +27955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27707,7 +27970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27726,7 +27989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27741,7 +28004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27760,7 +28023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27775,7 +28038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27794,7 +28057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27809,7 +28072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27828,7 +28091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27843,7 +28106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27862,7 +28125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27877,7 +28140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27896,7 +28159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27911,7 +28174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27930,7 +28193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27945,7 +28208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27964,7 +28227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -27979,7 +28242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27998,7 +28261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28013,7 +28276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28032,7 +28295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28047,7 +28310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28066,7 +28329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28081,7 +28344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28100,7 +28363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28115,7 +28378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28134,7 +28397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28149,7 +28412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28168,7 +28431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28183,7 +28446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28202,7 +28465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28217,7 +28480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28236,7 +28499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28251,7 +28514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28270,7 +28533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28285,7 +28548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28304,7 +28567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28319,7 +28582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28338,7 +28601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28353,7 +28616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28372,7 +28635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28387,7 +28650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28406,7 +28669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28421,7 +28684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28440,7 +28703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28455,7 +28718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28474,7 +28737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28489,7 +28752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28508,7 +28771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28523,7 +28786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28542,7 +28805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28557,7 +28820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28576,7 +28839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28591,7 +28854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28610,7 +28873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28625,7 +28888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28644,7 +28907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28659,7 +28922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28678,7 +28941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28693,7 +28956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28712,7 +28975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28727,7 +28990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28746,7 +29009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28761,7 +29024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28780,7 +29043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28795,7 +29058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28814,7 +29077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28829,7 +29092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28848,7 +29111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28863,7 +29126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28882,7 +29145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28897,7 +29160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28916,7 +29179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28931,7 +29194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28950,7 +29213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28965,7 +29228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28984,7 +29247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -28999,7 +29262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29018,7 +29281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29033,7 +29296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29052,7 +29315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29067,7 +29330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29086,7 +29349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29101,7 +29364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29120,7 +29383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29135,7 +29398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29154,7 +29417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29169,7 +29432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29188,7 +29451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29203,7 +29466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29222,7 +29485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29237,7 +29500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29256,7 +29519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29271,7 +29534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29290,7 +29553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29305,7 +29568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29324,7 +29587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29339,7 +29602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29358,7 +29621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29373,7 +29636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29392,7 +29655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29407,7 +29670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29426,7 +29689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29441,7 +29704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29460,7 +29723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29475,7 +29738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29494,7 +29757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29509,7 +29772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29528,7 +29791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29543,7 +29806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29562,7 +29825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29577,7 +29840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29596,7 +29859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29611,7 +29874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29630,7 +29893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29645,7 +29908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29664,7 +29927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29679,7 +29942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29698,7 +29961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29713,7 +29976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29732,7 +29995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29747,7 +30010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29766,7 +30029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29781,7 +30044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29800,7 +30063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29815,7 +30078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29834,7 +30097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29849,7 +30112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29868,7 +30131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29883,7 +30146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29902,7 +30165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29917,7 +30180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29936,7 +30199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29951,7 +30214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29970,7 +30233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -29985,7 +30248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30004,7 +30267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30019,7 +30282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30038,7 +30301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30053,7 +30316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30072,7 +30335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30087,7 +30350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30106,7 +30369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30121,7 +30384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30140,7 +30403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30155,7 +30418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 868,
+        "line": 878,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30174,7 +30437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30189,7 +30452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 868,
+        "line": 878,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30208,7 +30471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30223,7 +30486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 868,
+        "line": 878,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30242,7 +30505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30257,7 +30520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 868,
+        "line": 878,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30276,7 +30539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30291,7 +30554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 874,
+        "line": 884,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30310,7 +30573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30325,7 +30588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 874,
+        "line": 884,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30344,7 +30607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30359,7 +30622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 874,
+        "line": 884,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30378,7 +30641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30393,7 +30656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 879,
+        "line": 889,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -30412,7 +30675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30427,7 +30690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 879,
+        "line": 889,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -30446,7 +30709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30461,7 +30724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 879,
+        "line": 889,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -30480,7 +30743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30495,7 +30758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30514,7 +30777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30529,7 +30792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30548,7 +30811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30563,7 +30826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30582,7 +30845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30597,7 +30860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30616,7 +30879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30631,7 +30894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30650,7 +30913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30665,7 +30928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30684,7 +30947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30699,7 +30962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30718,7 +30981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30733,7 +30996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -30752,7 +31015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30767,7 +31030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -30786,7 +31049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30801,7 +31064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -30820,7 +31083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30835,7 +31098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 905,
+        "line": 915,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30854,7 +31117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30869,7 +31132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 905,
+        "line": 915,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30888,7 +31151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30903,7 +31166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 905,
+        "line": 915,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30922,7 +31185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30937,7 +31200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 905,
+        "line": 915,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -30956,7 +31219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -30971,7 +31234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 918,
+        "line": 928,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -30990,7 +31253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31005,7 +31268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 918,
+        "line": 928,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31024,7 +31287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31039,7 +31302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31058,7 +31321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31073,7 +31336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31092,7 +31355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31107,7 +31370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31126,7 +31389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31141,7 +31404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31160,7 +31423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31175,7 +31438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31194,7 +31457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31209,7 +31472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31228,7 +31491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31243,7 +31506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31262,7 +31525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31277,7 +31540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31296,7 +31559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31311,7 +31574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 937,
+        "line": 947,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31330,7 +31593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31345,7 +31608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 937,
+        "line": 947,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31364,7 +31627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31379,7 +31642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 937,
+        "line": 947,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31398,7 +31661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31413,7 +31676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 937,
+        "line": 947,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31432,7 +31695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31447,7 +31710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 943,
+        "line": 953,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31466,7 +31729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31481,7 +31744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 943,
+        "line": 953,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31500,7 +31763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31515,7 +31778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 943,
+        "line": 953,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31534,7 +31797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31549,7 +31812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 943,
+        "line": 953,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31568,7 +31831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31583,7 +31846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 943,
+        "line": 953,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31602,7 +31865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31617,7 +31880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 951,
+        "line": 961,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -31636,7 +31899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31651,7 +31914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 951,
+        "line": 961,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -31670,7 +31933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31685,7 +31948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 955,
+        "line": 965,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -31704,7 +31967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31719,7 +31982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 959,
+        "line": 969,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -31738,7 +32001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31753,7 +32016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 959,
+        "line": 969,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -31772,7 +32035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31787,7 +32050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 959,
+        "line": 969,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -31806,7 +32069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31821,7 +32084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 964,
+        "line": 974,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31840,7 +32103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31855,7 +32118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 964,
+        "line": 974,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31874,7 +32137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31889,7 +32152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 964,
+        "line": 974,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31908,7 +32171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31923,7 +32186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 964,
+        "line": 974,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31942,7 +32205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31957,7 +32220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 964,
+        "line": 974,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -31976,7 +32239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -31991,7 +32254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 971,
+        "line": 981,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32010,7 +32273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32025,7 +32288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 971,
+        "line": 981,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32044,7 +32307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32059,7 +32322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 971,
+        "line": 981,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32078,7 +32341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32093,7 +32356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 976,
+        "line": 986,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32112,7 +32375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32127,7 +32390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 976,
+        "line": 986,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32146,7 +32409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32161,7 +32424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 976,
+        "line": 986,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32180,7 +32443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32195,7 +32458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32214,7 +32477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32229,7 +32492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32248,7 +32511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32263,7 +32526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32282,7 +32545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32297,7 +32560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32316,7 +32579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32331,7 +32594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32350,7 +32613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32365,7 +32628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1027,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -32384,7 +32647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32399,7 +32662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1027,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -32418,7 +32681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32433,7 +32696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1031,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -32452,7 +32715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32467,7 +32730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1031,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -32486,7 +32749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32501,7 +32764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32520,7 +32783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32535,7 +32798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32554,7 +32817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32569,7 +32832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32588,7 +32851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32603,7 +32866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32622,7 +32885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32637,7 +32900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32656,7 +32919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32671,7 +32934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32690,7 +32953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32705,7 +32968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32724,7 +32987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32739,7 +33002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32758,7 +33021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32773,7 +33036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32792,7 +33055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32807,7 +33070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32826,7 +33089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32841,7 +33104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32860,7 +33123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32875,7 +33138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32894,7 +33157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32909,7 +33172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32928,7 +33191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32943,7 +33206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32962,7 +33225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -32977,7 +33240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32996,7 +33259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33011,7 +33274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33030,7 +33293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33045,7 +33308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33064,7 +33327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33079,7 +33342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33098,7 +33361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33113,7 +33376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33132,7 +33395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33147,7 +33410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33166,7 +33429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33181,7 +33444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33200,7 +33463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33215,7 +33478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33234,7 +33497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33249,7 +33512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33268,7 +33531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33283,7 +33546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1063,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -33302,7 +33565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33317,7 +33580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1063,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -33336,7 +33599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33351,7 +33614,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1067,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -33370,7 +33633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33385,7 +33648,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1067,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -33404,7 +33667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33419,7 +33682,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1068,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -33438,7 +33701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33453,7 +33716,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1069,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -33472,7 +33735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33487,7 +33750,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1069,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -33506,7 +33769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33521,7 +33784,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1069,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -33540,7 +33803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33555,7 +33818,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1074,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -33574,7 +33837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33589,7 +33852,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1074,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -33608,7 +33871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33623,7 +33886,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33642,7 +33905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33657,7 +33920,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33676,7 +33939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33691,7 +33954,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33710,7 +33973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33725,7 +33988,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33744,7 +34007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33759,7 +34022,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33778,7 +34041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33793,7 +34056,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33812,7 +34075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33827,7 +34090,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33846,7 +34109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33861,7 +34124,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33880,7 +34143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33895,7 +34158,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33914,7 +34177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33929,7 +34192,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33948,7 +34211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33963,7 +34226,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33982,7 +34245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -33997,7 +34260,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34016,7 +34279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -34031,7 +34294,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34050,7 +34313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -34065,7 +34328,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34084,7 +34347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -34099,7 +34362,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34118,7 +34381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -34133,7 +34396,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34152,7 +34415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -34167,7 +34430,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34186,7 +34449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -34201,7 +34464,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34220,7 +34483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -34235,7 +34498,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34253,7 +34516,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1582
+            "line": 1592
           }
         ],
         "classification": "external",
@@ -34261,7 +34524,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1583,
+        "line": 1593,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -34278,7 +34541,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1619
+            "line": 1629
           }
         ],
         "classification": "external",
@@ -34286,7 +34549,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1620,
+        "line": 1630,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -34303,7 +34566,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1627
+            "line": 1637
           }
         ],
         "classification": "external",
@@ -34311,7 +34574,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1628,
+        "line": 1638,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -36322,6 +36585,10 @@
       },
       {
         "from": "nodes.py",
+        "to": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "from": "nodes.py",
         "to": "easyuse_anima/common/serialization.py"
       },
       {
@@ -36677,6 +36944,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/aio/usdu.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/bootstrap.py"
         ]
       },
@@ -36983,7 +37256,7 @@
     ]
   },
   "inventory": {
-    "module_count": 81,
+    "module_count": 82,
     "modules": [
       {
         "is_package": true,
@@ -37342,6 +37615,18 @@
         "top_level": {
           "class_count": 0,
           "function_count": 13,
+          "global_count": 3
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 108,
+        "module": "easyuse_anima.aio.usdu",
+        "normalized_git_blob_sha1": "5d9af74e628ba88596dc01eae22df891155b2850",
+        "path": "easyuse_anima/aio/usdu.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 4,
           "global_count": 3
         }
       },
@@ -37899,13 +38184,13 @@
       },
       {
         "is_package": false,
-        "loc": 2464,
+        "loc": 2429,
         "module": "nodes",
-        "normalized_git_blob_sha1": "54ec149837848c16a459f0f249b33038105bf507",
+        "normalized_git_blob_sha1": "59f8b61ab03fe443fe98068cdc59114dc6672c34",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 26,
+          "function_count": 24,
           "global_count": 26
         }
       },
@@ -39265,7 +39550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39274,7 +39559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39288,7 +39573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39297,7 +39582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39311,7 +39596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39320,7 +39605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39334,7 +39619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39343,7 +39628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39357,7 +39642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39366,7 +39651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39380,7 +39665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39389,7 +39674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39403,7 +39688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39412,7 +39697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39426,7 +39711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39435,7 +39720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 549,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39449,7 +39734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39458,7 +39743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 560,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39472,7 +39757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39481,7 +39766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 560,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39495,7 +39780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39504,7 +39789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39518,7 +39803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39527,7 +39812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39541,7 +39826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39550,7 +39835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39564,7 +39849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39573,7 +39858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39587,7 +39872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39596,7 +39881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39610,7 +39895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39619,7 +39904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39633,7 +39918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39642,7 +39927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39656,7 +39941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39665,7 +39950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39679,7 +39964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39688,7 +39973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39702,7 +39987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39711,7 +39996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39725,7 +40010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39734,7 +40019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39748,7 +40033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39757,7 +40042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39771,7 +40056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39780,7 +40065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39794,7 +40079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39803,7 +40088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39817,7 +40102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39826,7 +40111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 564,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39840,7 +40125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39849,7 +40134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39863,7 +40148,76 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
+        "kind": "static_from",
+        "line": 589,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 553,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
+        "kind": "static_from",
+        "line": 589,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 553,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
+        "kind": "static_from",
+        "line": 589,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39872,7 +40226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 584,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39886,7 +40240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39895,7 +40249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 584,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39909,7 +40263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39918,7 +40272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 584,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39932,7 +40286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39941,7 +40295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 584,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39955,7 +40309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39964,7 +40318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39978,7 +40332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -39987,7 +40341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40001,7 +40355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40010,7 +40364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40024,7 +40378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40033,7 +40387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40047,7 +40401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40056,7 +40410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40070,7 +40424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40079,7 +40433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40093,7 +40447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40102,7 +40456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40116,7 +40470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40125,7 +40479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40139,7 +40493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40148,7 +40502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40162,7 +40516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40171,7 +40525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40185,7 +40539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40194,7 +40548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40208,7 +40562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40217,7 +40571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40231,7 +40585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40240,7 +40594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 590,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40254,7 +40608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40263,7 +40617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40277,7 +40631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40286,7 +40640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40300,7 +40654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40309,7 +40663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40323,7 +40677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40332,7 +40686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40346,7 +40700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40355,7 +40709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40369,7 +40723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40378,7 +40732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40392,7 +40746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40401,7 +40755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40415,7 +40769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40424,7 +40778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40438,7 +40792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40447,7 +40801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40461,7 +40815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40470,7 +40824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40484,7 +40838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40493,7 +40847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40507,7 +40861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40516,7 +40870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 605,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40530,7 +40884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40539,7 +40893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40553,7 +40907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40562,7 +40916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40576,7 +40930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40585,7 +40939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40599,7 +40953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40608,7 +40962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40622,7 +40976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40631,7 +40985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40645,7 +40999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40654,7 +41008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40668,7 +41022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40677,7 +41031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40691,7 +41045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40700,7 +41054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40714,7 +41068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40723,7 +41077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40737,7 +41091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40746,7 +41100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 619,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40760,7 +41114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40769,7 +41123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40783,7 +41137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40792,7 +41146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40806,7 +41160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40815,7 +41169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40829,7 +41183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40838,7 +41192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40852,7 +41206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40861,7 +41215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40875,7 +41229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40884,7 +41238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40898,7 +41252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40907,7 +41261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40921,7 +41275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40930,7 +41284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40944,7 +41298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40953,7 +41307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40967,7 +41321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40976,7 +41330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 631,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40990,7 +41344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -40999,7 +41353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41013,7 +41367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41022,7 +41376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41036,7 +41390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41045,7 +41399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41059,7 +41413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41068,7 +41422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41082,7 +41436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41091,7 +41445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41105,7 +41459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41114,7 +41468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41128,7 +41482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41137,7 +41491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41151,7 +41505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41160,7 +41514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41174,7 +41528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41183,7 +41537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41197,7 +41551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41206,7 +41560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41220,7 +41574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41229,7 +41583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41243,7 +41597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41252,7 +41606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 643,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41266,7 +41620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41275,7 +41629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 657,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41289,7 +41643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41298,7 +41652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 657,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41312,7 +41666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41321,7 +41675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 657,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41335,7 +41689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41344,7 +41698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 662,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41358,7 +41712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41367,7 +41721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 662,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41381,7 +41735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41390,7 +41744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 662,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41404,7 +41758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41413,7 +41767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 662,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41427,7 +41781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41436,7 +41790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 662,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41450,7 +41804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41459,7 +41813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 669,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41473,7 +41827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41482,7 +41836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 670,
+        "line": 680,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41496,7 +41850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41505,7 +41859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 670,
+        "line": 680,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41519,7 +41873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41528,7 +41882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 670,
+        "line": 680,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41542,7 +41896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41551,7 +41905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 670,
+        "line": 680,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41565,7 +41919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41574,7 +41928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41588,7 +41942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41597,7 +41951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41611,7 +41965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41620,7 +41974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41634,7 +41988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41643,7 +41997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41657,7 +42011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41666,7 +42020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41680,7 +42034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41689,7 +42043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41703,7 +42057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41712,7 +42066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41726,7 +42080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41735,7 +42089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41749,7 +42103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41758,7 +42112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41772,7 +42126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41781,7 +42135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 676,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41795,7 +42149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41804,7 +42158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41818,7 +42172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41827,7 +42181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41841,7 +42195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41850,7 +42204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41864,7 +42218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41873,7 +42227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41887,7 +42241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41896,7 +42250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41910,7 +42264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41919,7 +42273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41933,7 +42287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41942,7 +42296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 690,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41956,7 +42310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41965,7 +42319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41979,7 +42333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -41988,7 +42342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42002,7 +42356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42011,7 +42365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42025,7 +42379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42034,7 +42388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42048,7 +42402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42057,7 +42411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42071,7 +42425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42080,7 +42434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42094,7 +42448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42103,7 +42457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42117,7 +42471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42126,7 +42480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42140,7 +42494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42149,7 +42503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42163,7 +42517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42172,7 +42526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42186,7 +42540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42195,7 +42549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42209,7 +42563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42218,7 +42572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42232,7 +42586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42241,7 +42595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42255,7 +42609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42264,7 +42618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42278,7 +42632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42287,7 +42641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42301,7 +42655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42310,7 +42664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42324,7 +42678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42333,7 +42687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42347,7 +42701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42356,7 +42710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42370,7 +42724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42379,7 +42733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42393,7 +42747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42402,7 +42756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42416,7 +42770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42425,7 +42779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42439,7 +42793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42448,7 +42802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 708,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42462,7 +42816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42471,7 +42825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42485,7 +42839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42494,7 +42848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42508,7 +42862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42517,7 +42871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42531,7 +42885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42540,7 +42894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42554,7 +42908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42563,7 +42917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42577,7 +42931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42586,7 +42940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42600,7 +42954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42609,7 +42963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42623,7 +42977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42632,7 +42986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42646,7 +43000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42655,7 +43009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42669,7 +43023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42678,7 +43032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42692,7 +43046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42701,7 +43055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42715,7 +43069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42724,7 +43078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42738,7 +43092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42747,7 +43101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42761,7 +43115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42770,7 +43124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 744,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42784,7 +43138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42793,7 +43147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42807,7 +43161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42816,7 +43170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42830,7 +43184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42839,7 +43193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42853,7 +43207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42862,7 +43216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42876,7 +43230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42885,7 +43239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42899,7 +43253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42908,7 +43262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42922,7 +43276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42931,7 +43285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42945,7 +43299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42954,7 +43308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42968,7 +43322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -42977,7 +43331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 772,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42991,7 +43345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43000,7 +43354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43014,7 +43368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43023,7 +43377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43037,7 +43391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43046,7 +43400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43060,7 +43414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43069,7 +43423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43083,7 +43437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43092,7 +43446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43106,7 +43460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43115,7 +43469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43129,7 +43483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43138,7 +43492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43152,7 +43506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43161,7 +43515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43175,7 +43529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43184,7 +43538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43198,7 +43552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43207,7 +43561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43221,7 +43575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43230,7 +43584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43244,7 +43598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43253,7 +43607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43267,7 +43621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43276,7 +43630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43290,7 +43644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43299,7 +43653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43313,7 +43667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43322,7 +43676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43336,7 +43690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43345,7 +43699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43359,7 +43713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43368,7 +43722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43382,7 +43736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43391,7 +43745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43405,7 +43759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43414,7 +43768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43428,7 +43782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43437,7 +43791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43451,7 +43805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43460,7 +43814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43474,7 +43828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43483,7 +43837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43497,7 +43851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43506,7 +43860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43520,7 +43874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43529,7 +43883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43543,7 +43897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43552,7 +43906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 788,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43566,7 +43920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43575,7 +43929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 868,
+        "line": 878,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43589,7 +43943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43598,7 +43952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 868,
+        "line": 878,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43612,7 +43966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43621,7 +43975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 868,
+        "line": 878,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43635,7 +43989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43644,7 +43998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 868,
+        "line": 878,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43658,7 +44012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43667,7 +44021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 874,
+        "line": 884,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43681,7 +44035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43690,7 +44044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 874,
+        "line": 884,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43704,7 +44058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43713,7 +44067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 874,
+        "line": 884,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43727,7 +44081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43736,7 +44090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 879,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43750,7 +44104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43759,7 +44113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 879,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43773,7 +44127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43782,7 +44136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 879,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43796,7 +44150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43805,7 +44159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43819,7 +44173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43828,7 +44182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43842,7 +44196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43851,7 +44205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43865,7 +44219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43874,7 +44228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43888,7 +44242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43897,7 +44251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43911,7 +44265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43920,7 +44274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43934,7 +44288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43943,7 +44297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 885,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43957,7 +44311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43966,7 +44320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43980,7 +44334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -43989,7 +44343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44003,7 +44357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44012,7 +44366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 894,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44026,7 +44380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44035,7 +44389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 905,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44049,7 +44403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44058,7 +44412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 905,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44072,7 +44426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44081,7 +44435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 905,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44095,7 +44449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44104,7 +44458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 905,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44118,7 +44472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44127,7 +44481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 918,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44141,7 +44495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44150,7 +44504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 918,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44164,7 +44518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44173,7 +44527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44187,7 +44541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44196,7 +44550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44210,7 +44564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44219,7 +44573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44233,7 +44587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44242,7 +44596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44256,7 +44610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44265,7 +44619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44279,7 +44633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44288,7 +44642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44302,7 +44656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44311,7 +44665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44325,7 +44679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44334,7 +44688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 926,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44348,7 +44702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44357,7 +44711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 937,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44371,7 +44725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44380,7 +44734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 937,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44394,7 +44748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44403,7 +44757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 937,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44417,7 +44771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44426,7 +44780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 937,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44440,7 +44794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44449,7 +44803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 943,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44463,7 +44817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44472,7 +44826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 943,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44486,7 +44840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44495,7 +44849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 943,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44509,7 +44863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44518,7 +44872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 943,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44532,7 +44886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44541,7 +44895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 943,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44555,7 +44909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44564,7 +44918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 951,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44578,7 +44932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44587,7 +44941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 951,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44601,7 +44955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44610,7 +44964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 955,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44624,7 +44978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44633,7 +44987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 959,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44647,7 +45001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44656,7 +45010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 959,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44670,7 +45024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44679,7 +45033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 959,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44693,7 +45047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44702,7 +45056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 964,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44716,7 +45070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44725,7 +45079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 964,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44739,7 +45093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44748,7 +45102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 964,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44762,7 +45116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44771,7 +45125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 964,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44785,7 +45139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44794,7 +45148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 964,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44808,7 +45162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44817,7 +45171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 971,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44831,7 +45185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44840,7 +45194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 971,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44854,7 +45208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44863,7 +45217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 971,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44877,7 +45231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44886,7 +45240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 976,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44900,7 +45254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44909,7 +45263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 976,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44923,7 +45277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44932,7 +45286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 976,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44946,7 +45300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44955,7 +45309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44969,7 +45323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -44978,7 +45332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44992,7 +45346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45001,7 +45355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45015,7 +45369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45024,7 +45378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45038,7 +45392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45047,7 +45401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 994,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45061,7 +45415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45070,7 +45424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1027,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45084,7 +45438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45093,7 +45447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1027,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45107,7 +45461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45116,7 +45470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1031,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45130,7 +45484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45139,7 +45493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1031,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45153,7 +45507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45162,7 +45516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45176,7 +45530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45185,7 +45539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45199,7 +45553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45208,7 +45562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45222,7 +45576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45231,7 +45585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45245,7 +45599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45254,7 +45608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45268,7 +45622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45277,7 +45631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45291,7 +45645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45300,7 +45654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45314,7 +45668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45323,7 +45677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45337,7 +45691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45346,7 +45700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45360,7 +45714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45369,7 +45723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45383,7 +45737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45392,7 +45746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45406,7 +45760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45415,7 +45769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45429,7 +45783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45438,7 +45792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45452,7 +45806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45461,7 +45815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45475,7 +45829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45484,7 +45838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45498,7 +45852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45507,7 +45861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45521,7 +45875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45530,7 +45884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45544,7 +45898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45553,7 +45907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45567,7 +45921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45576,7 +45930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45590,7 +45944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45599,7 +45953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45613,7 +45967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45622,7 +45976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45636,7 +45990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45645,7 +45999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45659,7 +46013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45668,7 +46022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45682,7 +46036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45691,7 +46045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45705,7 +46059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45714,7 +46068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45728,7 +46082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45737,7 +46091,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45751,7 +46105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45760,7 +46114,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45774,7 +46128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45783,7 +46137,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45797,7 +46151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45806,7 +46160,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45820,7 +46174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45829,7 +46183,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45843,7 +46197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45852,7 +46206,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45866,7 +46220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45875,7 +46229,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45889,7 +46243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45898,7 +46252,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45912,7 +46266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45921,7 +46275,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45935,7 +46289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45944,7 +46298,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45958,7 +46312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45967,7 +46321,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45981,7 +46335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -45990,7 +46344,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46004,7 +46358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46013,7 +46367,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46027,7 +46381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46036,7 +46390,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46050,7 +46404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46059,7 +46413,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46073,7 +46427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46082,7 +46436,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46096,7 +46450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46105,7 +46459,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46119,7 +46473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46128,7 +46482,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46142,7 +46496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46151,7 +46505,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46165,7 +46519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46174,7 +46528,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46188,7 +46542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46197,7 +46551,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46211,7 +46565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46220,7 +46574,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46234,7 +46588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46243,7 +46597,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46257,7 +46611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46266,7 +46620,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46280,7 +46634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46289,7 +46643,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46303,7 +46657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46312,7 +46666,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46326,7 +46680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 548,
+            "handler_line": 553,
             "kind": "try",
             "line": 10
           }
@@ -46335,7 +46689,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48219,6 +48573,50 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/bootstrap.py"
       },
       {
@@ -50074,14 +50472,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1582
+            "line": 1592
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1583,
+        "line": 1593,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50093,14 +50491,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1619
+            "line": 1629
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1620,
+        "line": 1630,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50112,14 +50510,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1627
+            "line": 1637
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1628,
+        "line": 1638,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51494,14 +51892,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1582
+            "line": 1592
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1583,
+        "line": 1593,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51513,14 +51911,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1619
+            "line": 1629
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1620,
+        "line": 1630,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51532,14 +51930,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1627
+            "line": 1637
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1628,
+        "line": 1638,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51672,6 +52070,7 @@
       "easyuse_anima/aio/preview.py",
       "easyuse_anima/aio/resources.py",
       "easyuse_anima/aio/sampling.py",
+      "easyuse_anima/aio/usdu.py",
       "easyuse_anima/bootstrap.py",
       "easyuse_anima/common/__init__.py",
       "easyuse_anima/common/serialization.py",
@@ -51755,6 +52154,7 @@
       "easyuse_anima/aio/preview.py",
       "easyuse_anima/aio/resources.py",
       "easyuse_anima/aio/sampling.py",
+      "easyuse_anima/aio/usdu.py",
       "easyuse_anima/bootstrap.py",
       "easyuse_anima/common/__init__.py",
       "easyuse_anima/common/serialization.py",
@@ -52996,7 +53396,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1087,
+        "line": 1097,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53005,7 +53405,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2366,
+        "line": 2328,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53014,7 +53414,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2369,
+        "line": 2331,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53023,7 +53423,16 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2372,
+        "line": 2334,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_bind_aio_usdu_planning_runtime",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 2337,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53032,7 +53441,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2375,
+        "line": 2340,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53041,7 +53450,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2378,
+        "line": 2343,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53050,7 +53459,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2381,
+        "line": 2346,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53059,7 +53468,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2384,
+        "line": 2349,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53068,7 +53477,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2387,
+        "line": 2352,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53077,7 +53486,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2390,
+        "line": 2355,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53086,7 +53495,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2393,
+        "line": 2358,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53095,7 +53504,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2396,
+        "line": 2361,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53104,7 +53513,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2399,
+        "line": 2364,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53113,7 +53522,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2402,
+        "line": 2367,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53122,7 +53531,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2405,
+        "line": 2370,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53131,7 +53540,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2409,
+        "line": 2374,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53140,7 +53549,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2412,
+        "line": 2377,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53149,7 +53558,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2416,
+        "line": 2381,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53158,7 +53567,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2419,
+        "line": 2384,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53167,7 +53576,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2423,
+        "line": 2388,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53176,7 +53585,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2426,
+        "line": 2391,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53185,7 +53594,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2429,
+        "line": 2394,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53194,7 +53603,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2432,
+        "line": 2397,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53203,7 +53612,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2435,
+        "line": 2400,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53212,7 +53621,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2438,
+        "line": 2403,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53221,7 +53630,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2445,
+        "line": 2410,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53230,7 +53639,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2451,
+        "line": 2416,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53239,7 +53648,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2456,
+        "line": 2421,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53248,7 +53657,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2460,
+        "line": 2425,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53762,13 +54171,13 @@
       },
       {
         "kind": "dict",
-        "line": 1149,
+        "line": 1159,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1138,
+        "line": 1148,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "236a7f529f786c19a8bd0bcd34fd02d38b9d8af6",
+    "base_commit": "98812ef070096e7416bba08750a7c089f8564d29",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -41,7 +41,8 @@
       "B-11c8",
       "B-11c9",
       "B-11c10",
-      "B-11c11"
+      "B-11c11",
+      "B-11c12"
     ]
   },
   "enums": {
@@ -76,14 +77,14 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 281,
+    "nodes_canonical_bindings": 284,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 26,
+    "root_residual_functions": 24,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
-    "runtime_binders": 28,
+    "runtime_binders": 29,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -122,6 +123,7 @@
     "_bind_aio_first_pass_cache_runtime",
     "_bind_aio_legacy_generation_runtime",
     "_bind_aio_generation_normalization_runtime",
+    "_bind_aio_usdu_planning_runtime",
     "_bind_aio_resource_runtime",
     "_bind_aio_model_preparation_runtime",
     "_bind_aio_sampling_runtime",
@@ -421,8 +423,14 @@
     "_aio_save_filename_prefix": [
       "easyuse_anima.aio.legacy_generation"
     ],
+    "_aio_usdu_auto_tile_dimension": [
+      "easyuse_anima.aio.usdu"
+    ],
     "_aio_usdu_prompt_without_general": [
       "easyuse_anima.aio.conditioning"
+    ],
+    "_align_nearest": [
+      "easyuse_anima.aio.usdu"
     ],
     "_apply_advanced_field_inputs": [
       "easyuse_anima.nodes.prompt_advanced_nodes"
@@ -488,6 +496,7 @@
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.output",
       "easyuse_anima.aio.sampling",
+      "easyuse_anima.aio.usdu",
       "easyuse_anima.nodes.lora_nodes",
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.nodes.prompt_data_nodes",
@@ -510,6 +519,7 @@
       "easyuse_anima.aio.output",
       "easyuse_anima.aio.resources",
       "easyuse_anima.aio.sampling",
+      "easyuse_anima.aio.usdu",
       "easyuse_anima.lora.preset",
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.prompt.advanced",
@@ -689,7 +699,8 @@
     ],
     "_image_tensor_size": [
       "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.preview"
+      "easyuse_anima.aio.preview",
+      "easyuse_anima.aio.usdu"
     ],
     "_impact_scheduler_names": [
       "easyuse_anima.aio.generation_normalization",
@@ -2284,6 +2295,38 @@
       "lifecycle_state": "transitional"
     },
     {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.usdu:transitional_private_seam",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_aio_usdu_auto_tile_dimension": "_aio_usdu_auto_tile_dimension",
+        "_aio_usdu_tile_plan": "_aio_usdu_tile_plan",
+        "_bind_aio_usdu_planning_runtime": "_bind_aio_usdu_planning_runtime"
+      },
+      "classification": "transitional_private_seam",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.usdu",
+      "target_state": "canonical",
+      "identity_requirement": "required",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.usdu",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.usdu"
+      ],
+      "evidence": [
+        "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.usdu string runtime lookup"
+      ],
+      "removal_gates": [
+        "canonical production consumer migration",
+        "focused monkeypatch and identity contract review",
+        "separate B-10b or B-11 rollback unit"
+      ],
+      "lifecycle_state": "transitional"
+    },
+    {
       "id": "nodes_canonical_bindings:easyuse_anima.common.serialization:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -2358,6 +2401,7 @@
         "canonical runtime resolver: easyuse_anima.aio.preview",
         "canonical runtime resolver: easyuse_anima.aio.resources",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
+        "canonical runtime resolver: easyuse_anima.aio.usdu",
         "canonical runtime resolver: easyuse_anima.lora.preset",
         "canonical runtime resolver: easyuse_anima.nodes.lora_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
@@ -2377,6 +2421,7 @@
         "AST:easyuse_anima.aio.preview string runtime lookup",
         "AST:easyuse_anima.aio.resources string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
+        "AST:easyuse_anima.aio.usdu string runtime lookup",
         "AST:easyuse_anima.lora.preset string runtime lookup",
         "AST:easyuse_anima.nodes.lora_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
@@ -2413,12 +2458,14 @@
       "known_consumers": [
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.preview"
+        "canonical runtime resolver: easyuse_anima.aio.preview",
+        "canonical runtime resolver: easyuse_anima.aio.usdu"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.preview string runtime lookup"
+        "AST:easyuse_anima.aio.preview string runtime lookup",
+        "AST:easyuse_anima.aio.usdu string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -4017,8 +4064,6 @@
       "symbols": {
         "_aio_detailer_has_enabled_targets": "_aio_detailer_has_enabled_targets",
         "_aio_final_fit_size": "_aio_final_fit_size",
-        "_aio_usdu_auto_tile_dimension": "_aio_usdu_auto_tile_dimension",
-        "_aio_usdu_tile_plan": "_aio_usdu_tile_plan",
         "_aio_usdu_tile_size": "_aio_usdu_tile_size",
         "_apply_aio_final_fit": "_apply_aio_final_fit",
         "_comfy_clip_loader_types": "_comfy_clip_loader_types",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -23,6 +23,7 @@ from easyuse_anima.aio import (
     generation_normalization as aio_generation_normalization,
     resources as aio_resources,
     sampling as aio_sampling,
+    usdu as aio_usdu,
 )
 from easyuse_anima.aio import model_preparation as aio_model_preparation
 from easyuse_anima.common import serialization as common_serialization
@@ -917,6 +918,124 @@ class AioDetailerNormalizationMoveContractTests(unittest.TestCase):
                 f"{package_name}.easyuse_anima.aio.generation_normalization"
             ]
             self._assert_contract(package_nodes, package_generation_normalization)
+
+
+class AioUsduTilePlanningMoveContractTests(unittest.TestCase):
+    MOVED_NAMES = (
+        "_aio_usdu_auto_tile_dimension",
+        "_aio_usdu_tile_plan",
+        "_bind_aio_usdu_planning_runtime",
+    )
+
+    def _assert_contract(self, root_module, canonical_module):
+        for name in self.MOVED_NAMES:
+            with self.subTest(name=name):
+                self.assertIs(getattr(root_module, name), getattr(canonical_module, name))
+
+        with (
+            patch.object(root_module, "ceil", wraps=math.ceil) as ceil,
+            patch.object(
+                root_module,
+                "_align_nearest",
+                wraps=root_module._align_nearest,
+            ) as align_nearest,
+        ):
+            self.assertEqual(
+                canonical_module._aio_usdu_auto_tile_dimension(1500, 1000, 512, 2048),
+                768,
+            )
+        self.assertEqual(ceil.call_args_list, [call(1.5), call(750.0)])
+        align_nearest.assert_called_once_with(750, 64)
+
+        with (
+            patch.object(root_module, "_image_tensor_size", return_value=(320, 240)) as image_size,
+            patch.object(root_module, "_as_bool", return_value=False) as as_bool,
+            patch.object(root_module, "_as_int", side_effect=(321, 241)) as as_int,
+        ):
+            manual = canonical_module._aio_usdu_tile_plan(
+                "image",
+                0.01,
+                {
+                    "auto_tile_size": False,
+                    "tile_width": "321",
+                    "tile_height": "241",
+                },
+            )
+        self.assertEqual(
+            manual,
+            {
+                "auto": False,
+                "input_width": 320,
+                "input_height": 240,
+                "target_width": 16,
+                "target_height": 12,
+                "tile_width": 321,
+                "tile_height": 241,
+            },
+        )
+        image_size.assert_called_once_with("image", 512, 512)
+        as_bool.assert_called_once_with(False, True)
+        self.assertEqual(as_int.call_args_list, [call("321", 512), call("241", 512)])
+
+        with (
+            patch.object(root_module, "_image_tensor_size", return_value=(512, 768)),
+            patch.object(root_module, "_as_bool", return_value=True),
+            patch.object(root_module, "_as_int", side_effect=(900, 500, 2000)),
+            patch.object(
+                root_module,
+                "_aio_usdu_auto_tile_dimension",
+                side_effect=(1024, 1536),
+            ) as auto_dimension,
+        ):
+            automatic = canonical_module._aio_usdu_tile_plan(
+                "image",
+                2.0,
+                {
+                    "auto_tile_size": True,
+                    "auto_tile_target": 900,
+                    "auto_tile_min": 500,
+                    "auto_tile_max": 2000,
+                },
+            )
+        self.assertEqual(
+            automatic,
+            {
+                "auto": True,
+                "input_width": 512,
+                "input_height": 768,
+                "target_width": 1024,
+                "target_height": 1536,
+                "preferred": 900,
+                "min": 500,
+                "max": 2000,
+                "tile_width": 1024,
+                "tile_height": 1536,
+            },
+        )
+        self.assertEqual(
+            auto_dimension.call_args_list,
+            [call(1024, 900, 500, 2000), call(1536, 900, 500, 2000)],
+        )
+
+        with patch.object(
+            root_module,
+            "_aio_usdu_tile_plan",
+            return_value={"tile_width": 111, "tile_height": 222},
+        ) as tile_plan:
+            self.assertEqual(
+                root_module._aio_usdu_tile_size("image", 2.0, {"manual": True}),
+                (111, 222),
+            )
+        tile_plan.assert_called_once_with("image", 2.0, {"manual": True})
+
+    def test_root_aliases_and_call_time_helpers(self):
+        self._assert_contract(nodes, aio_usdu)
+
+    def test_package_aliases_and_call_time_helpers(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_usdu = sys.modules[f"{package_name}.easyuse_anima.aio.usdu"]
+            self._assert_contract(package_nodes, package_usdu)
 
 
 class AioSeedNormalizationMoveContractTests(unittest.TestCase):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "54ec149837848c16a459f0f249b33038105bf507")
-        # Issue #184 B-11c11 moves the AiO Detailer target normalizers and
-        # their two implementation constants to the canonical owner.
-        self.assertEqual(report["top_level"]["function_count"], 26)
+        self.assertEqual(report["git_blob_sha1"], "59f8b61ab03fe443fe98068cdc59114dc6672c34")
+        # Issue #184 B-11c12 moves the two live USDU tile-planning helpers
+        # while the dead tile-size wrapper remains root-owned for cleanup.
+        self.assertEqual(report["top_level"]["function_count"], 24)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_464)
+        self.assertEqual(report["line_count"], 2_429)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 81)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 81)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 81)
+        self.assertEqual(report["inventory"]["module_count"], 82)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 82)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 82)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
         self.assertTrue(
@@ -708,6 +708,7 @@ ignored/
                 "easyuse_anima/aio/preview.py",
                 "easyuse_anima/aio/resources.py",
                 "easyuse_anima/aio/sampling.py",
+                "easyuse_anima/aio/usdu.py",
                 "easyuse_anima/bootstrap.py",
                 "easyuse_anima/common/__init__.py",
                 "easyuse_anima/common/serialization.py",

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "236a7f529f786c19a8bd0bcd34fd02d38b9d8af6"
+BASE_COMMIT = "98812ef070096e7416bba08750a7c089f8564d29"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1314,6 +1314,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c9",
                 "B-11c10",
                 "B-11c11",
+                "B-11c12",
             ],
         },
         "enums": {
@@ -1326,14 +1327,14 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 281,
+            "nodes_canonical_bindings": 284,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 26,
+            "root_residual_functions": 24,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
-            "runtime_binders": 28,
+            "runtime_binders": 29,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -1564,7 +1565,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 28)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 29)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_string_runtime_resolvers_keep_production_seams_transitional(self):

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -29,6 +29,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.aio.generation_migrations",
     "easyuse_anima.aio.generation_settings",
     "easyuse_anima.aio.resources",
+    "easyuse_anima.aio.usdu",
     "easyuse_anima.common",
     "easyuse_anima.common.values",
     "easyuse_anima.common.serialization",


### PR DESCRIPTION
## 변경 요약

- B-11c12 단일 Move로 live USDU tile planning 함수 2개를 신규 canonical owner `easyuse_anima.aio.usdu`로 이동합니다.
- root `nodes.py`에는 relative/flat direct identity alias와 기존 root monkeypatch를 보존하는 runtime binder만 유지합니다.
- dead `_aio_usdu_tile_size`는 이번 Move에서 승격·삭제하지 않고 root에 남깁니다.

## 작업 전 inventory

### Symbol / caller

- `_aio_usdu_auto_tile_dimension`
  - production caller: `_aio_usdu_tile_plan`
  - focused contract: `tests/test_aio_nodes.py`
  - dependencies: root `ceil`, `_align_nearest`
- `_aio_usdu_tile_plan`
  - production callers: root `_run_aio_usdu_upscale_stage`, dead root wrapper `_aio_usdu_tile_size`
  - dependencies: root `_image_tensor_size`, `_as_bool`, `_as_int`, `_aio_usdu_auto_tile_dimension`
- `_aio_usdu_tile_size`
  - 저장소 내 정의 외 caller/resolver/test 없음
  - 이번 PR에서는 root definition을 그대로 유지하고 별도 Contract/cleanup 대상으로 둠

### Alias / global-state seam

- 두 live 함수는 relative/flat import 양쪽에서 canonical object를 직접 alias합니다.
- 신규 `_bind_aio_usdu_planning_runtime`은 root를 import하지 않고 call time에 `ceil`, `_align_nearest`, `_image_tensor_size`, `_as_bool`, `_as_int`, `_aio_usdu_auto_tile_dimension`을 resolve합니다.
- cache, mutable module state, I/O, optional dependency, import-time Comfy 호출은 없습니다.

## Allowed-file boundary

- production: `nodes.py`, 신규 `easyuse_anima/aio/usdu.py`
- contract/gate: `tests/test_node_contracts.py`, `tests/test_python_package_skeleton.py`, `tests/test_nodes_module_analyzer.py`, `tests/test_python_backend_analyzer.py`, `tests/test_python_compatibility_surface.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 금지 경계

- target/min/max/preferred clamp 및 두 번의 `ceil`/64 alignment 순서 변경 금지
- image fallback, scale minimum, Python `round`, manual `_as_int` fallback, key/order 변경 금지
- 입력 image/settings mutation 추가 금지
- USDU model loading, conditioning, sampling, logging, metadata, stage 순서 변경 금지
- dead `_aio_usdu_tile_size` 제거/승격 금지
- final-fit/postprocess, capability provider Contract 혼합 금지

## 검증

- focused contract/behavior/package/analyzer/import-boundary tests: 38 passed
- analyzer module inventory focused rerun: 1 passed
- 신규 `easyuse_anima/aio/usdu.py` Ruff: passed
- 독립 diff review: P1/P2 없음; P3 문서 resolver count 1건 수정 완료
- 첫 `tools/check_project.ps1 -Profile full`: Python 908개 중 새 모듈 수 gate 1건(`81 → 82`)만 실패하여 위 analyzer contract 파일을 boundary에 추가
- exact head `d423db17c5de7b40af3696c3337773674365557c`의 `tools/check_project.ps1 -Profile full`: passed
  - Python unittest: 908 passed
  - frontend: 114 JavaScript files passed
  - Pyright baseline ratchet: passed
  - Python import boundary: 6 groups, 0 violations
  - G-01 Ruff: 기존 108건 report-only, 실행 성공
  - `git diff --check`: passed
- Live ComfyUI smoke: 이 private planning Move에서는 수행하지 않음

## 남은 위험 / 미확인

- private pure planning Move이므로 Live ComfyUI/browser smoke는 수행하지 않았습니다.
- dead `_aio_usdu_tile_size`는 별도 Contract/cleanup 대상으로 남습니다.
