### PR TITLE
refactor: retire unused USDU tile-size wrapper

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `98812ef070096e7416bba08750a7c089f8564d29`
+- Integrated `dev` snapshot commit: `7c2fdd50b644fe48e98220ad72f7e5c78a0b070e`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c11 / `98812ef`; B-11c12 USDU tile-planning Move in PR #306 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c12 / `7c2fdd5`; B-11c13 dead USDU wrapper cleanup in PR #307 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,464
-  lines after B-11c11.
-- The mechanical extraction has removed 10,199
-  lines, approximately 80.5% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,429
+  lines after B-11c12.
+- The mechanical extraction has removed 10,234
+  lines, approximately 80.8% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -71,8 +71,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   root `_settings_json` definition in PR #304 / `236a7f5`; live serializers
   remain unchanged. B-11c11 moved only the five Detailer target normalization
   symbols to their existing generation-normalization owner in PR #305 /
-  `98812ef`. B-11c12 moves only the two live USDU tile planners to a dedicated
-  owner in PR #306; the dead tile-size wrapper remains separate.
+  `98812ef`. B-11c12 moved only the two live USDU tile planners to a dedicated
+  owner in PR #306 / `7c2fdd5`. B-11c13 removes only the dead private root
+  `_aio_usdu_tile_size` wrapper in PR #307.
 
 ### Current quality baseline
 
@@ -314,7 +315,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 USDU tile-planning Move PR #306 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 dead USDU wrapper cleanup PR #307 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -879,8 +880,12 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     #306 retains direct root alias identity and call-time root `ceil`, alignment,
     image-size, coercion, and nested auto-dimension replacement. Tile clamp,
     fallback, scale, rounding, dict order, and stage behavior remain unchanged.
-    The unused `_aio_usdu_tile_size` wrapper remains root-owned for a separate
+    The unused `_aio_usdu_tile_size` wrapper remained root-owned for a separate
     Contract/cleanup decision.
+  - B-11c13 removes only the unused private root `_aio_usdu_tile_size`
+    definition in PR #307. The compatibility fixture and flat/package contract
+    record its absence; the live canonical planners and USDU stage remain
+    unchanged.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `98812ef070096e7416bba08750a7c089f8564d29`
+  `7c2fdd50b644fe48e98220ad72f7e5c78a0b070e`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c11 are integrated through PR #305. B-11c is
+- Current state: B-11a through B-11c12 are integrated through PR #306. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c12 USDU tile planning is tracked by PR #306.
+  the final root shim; B-11c13 dead USDU wrapper cleanup is tracked by PR #307.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -84,8 +84,8 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 24 functions, 0 classes, and 26 assigned
-  globals in B-11c12 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 23 functions, 0 classes, and 26 assigned
+  globals in B-11c13 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 29 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 268, including
   literal lookups and binder-owned helper-name/default collections;
@@ -344,7 +344,19 @@ convenience-node compatibility; it remains unmapped and is not public support.
   fallback, scale floor and rounding, manual/auto return fields and insertion
   order, and input non-mutation. It does not move USDU model loading,
   conditioning, sampling, logging, metadata, or stage execution. The unused
-  `_aio_usdu_tile_size` stays root-owned pending separate cleanup.
+  `_aio_usdu_tile_size` stayed root-owned pending separate cleanup.
+
+### B-11c13 dead USDU tile-size wrapper retirement
+
+- `_aio_usdu_tile_size` was a root-only private definition with no production
+  caller, runtime resolver, public mapping/export, documented user consumer, or
+  canonical target. It is removed rather than promoted into the canonical
+  package.
+- The compatibility fixture and flat/package contract record its absence.
+  `_aio_usdu_auto_tile_dimension`, `_aio_usdu_tile_plan`, their binder, and the
+  live USDU stage remain present and unchanged.
+- PR #307 changes no tile calculation, clamp, rounding, alignment, stage,
+  model, conditioning, sampling, logging, metadata, or workflow behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/nodes.py
+++ b/nodes.py
@@ -1761,11 +1761,6 @@ def _run_aio_highres_stage(
     }
 
 
-def _aio_usdu_tile_size(image, scale_by: float, usdu_settings: dict[str, Any]) -> tuple[int, int]:
-    tile_plan = _aio_usdu_tile_plan(image, scale_by, usdu_settings)
-    return int(tile_plan["tile_width"]), int(tile_plan["tile_height"])
-
-
 def _aio_final_fit_size(width: int, height: int, fit_settings: dict[str, Any]) -> tuple[int, int, float]:
     width = max(1, int(width))
     height = max(1, int(height))

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -38184,13 +38184,13 @@
       },
       {
         "is_package": false,
-        "loc": 2429,
+        "loc": 2424,
         "module": "nodes",
-        "normalized_git_blob_sha1": "59f8b61ab03fe443fe98068cdc59114dc6672c34",
+        "normalized_git_blob_sha1": "c0657af63f4a523fffe47dcc090ac2fc2ab38650",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 24,
+          "function_count": 23,
           "global_count": 26
         }
       },
@@ -53405,7 +53405,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2328,
+        "line": 2323,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53414,7 +53414,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2331,
+        "line": 2326,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53423,7 +53423,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2334,
+        "line": 2329,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53432,7 +53432,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2337,
+        "line": 2332,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53441,7 +53441,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2340,
+        "line": 2335,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53450,7 +53450,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2343,
+        "line": 2338,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53459,7 +53459,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2346,
+        "line": 2341,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53468,7 +53468,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2349,
+        "line": 2344,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53477,7 +53477,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2352,
+        "line": 2347,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53486,7 +53486,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2355,
+        "line": 2350,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53495,7 +53495,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2358,
+        "line": 2353,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53504,7 +53504,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2361,
+        "line": 2356,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53513,7 +53513,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2364,
+        "line": 2359,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53522,7 +53522,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2367,
+        "line": 2362,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53531,7 +53531,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2370,
+        "line": 2365,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53540,7 +53540,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2374,
+        "line": 2369,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53549,7 +53549,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2377,
+        "line": 2372,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53558,7 +53558,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2381,
+        "line": 2376,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53567,7 +53567,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2384,
+        "line": 2379,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53576,7 +53576,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2388,
+        "line": 2383,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53585,7 +53585,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2391,
+        "line": 2386,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53594,7 +53594,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2394,
+        "line": 2389,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53603,7 +53603,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2397,
+        "line": 2392,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53612,7 +53612,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2400,
+        "line": 2395,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53621,7 +53621,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2403,
+        "line": 2398,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53630,7 +53630,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2410,
+        "line": 2405,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53639,7 +53639,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2416,
+        "line": 2411,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53648,7 +53648,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2421,
+        "line": 2416,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53657,7 +53657,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2425,
+        "line": 2420,
         "module": "nodes.py",
         "scope": "<module>"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "98812ef070096e7416bba08750a7c089f8564d29",
+    "base_commit": "7c2fdd50b644fe48e98220ad72f7e5c78a0b070e",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -42,7 +42,8 @@
       "B-11c9",
       "B-11c10",
       "B-11c11",
-      "B-11c12"
+      "B-11c12",
+      "B-11c13"
     ]
   },
   "enums": {
@@ -81,7 +82,7 @@
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 24,
+    "root_residual_functions": 23,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 29,
@@ -4064,7 +4065,6 @@
       "symbols": {
         "_aio_detailer_has_enabled_targets": "_aio_detailer_has_enabled_targets",
         "_aio_final_fit_size": "_aio_final_fit_size",
-        "_aio_usdu_tile_size": "_aio_usdu_tile_size",
         "_apply_aio_final_fit": "_apply_aio_final_fit",
         "_comfy_clip_loader_types": "_comfy_clip_loader_types",
         "_comfy_diffusion_model_names": "_comfy_diffusion_model_names",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -931,6 +931,7 @@ class AioUsduTilePlanningMoveContractTests(unittest.TestCase):
         for name in self.MOVED_NAMES:
             with self.subTest(name=name):
                 self.assertIs(getattr(root_module, name), getattr(canonical_module, name))
+        self.assertFalse(hasattr(root_module, "_aio_usdu_tile_size"))
 
         with (
             patch.object(root_module, "ceil", wraps=math.ceil) as ceil,
@@ -1016,17 +1017,6 @@ class AioUsduTilePlanningMoveContractTests(unittest.TestCase):
             auto_dimension.call_args_list,
             [call(1024, 900, 500, 2000), call(1536, 900, 500, 2000)],
         )
-
-        with patch.object(
-            root_module,
-            "_aio_usdu_tile_plan",
-            return_value={"tile_width": 111, "tile_height": 222},
-        ) as tile_plan:
-            self.assertEqual(
-                root_module._aio_usdu_tile_size("image", 2.0, {"manual": True}),
-                (111, 222),
-            )
-        tile_plan.assert_called_once_with("image", 2.0, {"manual": True})
 
     def test_root_aliases_and_call_time_helpers(self):
         self._assert_contract(nodes, aio_usdu)

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "59f8b61ab03fe443fe98068cdc59114dc6672c34")
-        # Issue #184 B-11c12 moves the two live USDU tile-planning helpers
-        # while the dead tile-size wrapper remains root-owned for cleanup.
-        self.assertEqual(report["top_level"]["function_count"], 24)
+        self.assertEqual(report["git_blob_sha1"], "c0657af63f4a523fffe47dcc090ac2fc2ab38650")
+        # Issue #184 B-11c13 retires only the dead private USDU tile-size
+        # wrapper while the live canonical tile planners remain unchanged.
+        self.assertEqual(report["top_level"]["function_count"], 23)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_429)
+        self.assertEqual(report["line_count"], 2_424)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "98812ef070096e7416bba08750a7c089f8564d29"
+BASE_COMMIT = "7c2fdd50b644fe48e98220ad72f7e5c78a0b070e"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1315,6 +1315,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c10",
                 "B-11c11",
                 "B-11c12",
+                "B-11c13",
             ],
         },
         "enums": {
@@ -1331,7 +1332,7 @@ def _build_document() -> dict[str, Any]:
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 24,
+            "root_residual_functions": 23,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 29,


### PR DESCRIPTION
## 변경 요약

- B-11c13 단일 Contract/cleanup으로 사용되지 않는 private root `_aio_usdu_tile_size` 정의를 제거합니다.
- live `_aio_usdu_tile_plan`과 canonical `easyuse_anima.aio.usdu`는 변경하지 않습니다.

## 작업 전 inventory

### Symbol / caller

- `_aio_usdu_tile_size`
  - 정의: `nodes.py` root private function
  - production/canonical/runtime-resolver/string consumer: 없음
  - test-only consumer: B-11c12의 root-plan delegation 임시 계약 1곳
  - docs/fixture: unused/dead 별도 cleanup 대상으로만 기록
- dependencies: root direct alias `_aio_usdu_tile_plan`, builtin `int`
- public mapping/export/canonical alias: 없음

### Alias / global-state seam

- canonical target이 없는 root-only dead definition입니다.
- cache, mutable module state, I/O, logger, optional dependency, workflow mutation이 없습니다.
- live USDU stage는 이미 `_aio_usdu_tile_plan`을 직접 호출합니다.

## Allowed-file boundary

- production: `nodes.py`
- contract/analyzer: `tests/test_node_contracts.py`, `tests/test_nodes_module_analyzer.py`, `tests/test_python_compatibility_surface.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 예상 계약 delta

- root/top-level residual functions: `24 → 23`
- canonical bindings 284, globals 26, runtime binders 29: 변화 없음
- `nodes.py` line count: `2429 → 2424`
- flat/package root에서 `_aio_usdu_tile_size` 부재를 명시적으로 고정

## 금지 경계

- `_aio_usdu_auto_tile_dimension`, `_aio_usdu_tile_plan`, `easyuse_anima.aio.usdu`, binder 변경 금지
- USDU 계산/clamp/round/alignment/stage/model/conditioning/sampling/logging/metadata 변경 금지
- 새 canonical alias 또는 replacement wrapper 생성 금지
- 다른 residual cleanup, Move, Behavior 변경 결합 금지

## 검증

- focused contract/USDU behavior/analyzer/compatibility: 21 passed
- 독립 diff review: P1-P3 없음
- exact head `bacba119ac644c8e535c7d8a5c990da4940198fa`의 `tools/check_project.ps1 -Profile full`: passed
  - Python unittest: 908 passed
  - frontend: 114 JavaScript files passed
  - Pyright baseline ratchet: passed
  - Python import boundary: 6 groups, 0 violations
  - G-01 Ruff: 기존 108건 report-only, 실행 성공
  - `git diff --check`: passed
- Live ComfyUI/browser smoke: private dead-symbol Contract cleanup 범위에서는 수행하지 않음

## 남은 위험 / 미확인

- 저장소와 compatibility 증거에는 없지만 외부 코드가 undocumented private helper를 직접 import했을 가능성은 이론적으로 남습니다.
