### PR TITLE
refactor: move final-fit size planning

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `21f8c97ab6a61a03d8eca3aac1864e2c565c3b46`
+- Integrated `dev` snapshot commit: `5a86162f9063373aedc1718dc6cb5d1cd6a93fee`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c13 / `21f8c97`; B-11c14 Detailer enabled-target predicate Move in PR #308 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c14 / `5a86162`; B-11c15 final-fit size planning Move in PR #309 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,9 +42,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,424
-  lines after B-11c13.
-- The mechanical extraction has removed 10,239
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,416
+  lines after B-11c14.
+- The mechanical extraction has removed 10,247
   lines, approximately 80.9% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
@@ -73,8 +73,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   symbols to their existing generation-normalization owner in PR #305 /
   `98812ef`. B-11c12 moved only the two live USDU tile planners to a dedicated
   owner in PR #306 / `7c2fdd5`. B-11c13 removed only the dead private root
-  `_aio_usdu_tile_size` wrapper in PR #307 / `21f8c97`. B-11c14 moves only the
-  Detailer enabled-target predicate in PR #308.
+  `_aio_usdu_tile_size` wrapper in PR #307 / `21f8c97`. B-11c14 moved only the
+  Detailer enabled-target predicate in PR #308 / `5a86162`. B-11c15 moves only
+  final-fit size planning in PR #309.
 
 ### Current quality baseline
 
@@ -316,7 +317,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 Detailer enabled-target predicate Move PR #308 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 final-fit size planning Move PR #309 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -892,6 +893,11 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     predicate remains a direct alias and resolves boolean coercion and target
     ordering at call time; Detailer normalization and stage execution remain
     unchanged.
+  - B-11c15 moves only `_aio_final_fit_size` to the dedicated
+    `easyuse_anima.aio.postprocess` owner in PR #309. Root coercion, square-root,
+    alignment, and latent-alignment seams remain call-time resolved. Final-fit
+    application, resize, postprocess stage execution, and
+    `AIO_FINAL_FIT_MODES` ownership remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,15 +3,15 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `21f8c97ab6a61a03d8eca3aac1864e2c565c3b46`
+  `5a86162f9063373aedc1718dc6cb5d1cd6a93fee`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c13 are integrated through PR #307. B-11c is
+- Current state: B-11a through B-11c14 are integrated through PR #308. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c14 Detailer enabled-target predicate Move is tracked
-  by PR #308.
+  the final root shim; B-11c15 final-fit size planning Move is tracked by PR
+  #309.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -76,7 +76,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 285 in B-11c14
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 287 in B-11c15
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -85,10 +85,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 22 functions, 0 classes, and 26 assigned
-  globals in B-11c14 (41/2/33 at the integrated B-10b20 baseline).
-- import-time runtime binders: 29 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 268, including
+- root-owned residual implementation: 21 functions, 0 classes, and 26 assigned
+  globals in B-11c15 (41/2/33 at the integrated B-10b20 baseline).
+- import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
+- root names reached by those canonical runtime resolvers: 270, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -372,6 +372,22 @@ convenience-node compatibility; it remains unmapped and is not public support.
   evaluation are preserved.
 - PR #308 changes no Detailer defaults/normalization, stage/target execution,
   SAM3/Impact behavior, metadata, preview, schema, or workflow behavior.
+
+### B-11c15 final-fit size-planning alias
+
+- Canonical owner: `easyuse_anima.aio.postprocess` for
+  `_aio_final_fit_size`.
+- The private root function remains a transitional direct alias in relative
+  package and flat import modes. Root `_apply_aio_final_fit` continues to call
+  that alias.
+- The postprocess binder resolves `_as_bool`, `_as_float`, `_as_int`, `sqrt`,
+  `_align_down`, and `LATENT_ALIGN` at use time. Width/height clamp order,
+  disabled and no-downscale short-circuits, mode fallback, strict pixel/edge
+  comparisons, Python rounding, alignment call order, and settings immutability
+  are preserved.
+- PR #309 does not move or change `AIO_FINAL_FIT_MODES`, final-fit application,
+  resize behavior, postprocess stage execution, logging, metadata, schema, or
+  workflow behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/postprocess.py
+++ b/easyuse_anima/aio/postprocess.py
@@ -1,0 +1,75 @@
+"""AiO postprocess size-planning policy."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeAlias
+
+_RuntimeResolver: TypeAlias = Callable[[str], Any]
+_RUNTIME_RESOLVER: _RuntimeResolver | None = None
+
+
+def _bind_aio_postprocess_runtime(*, resolve_helper: _RuntimeResolver) -> None:
+    """Bind root compatibility helpers without importing the root module."""
+
+    global _RUNTIME_RESOLVER
+    _RUNTIME_RESOLVER = resolve_helper
+
+
+def _runtime_helper(name: str) -> Any:
+    resolver = _RUNTIME_RESOLVER
+    if resolver is None:
+        raise RuntimeError(
+            f"[EasyUseAnima] AiO postprocess runtime helper is not bound: {name}"
+        )
+    return resolver(name)
+
+
+def _aio_final_fit_size(
+    width: int,
+    height: int,
+    fit_settings: dict[str, Any],
+) -> tuple[int, int, float]:
+    width = max(1, int(width))
+    height = max(1, int(height))
+    if not _runtime_helper("_as_bool")(fit_settings.get("enabled"), False):
+        return width, height, 1.0
+    mode = str(fit_settings.get("mode") or "max_long_edge")
+    scale = 1.0
+    if mode == "megapixels":
+        max_pixels = max(
+            1.0,
+            _runtime_helper("_as_float")(
+                fit_settings.get("max_megapixels"),
+                4.0,
+            )
+            * 1_000_000.0,
+        )
+        pixels = float(width * height)
+        if pixels > max_pixels:
+            scale = _runtime_helper("sqrt")(max_pixels / pixels)
+    else:
+        max_long_edge = max(
+            1,
+            _runtime_helper("_as_int")(
+                fit_settings.get("max_long_edge"),
+                2048,
+            ),
+        )
+        long_edge = max(width, height)
+        if long_edge > max_long_edge:
+            scale = max_long_edge / long_edge
+    if scale >= 1.0:
+        return width, height, 1.0
+    target_width = _runtime_helper("_align_down")(
+        round(width * scale),
+        _runtime_helper("LATENT_ALIGN"),
+    )
+    target_height = _runtime_helper("_align_down")(
+        round(height * scale),
+        _runtime_helper("LATENT_ALIGN"),
+    )
+    return max(1, target_width), max(1, target_height), scale
+
+
+__all__ = ()

--- a/nodes.py
+++ b/nodes.py
@@ -49,6 +49,10 @@ try:
         _aio_usdu_tile_plan as _aio_usdu_tile_plan,
         _bind_aio_usdu_planning_runtime as _bind_aio_usdu_planning_runtime,
     )
+    from .easyuse_anima.aio.postprocess import (
+        _aio_final_fit_size as _aio_final_fit_size,
+        _bind_aio_postprocess_runtime as _bind_aio_postprocess_runtime,
+    )
     from .easyuse_anima.aio.conditioning import (
         _aio_prompt_data_fields_for_usdu as _aio_prompt_data_fields_for_usdu,
         _aio_usdu_conditioning as _aio_usdu_conditioning,
@@ -592,6 +596,10 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _aio_usdu_auto_tile_dimension as _aio_usdu_auto_tile_dimension,
         _aio_usdu_tile_plan as _aio_usdu_tile_plan,
         _bind_aio_usdu_planning_runtime as _bind_aio_usdu_planning_runtime,
+    )
+    from easyuse_anima.aio.postprocess import (
+        _aio_final_fit_size as _aio_final_fit_size,
+        _bind_aio_postprocess_runtime as _bind_aio_postprocess_runtime,
     )
     from easyuse_anima.aio.conditioning import (
         _aio_prompt_data_fields_for_usdu as _aio_prompt_data_fields_for_usdu,
@@ -1763,30 +1771,6 @@ def _run_aio_highres_stage(
     }
 
 
-def _aio_final_fit_size(width: int, height: int, fit_settings: dict[str, Any]) -> tuple[int, int, float]:
-    width = max(1, int(width))
-    height = max(1, int(height))
-    if not _as_bool(fit_settings.get("enabled"), False):
-        return width, height, 1.0
-    mode = str(fit_settings.get("mode") or "max_long_edge")
-    scale = 1.0
-    if mode == "megapixels":
-        max_pixels = max(1.0, _as_float(fit_settings.get("max_megapixels"), 4.0) * 1_000_000.0)
-        pixels = float(width * height)
-        if pixels > max_pixels:
-            scale = sqrt(max_pixels / pixels)
-    else:
-        max_long_edge = max(1, _as_int(fit_settings.get("max_long_edge"), 2048))
-        long_edge = max(width, height)
-        if long_edge > max_long_edge:
-            scale = max_long_edge / long_edge
-    if scale >= 1.0:
-        return width, height, 1.0
-    target_width = _align_down(round(width * scale), LATENT_ALIGN)
-    target_height = _align_down(round(height * scale), LATENT_ALIGN)
-    return max(1, target_width), max(1, target_height), scale
-
-
 def _apply_aio_final_fit(image, postprocess_settings: dict[str, Any]) -> tuple[Any, dict[str, Any]]:
     fit_settings = postprocess_settings.get("fit", {})
     if not isinstance(fit_settings, dict):
@@ -2322,6 +2306,9 @@ _bind_aio_generation_normalization_runtime(
     resolve_helper=lambda name: globals()[name],
 )
 _bind_aio_usdu_planning_runtime(
+    resolve_helper=lambda name: globals()[name],
+)
+_bind_aio_postprocess_runtime(
     resolve_helper=lambda name: globals()[name],
 )
 _bind_aio_resource_runtime(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6428,6 +6428,74 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TypeAlias",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TypeAlias",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/aio/preview.py"
       },
       {
@@ -15223,6 +15291,68 @@
         "target": "easyuse_anima/aio/usdu.py"
       },
       {
+        "alias": "_aio_final_fit_size",
+        "bound_name": "_aio_final_fit_size",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_aio_final_fit_size",
+          "target": "easyuse_anima/aio/postprocess.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
+        "kind": "static_from",
+        "line": 52,
+        "name": "_aio_final_fit_size",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.postprocess",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "alias": "_bind_aio_postprocess_runtime",
+        "bound_name": "_bind_aio_postprocess_runtime",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_aio_postprocess_runtime",
+          "target": "easyuse_anima/aio/postprocess.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
+        "kind": "static_from",
+        "line": 52,
+        "name": "_bind_aio_postprocess_runtime",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.postprocess",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
         "alias": "_aio_prompt_data_fields_for_usdu",
         "bound_name": "_aio_prompt_data_fields_for_usdu",
         "branch_context": [
@@ -15244,7 +15374,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 52,
+        "line": 56,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15275,7 +15405,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 52,
+        "line": 56,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15306,7 +15436,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 52,
+        "line": 56,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15337,7 +15467,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 52,
+        "line": 56,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15368,7 +15498,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15399,7 +15529,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15430,7 +15560,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15461,7 +15591,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15492,7 +15622,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15523,7 +15653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15554,7 +15684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15585,7 +15715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15616,7 +15746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15647,7 +15777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15678,7 +15808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15709,7 +15839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15740,7 +15870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 58,
+        "line": 62,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15771,7 +15901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 73,
+        "line": 77,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15802,7 +15932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 73,
+        "line": 77,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15833,7 +15963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 73,
+        "line": 77,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15864,7 +15994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 73,
+        "line": 77,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15895,7 +16025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 73,
+        "line": 77,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15926,7 +16056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 73,
+        "line": 77,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15957,7 +16087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 73,
+        "line": 77,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15988,7 +16118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 73,
+        "line": 77,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16019,7 +16149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 73,
+        "line": 77,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16050,7 +16180,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 73,
+        "line": 77,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16081,7 +16211,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 73,
+        "line": 77,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16112,7 +16242,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 73,
+        "line": 77,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16143,7 +16273,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16174,7 +16304,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16205,7 +16335,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16236,7 +16366,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16267,7 +16397,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16298,7 +16428,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16329,7 +16459,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16360,7 +16490,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16391,7 +16521,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16422,7 +16552,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16453,7 +16583,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 99,
+        "line": 103,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16484,7 +16614,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 99,
+        "line": 103,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16515,7 +16645,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 99,
+        "line": 103,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16546,7 +16676,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 99,
+        "line": 103,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16577,7 +16707,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 99,
+        "line": 103,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16608,7 +16738,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 99,
+        "line": 103,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16639,7 +16769,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 99,
+        "line": 103,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16670,7 +16800,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 99,
+        "line": 103,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16701,7 +16831,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 99,
+        "line": 103,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16732,7 +16862,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 99,
+        "line": 103,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16763,7 +16893,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 111,
+        "line": 115,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16794,7 +16924,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 111,
+        "line": 115,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16825,7 +16955,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 111,
+        "line": 115,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16856,7 +16986,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 111,
+        "line": 115,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16887,7 +17017,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 111,
+        "line": 115,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16918,7 +17048,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 111,
+        "line": 115,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16949,7 +17079,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 111,
+        "line": 115,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16980,7 +17110,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 111,
+        "line": 115,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17011,7 +17141,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 111,
+        "line": 115,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17042,7 +17172,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 111,
+        "line": 115,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17073,7 +17203,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 111,
+        "line": 115,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17104,7 +17234,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 111,
+        "line": 115,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17135,7 +17265,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 125,
+        "line": 129,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17166,7 +17296,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 125,
+        "line": 129,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17197,7 +17327,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 125,
+        "line": 129,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17228,7 +17358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 130,
+        "line": 134,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17259,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 130,
+        "line": 134,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17290,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 130,
+        "line": 134,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17321,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 130,
+        "line": 134,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17352,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 130,
+        "line": 134,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17383,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 137,
+        "line": 141,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17414,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 138,
+        "line": 142,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17445,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 138,
+        "line": 142,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17476,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 138,
+        "line": 142,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17507,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 138,
+        "line": 142,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17538,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 144,
+        "line": 148,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17569,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 144,
+        "line": 148,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17600,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 144,
+        "line": 148,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17631,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 144,
+        "line": 148,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17662,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 144,
+        "line": 148,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17693,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 144,
+        "line": 148,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17724,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 144,
+        "line": 148,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17755,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 144,
+        "line": 148,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17786,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 144,
+        "line": 148,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17817,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 144,
+        "line": 148,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17848,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 158,
+        "line": 162,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17879,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 158,
+        "line": 162,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17910,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 158,
+        "line": 162,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17941,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 158,
+        "line": 162,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17972,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 158,
+        "line": 162,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18003,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 158,
+        "line": 162,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18034,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 158,
+        "line": 162,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18065,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18096,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18127,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18158,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18189,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18220,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18251,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18282,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18313,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18344,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18375,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18406,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18437,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18468,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18499,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18530,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18561,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18592,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18623,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18654,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18685,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18716,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 176,
+        "line": 180,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18747,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18778,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18809,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18840,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18871,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18902,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18933,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18964,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18995,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19026,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19057,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19088,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19119,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19150,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 212,
+        "line": 216,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19181,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 240,
+        "line": 244,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19212,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 240,
+        "line": 244,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19243,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 240,
+        "line": 244,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19274,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 240,
+        "line": 244,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19305,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 240,
+        "line": 244,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19336,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 240,
+        "line": 244,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19367,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 240,
+        "line": 244,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19398,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 240,
+        "line": 244,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19429,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 240,
+        "line": 244,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19460,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19491,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19522,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19553,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19584,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19615,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19646,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19677,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19708,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19739,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19770,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19801,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19832,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19863,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19894,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19925,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19956,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19987,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20018,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20049,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20080,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20111,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20142,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20173,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20204,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 256,
+        "line": 260,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20235,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20266,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20297,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20328,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20359,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 342,
+        "line": 346,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20390,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 342,
+        "line": 346,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20421,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 342,
+        "line": 346,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20452,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 347,
+        "line": 351,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20483,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 347,
+        "line": 351,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20514,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 347,
+        "line": 351,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20545,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20576,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20607,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20638,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20669,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20700,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20731,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20762,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 362,
+        "line": 366,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20793,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 362,
+        "line": 366,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20824,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 362,
+        "line": 366,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20855,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 373,
+        "line": 377,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20886,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 373,
+        "line": 377,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20917,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 373,
+        "line": 377,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20948,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 373,
+        "line": 377,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20979,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 386,
+        "line": 390,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21010,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 386,
+        "line": 390,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21041,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 394,
+        "line": 398,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21072,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 394,
+        "line": 398,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21103,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 394,
+        "line": 398,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21134,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 394,
+        "line": 398,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21165,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 394,
+        "line": 398,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21196,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 394,
+        "line": 398,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21227,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 394,
+        "line": 398,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21258,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 394,
+        "line": 398,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21289,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 405,
+        "line": 409,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21320,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 405,
+        "line": 409,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21351,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 405,
+        "line": 409,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21382,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 405,
+        "line": 409,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21413,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 411,
+        "line": 415,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21444,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 411,
+        "line": 415,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21475,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 411,
+        "line": 415,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21506,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 411,
+        "line": 415,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21537,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 411,
+        "line": 415,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21568,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 419,
+        "line": 423,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21599,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 419,
+        "line": 423,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21630,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 423,
+        "line": 427,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21661,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 427,
+        "line": 431,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21692,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 427,
+        "line": 431,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21723,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 427,
+        "line": 431,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21754,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 432,
+        "line": 436,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21785,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 432,
+        "line": 436,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21816,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 432,
+        "line": 436,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21847,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 432,
+        "line": 436,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21878,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 432,
+        "line": 436,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21909,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 439,
+        "line": 443,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21940,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 439,
+        "line": 443,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21971,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 439,
+        "line": 443,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22002,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 444,
+        "line": 448,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22033,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 444,
+        "line": 448,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22064,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 444,
+        "line": 448,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22095,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 462,
+        "line": 466,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22126,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 462,
+        "line": 466,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22157,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 462,
+        "line": 466,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22188,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 462,
+        "line": 466,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22219,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 462,
+        "line": 466,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22250,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 485,
+        "line": 489,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22281,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 485,
+        "line": 489,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22312,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 489,
+        "line": 493,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22343,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 489,
+        "line": 493,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22374,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22405,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22436,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22467,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22498,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22529,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22560,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22591,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22622,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22653,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22684,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22715,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22746,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22777,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22808,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 494,
+        "line": 498,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22839,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 511,
+        "line": 515,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22870,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 511,
+        "line": 515,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22901,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 511,
+        "line": 515,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22932,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 511,
+        "line": 515,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22963,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 511,
+        "line": 515,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -22994,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 511,
+        "line": 515,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23025,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 511,
+        "line": 515,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23056,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 511,
+        "line": 515,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23087,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 521,
+        "line": 525,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23118,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 521,
+        "line": 525,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23149,7 +23279,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 525,
+        "line": 529,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23180,7 +23310,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 525,
+        "line": 529,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23211,7 +23341,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 526,
+        "line": 530,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23242,7 +23372,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 527,
+        "line": 531,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23273,7 +23403,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 527,
+        "line": 531,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23304,7 +23434,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 527,
+        "line": 531,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23335,7 +23465,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 532,
+        "line": 536,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23366,7 +23496,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 532,
+        "line": 536,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23397,7 +23527,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23428,7 +23558,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23459,7 +23589,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23490,7 +23620,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23521,7 +23651,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23552,7 +23682,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23583,7 +23713,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23614,7 +23744,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23645,7 +23775,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23676,7 +23806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23707,7 +23837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23738,7 +23868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23769,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23800,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23831,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23862,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23893,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23924,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23955,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23974,7 +24104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -23989,7 +24119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24008,7 +24138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24023,7 +24153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24042,7 +24172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24057,7 +24187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24076,7 +24206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24091,7 +24221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24110,7 +24240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24125,7 +24255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24144,7 +24274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24159,7 +24289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24178,7 +24308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24193,7 +24323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24212,7 +24342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24227,7 +24357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24246,7 +24376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24261,7 +24391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 566,
+        "line": 570,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24280,7 +24410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24295,7 +24425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 566,
+        "line": 570,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24314,7 +24444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24329,7 +24459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24348,7 +24478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24363,7 +24493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24382,7 +24512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24397,7 +24527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24416,7 +24546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24431,7 +24561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24450,7 +24580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24465,7 +24595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24484,7 +24614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24499,7 +24629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24518,7 +24648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24533,7 +24663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24552,7 +24682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24567,7 +24697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24586,7 +24716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24601,7 +24731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24620,7 +24750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24635,7 +24765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24654,7 +24784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24669,7 +24799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24688,7 +24818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24703,7 +24833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24722,7 +24852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24737,7 +24867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24756,7 +24886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24771,7 +24901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24790,7 +24920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24805,7 +24935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24824,7 +24954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24839,7 +24969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24858,7 +24988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24873,7 +25003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 588,
+        "line": 592,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -24892,7 +25022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24907,7 +25037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 591,
+        "line": 595,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -24926,7 +25056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24941,7 +25071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 591,
+        "line": 595,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -24960,7 +25090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -24975,7 +25105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 591,
+        "line": 595,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -24983,6 +25113,74 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "alias": "_aio_final_fit_size",
+        "bound_name": "_aio_final_fit_size",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 558,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_aio_final_fit_size",
+          "target": "easyuse_anima/aio/postprocess.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
+        "kind": "static_from",
+        "line": 600,
+        "name": "_aio_final_fit_size",
+        "optional": false,
+        "requested": "easyuse_anima.aio.postprocess",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "alias": "_bind_aio_postprocess_runtime",
+        "bound_name": "_bind_aio_postprocess_runtime",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 558,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_aio_postprocess_runtime",
+          "target": "easyuse_anima/aio/postprocess.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
+        "kind": "static_from",
+        "line": 600,
+        "name": "_bind_aio_postprocess_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.aio.postprocess",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
       },
       {
         "alias": "_aio_prompt_data_fields_for_usdu",
@@ -24994,7 +25192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25009,7 +25207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 596,
+        "line": 604,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25028,7 +25226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25043,7 +25241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 596,
+        "line": 604,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25062,7 +25260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25077,7 +25275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 596,
+        "line": 604,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25096,7 +25294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25111,7 +25309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 596,
+        "line": 604,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25130,7 +25328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25145,7 +25343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25164,7 +25362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25179,7 +25377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25198,7 +25396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25213,7 +25411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25232,7 +25430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25247,7 +25445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25266,7 +25464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25281,7 +25479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25300,7 +25498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25315,7 +25513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25334,7 +25532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25349,7 +25547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25368,7 +25566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25383,7 +25581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25402,7 +25600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25417,7 +25615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25436,7 +25634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25451,7 +25649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25470,7 +25668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25485,7 +25683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25504,7 +25702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25519,7 +25717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25538,7 +25736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25553,7 +25751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25572,7 +25770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25587,7 +25785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25606,7 +25804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25621,7 +25819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25640,7 +25838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25655,7 +25853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25674,7 +25872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25689,7 +25887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25708,7 +25906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25723,7 +25921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25742,7 +25940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25757,7 +25955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25776,7 +25974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25791,7 +25989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25810,7 +26008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25825,7 +26023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25844,7 +26042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25859,7 +26057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25878,7 +26076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25893,7 +26091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25912,7 +26110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25927,7 +26125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25946,7 +26144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25961,7 +26159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25980,7 +26178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -25995,7 +26193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26014,7 +26212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26029,7 +26227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26048,7 +26246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26063,7 +26261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26082,7 +26280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26097,7 +26295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26116,7 +26314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26131,7 +26329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26150,7 +26348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26165,7 +26363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26184,7 +26382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26199,7 +26397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26218,7 +26416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26233,7 +26431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26252,7 +26450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26267,7 +26465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26286,7 +26484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26301,7 +26499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26320,7 +26518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26335,7 +26533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26354,7 +26552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26369,7 +26567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26388,7 +26586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26403,7 +26601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26422,7 +26620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26437,7 +26635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26456,7 +26654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26471,7 +26669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26490,7 +26688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26505,7 +26703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26524,7 +26722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26539,7 +26737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26558,7 +26756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26573,7 +26771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26592,7 +26790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26607,7 +26805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26626,7 +26824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26641,7 +26839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26660,7 +26858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26675,7 +26873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26694,7 +26892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26709,7 +26907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26728,7 +26926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26743,7 +26941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26762,7 +26960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26777,7 +26975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26796,7 +26994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26811,7 +27009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26830,7 +27028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26845,7 +27043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26864,7 +27062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26879,7 +27077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26898,7 +27096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26913,7 +27111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26932,7 +27130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26947,7 +27145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26966,7 +27164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -26981,7 +27179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27000,7 +27198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27015,7 +27213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27034,7 +27232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27049,7 +27247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27068,7 +27266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27083,7 +27281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 669,
+        "line": 677,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27102,7 +27300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27117,7 +27315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 669,
+        "line": 677,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27136,7 +27334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27151,7 +27349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 669,
+        "line": 677,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27170,7 +27368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27185,7 +27383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 674,
+        "line": 682,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27204,7 +27402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27219,7 +27417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 674,
+        "line": 682,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27238,7 +27436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27253,7 +27451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 674,
+        "line": 682,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27272,7 +27470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27287,7 +27485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 674,
+        "line": 682,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27306,7 +27504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27321,7 +27519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 674,
+        "line": 682,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27340,7 +27538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27355,7 +27553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 681,
+        "line": 689,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -27374,7 +27572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27389,7 +27587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 682,
+        "line": 690,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27408,7 +27606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27423,7 +27621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 682,
+        "line": 690,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27442,7 +27640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27457,7 +27655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 682,
+        "line": 690,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27476,7 +27674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27491,7 +27689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 682,
+        "line": 690,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27510,7 +27708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27525,7 +27723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27544,7 +27742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27559,7 +27757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27578,7 +27776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27593,7 +27791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27612,7 +27810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27627,7 +27825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27646,7 +27844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27661,7 +27859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27680,7 +27878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27695,7 +27893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27714,7 +27912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27729,7 +27927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27748,7 +27946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27763,7 +27961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27782,7 +27980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27797,7 +27995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27816,7 +28014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27831,7 +28029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27850,7 +28048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27865,7 +28063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27884,7 +28082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27899,7 +28097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27918,7 +28116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27933,7 +28131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27952,7 +28150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -27967,7 +28165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27986,7 +28184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28001,7 +28199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28020,7 +28218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28035,7 +28233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28054,7 +28252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28069,7 +28267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28088,7 +28286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28103,7 +28301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28122,7 +28320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28137,7 +28335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28156,7 +28354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28171,7 +28369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28190,7 +28388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28205,7 +28403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28224,7 +28422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28239,7 +28437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28258,7 +28456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28273,7 +28471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28292,7 +28490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28307,7 +28505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28326,7 +28524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28341,7 +28539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28360,7 +28558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28375,7 +28573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28394,7 +28592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28409,7 +28607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28428,7 +28626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28443,7 +28641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28462,7 +28660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28477,7 +28675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28496,7 +28694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28511,7 +28709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28530,7 +28728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28545,7 +28743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28564,7 +28762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28579,7 +28777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28598,7 +28796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28613,7 +28811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28632,7 +28830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28647,7 +28845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28666,7 +28864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28681,7 +28879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28700,7 +28898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28715,7 +28913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28734,7 +28932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28749,7 +28947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28768,7 +28966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28783,7 +28981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28802,7 +29000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28817,7 +29015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28836,7 +29034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28851,7 +29049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28870,7 +29068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28885,7 +29083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28904,7 +29102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28919,7 +29117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28938,7 +29136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28953,7 +29151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28972,7 +29170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -28987,7 +29185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29006,7 +29204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29021,7 +29219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29040,7 +29238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29055,7 +29253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29074,7 +29272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29089,7 +29287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29108,7 +29306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29123,7 +29321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29142,7 +29340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29157,7 +29355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29176,7 +29374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29191,7 +29389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29210,7 +29408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29225,7 +29423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29244,7 +29442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29259,7 +29457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29278,7 +29476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29293,7 +29491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29312,7 +29510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29327,7 +29525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29346,7 +29544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29361,7 +29559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29380,7 +29578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29395,7 +29593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29414,7 +29612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29429,7 +29627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29448,7 +29646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29463,7 +29661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29482,7 +29680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29497,7 +29695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29516,7 +29714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29531,7 +29729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29550,7 +29748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29565,7 +29763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29584,7 +29782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29599,7 +29797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29618,7 +29816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29633,7 +29831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29652,7 +29850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29667,7 +29865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29686,7 +29884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29701,7 +29899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29720,7 +29918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29735,7 +29933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29754,7 +29952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29769,7 +29967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29788,7 +29986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29803,7 +30001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29822,7 +30020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29837,7 +30035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29856,7 +30054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29871,7 +30069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29890,7 +30088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29905,7 +30103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29924,7 +30122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29939,7 +30137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29958,7 +30156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -29973,7 +30171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29992,7 +30190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30007,7 +30205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30026,7 +30224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30041,7 +30239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30060,7 +30258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30075,7 +30273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30094,7 +30292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30109,7 +30307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30128,7 +30326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30143,7 +30341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30162,7 +30360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30177,7 +30375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30196,7 +30394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30211,7 +30409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30230,7 +30428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30245,7 +30443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30264,7 +30462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30279,7 +30477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30298,7 +30496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30313,7 +30511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30332,7 +30530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30347,7 +30545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30366,7 +30564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30381,7 +30579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30400,7 +30598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30415,7 +30613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30434,7 +30632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30449,7 +30647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30468,7 +30666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30483,7 +30681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30502,7 +30700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30517,7 +30715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30536,7 +30734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30551,7 +30749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30570,7 +30768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30585,7 +30783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30604,7 +30802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30619,7 +30817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 886,
+        "line": 894,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30638,7 +30836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30653,7 +30851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 886,
+        "line": 894,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30672,7 +30870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30687,7 +30885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 886,
+        "line": 894,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30706,7 +30904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30721,7 +30919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 891,
+        "line": 899,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -30740,7 +30938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30755,7 +30953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 891,
+        "line": 899,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -30774,7 +30972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30789,7 +30987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 891,
+        "line": 899,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -30808,7 +31006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30823,7 +31021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30842,7 +31040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30857,7 +31055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30876,7 +31074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30891,7 +31089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30910,7 +31108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30925,7 +31123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30944,7 +31142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30959,7 +31157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -30978,7 +31176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -30993,7 +31191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31012,7 +31210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31027,7 +31225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31046,7 +31244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31061,7 +31259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 906,
+        "line": 914,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31080,7 +31278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31095,7 +31293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 906,
+        "line": 914,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31114,7 +31312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31129,7 +31327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 906,
+        "line": 914,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31148,7 +31346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31163,7 +31361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 917,
+        "line": 925,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31182,7 +31380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31197,7 +31395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 917,
+        "line": 925,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31216,7 +31414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31231,7 +31429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 917,
+        "line": 925,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31250,7 +31448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31265,7 +31463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 917,
+        "line": 925,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31284,7 +31482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31299,7 +31497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 930,
+        "line": 938,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31318,7 +31516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31333,7 +31531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 930,
+        "line": 938,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31352,7 +31550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31367,7 +31565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31386,7 +31584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31401,7 +31599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31420,7 +31618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31435,7 +31633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31454,7 +31652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31469,7 +31667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31488,7 +31686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31503,7 +31701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31522,7 +31720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31537,7 +31735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31556,7 +31754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31571,7 +31769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31590,7 +31788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31605,7 +31803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31624,7 +31822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31639,7 +31837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 949,
+        "line": 957,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31658,7 +31856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31673,7 +31871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 949,
+        "line": 957,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31692,7 +31890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31707,7 +31905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 949,
+        "line": 957,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31726,7 +31924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31741,7 +31939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 949,
+        "line": 957,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31760,7 +31958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31775,7 +31973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31794,7 +31992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31809,7 +32007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31828,7 +32026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31843,7 +32041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31862,7 +32060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31877,7 +32075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31896,7 +32094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31911,7 +32109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31930,7 +32128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31945,7 +32143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -31964,7 +32162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -31979,7 +32177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -31998,7 +32196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32013,7 +32211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 967,
+        "line": 975,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32032,7 +32230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32047,7 +32245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 971,
+        "line": 979,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32066,7 +32264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32081,7 +32279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 971,
+        "line": 979,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32100,7 +32298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32115,7 +32313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 971,
+        "line": 979,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32134,7 +32332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32149,7 +32347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 976,
+        "line": 984,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32168,7 +32366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32183,7 +32381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 976,
+        "line": 984,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32202,7 +32400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32217,7 +32415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 976,
+        "line": 984,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32236,7 +32434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32251,7 +32449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 976,
+        "line": 984,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32270,7 +32468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32285,7 +32483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 976,
+        "line": 984,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32304,7 +32502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32319,7 +32517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 983,
+        "line": 991,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32338,7 +32536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32353,7 +32551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 983,
+        "line": 991,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32372,7 +32570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32387,7 +32585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 983,
+        "line": 991,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32406,7 +32604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32421,7 +32619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 988,
+        "line": 996,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32440,7 +32638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32455,7 +32653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 988,
+        "line": 996,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32474,7 +32672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32489,7 +32687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 988,
+        "line": 996,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32508,7 +32706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32523,7 +32721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1014,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32542,7 +32740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32557,7 +32755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1014,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32576,7 +32774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32591,7 +32789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1014,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32610,7 +32808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32625,7 +32823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1014,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32644,7 +32842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32659,7 +32857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1014,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32678,7 +32876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32693,7 +32891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1037,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -32712,7 +32910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32727,7 +32925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1037,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -32746,7 +32944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32761,7 +32959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1041,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -32780,7 +32978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32795,7 +32993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1041,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -32814,7 +33012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32829,7 +33027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32848,7 +33046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32863,7 +33061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32882,7 +33080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32897,7 +33095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32916,7 +33114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32931,7 +33129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32950,7 +33148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32965,7 +33163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -32984,7 +33182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -32999,7 +33197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33018,7 +33216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33033,7 +33231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33052,7 +33250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33067,7 +33265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33086,7 +33284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33101,7 +33299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33120,7 +33318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33135,7 +33333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33154,7 +33352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33169,7 +33367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33188,7 +33386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33203,7 +33401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33222,7 +33420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33237,7 +33435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33256,7 +33454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33271,7 +33469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33290,7 +33488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33305,7 +33503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33324,7 +33522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33339,7 +33537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33358,7 +33556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33373,7 +33571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33392,7 +33590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33407,7 +33605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33426,7 +33624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33441,7 +33639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33460,7 +33658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33475,7 +33673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33494,7 +33692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33509,7 +33707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33528,7 +33726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33543,7 +33741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33562,7 +33760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33577,7 +33775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33596,7 +33794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33611,7 +33809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1073,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -33630,7 +33828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33645,7 +33843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1073,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -33664,7 +33862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33679,7 +33877,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1077,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -33698,7 +33896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33713,7 +33911,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1077,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -33732,7 +33930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33747,7 +33945,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1078,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -33766,7 +33964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33781,7 +33979,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1079,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -33800,7 +33998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33815,7 +34013,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1079,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -33834,7 +34032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33849,7 +34047,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1079,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -33868,7 +34066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33883,7 +34081,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1084,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -33902,7 +34100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33917,7 +34115,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1084,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -33936,7 +34134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33951,7 +34149,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -33970,7 +34168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -33985,7 +34183,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34004,7 +34202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34019,7 +34217,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34038,7 +34236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34053,7 +34251,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34072,7 +34270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34087,7 +34285,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34106,7 +34304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34121,7 +34319,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34140,7 +34338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34155,7 +34353,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34174,7 +34372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34189,7 +34387,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34208,7 +34406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34223,7 +34421,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34242,7 +34440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34257,7 +34455,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34276,7 +34474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34291,7 +34489,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34310,7 +34508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34325,7 +34523,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34344,7 +34542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34359,7 +34557,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34378,7 +34576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34393,7 +34591,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34412,7 +34610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34427,7 +34625,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34446,7 +34644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34461,7 +34659,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34480,7 +34678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34495,7 +34693,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34514,7 +34712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34529,7 +34727,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34548,7 +34746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -34563,7 +34761,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34581,7 +34779,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1594
+            "line": 1602
           }
         ],
         "classification": "external",
@@ -34589,37 +34787,12 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1595,
+        "line": 1603,
         "name": null,
         "optional": true,
         "requested": "nodes",
         "role": "optional_dependency",
         "scope": "_comfy_max_resolution",
-        "source": "nodes.py"
-      },
-      {
-        "alias": "comfy_nodes",
-        "bound_name": "comfy_nodes",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1631
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1632,
-        "name": null,
-        "optional": true,
-        "requested": "nodes",
-        "role": "optional_dependency",
-        "scope": "_find_comfy_node_class",
         "source": "nodes.py"
       },
       {
@@ -34640,6 +34813,31 @@
         "imported": "nodes",
         "kind": "static_import",
         "line": 1640,
+        "name": null,
+        "optional": true,
+        "requested": "nodes",
+        "role": "optional_dependency",
+        "scope": "_find_comfy_node_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "comfy_nodes",
+        "bound_name": "comfy_nodes",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 1647
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1648,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -36638,6 +36836,10 @@
       },
       {
         "from": "nodes.py",
+        "to": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "from": "nodes.py",
         "to": "easyuse_anima/aio/preview.py"
       },
       {
@@ -36991,6 +37193,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/aio/postprocess.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/aio/preview.py"
         ]
       },
@@ -37321,7 +37529,7 @@
     ]
   },
   "inventory": {
-    "module_count": 82,
+    "module_count": 83,
     "modules": [
       {
         "is_package": true,
@@ -37644,6 +37852,18 @@
         "top_level": {
           "class_count": 0,
           "function_count": 11,
+          "global_count": 3
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 75,
+        "module": "easyuse_anima.aio.postprocess",
+        "normalized_git_blob_sha1": "cd64ef7da8506791842b393fc27c3032e6167610",
+        "path": "easyuse_anima/aio/postprocess.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 3,
           "global_count": 3
         }
       },
@@ -38249,13 +38469,13 @@
       },
       {
         "is_package": false,
-        "loc": 2416,
+        "loc": 2403,
         "module": "nodes",
-        "normalized_git_blob_sha1": "90e21ddec7a46ab748af1c646973c57d4625ecb5",
+        "normalized_git_blob_sha1": "bac2b80fa25e96d203376423229014e0c5036a45",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 22,
+          "function_count": 21,
           "global_count": 26
         }
       },
@@ -39615,7 +39835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39624,7 +39844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39638,7 +39858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39647,7 +39867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39661,7 +39881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39670,7 +39890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39684,7 +39904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39693,7 +39913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39707,7 +39927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39716,7 +39936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39730,7 +39950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39739,7 +39959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39753,7 +39973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39762,7 +39982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39776,7 +39996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39785,7 +40005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 555,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39799,7 +40019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39808,7 +40028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 566,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39822,7 +40042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39831,7 +40051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 566,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39845,7 +40065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39854,7 +40074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39868,7 +40088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39877,7 +40097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39891,7 +40111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39900,7 +40120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39914,7 +40134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39923,7 +40143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39937,7 +40157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39946,7 +40166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39960,7 +40180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39969,7 +40189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39983,7 +40203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -39992,7 +40212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40006,7 +40226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40015,7 +40235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40029,7 +40249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40038,7 +40258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40052,7 +40272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40061,7 +40281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40075,7 +40295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40084,7 +40304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40098,7 +40318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40107,7 +40327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40121,7 +40341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40130,7 +40350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40144,7 +40364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40153,7 +40373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40167,7 +40387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40176,7 +40396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40190,7 +40410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40199,7 +40419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 570,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40213,7 +40433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40222,7 +40442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 588,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40236,7 +40456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40245,7 +40465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 591,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40259,7 +40479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40268,7 +40488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 591,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40282,7 +40502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40291,7 +40511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 591,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40305,7 +40525,53 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
+        "kind": "static_from",
+        "line": 600,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 558,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
+        "kind": "static_from",
+        "line": 600,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40314,7 +40580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 596,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40328,7 +40594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40337,7 +40603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 596,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40351,7 +40617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40360,7 +40626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 596,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40374,7 +40640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40383,7 +40649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 596,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40397,7 +40663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40406,7 +40672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40420,7 +40686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40429,7 +40695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40443,7 +40709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40452,7 +40718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40466,7 +40732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40475,7 +40741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40489,7 +40755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40498,7 +40764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40512,7 +40778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40521,7 +40787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40535,7 +40801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40544,7 +40810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40558,7 +40824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40567,7 +40833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40581,7 +40847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40590,7 +40856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40604,7 +40870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40613,7 +40879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40627,7 +40893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40636,7 +40902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40650,7 +40916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40659,7 +40925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40673,7 +40939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40682,7 +40948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 602,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40696,7 +40962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40705,7 +40971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40719,7 +40985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40728,7 +40994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40742,7 +41008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40751,7 +41017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40765,7 +41031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40774,7 +41040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40788,7 +41054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40797,7 +41063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40811,7 +41077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40820,7 +41086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40834,7 +41100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40843,7 +41109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40857,7 +41123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40866,7 +41132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40880,7 +41146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40889,7 +41155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40903,7 +41169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40912,7 +41178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40926,7 +41192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40935,7 +41201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40949,7 +41215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40958,7 +41224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 617,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40972,7 +41238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -40981,7 +41247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40995,7 +41261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41004,7 +41270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41018,7 +41284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41027,7 +41293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41041,7 +41307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41050,7 +41316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41064,7 +41330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41073,7 +41339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41087,7 +41353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41096,7 +41362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41110,7 +41376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41119,7 +41385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41133,7 +41399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41142,7 +41408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41156,7 +41422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41165,7 +41431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41179,7 +41445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41188,7 +41454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41202,7 +41468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41211,7 +41477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41225,7 +41491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41234,7 +41500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41248,7 +41514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41257,7 +41523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41271,7 +41537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41280,7 +41546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41294,7 +41560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41303,7 +41569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41317,7 +41583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41326,7 +41592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41340,7 +41606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41349,7 +41615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41363,7 +41629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41372,7 +41638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41386,7 +41652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41395,7 +41661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41409,7 +41675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41418,7 +41684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 643,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41432,7 +41698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41441,7 +41707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41455,7 +41721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41464,7 +41730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41478,7 +41744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41487,7 +41753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41501,7 +41767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41510,7 +41776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41524,7 +41790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41533,7 +41799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41547,7 +41813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41556,7 +41822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41570,7 +41836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41579,7 +41845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41593,7 +41859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41602,7 +41868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41616,7 +41882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41625,7 +41891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41639,7 +41905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41648,7 +41914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41662,7 +41928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41671,7 +41937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41685,7 +41951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41694,7 +41960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 655,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41708,7 +41974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41717,7 +41983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 669,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41731,7 +41997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41740,7 +42006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 669,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41754,7 +42020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41763,7 +42029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 669,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41777,7 +42043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41786,7 +42052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 674,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41800,7 +42066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41809,7 +42075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 674,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41823,7 +42089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41832,7 +42098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 674,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41846,7 +42112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41855,7 +42121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 674,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41869,7 +42135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41878,7 +42144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 674,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41892,7 +42158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41901,7 +42167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 681,
+        "line": 689,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41915,7 +42181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41924,7 +42190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 682,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41938,7 +42204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41947,7 +42213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 682,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41961,7 +42227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41970,7 +42236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 682,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41984,7 +42250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -41993,7 +42259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 682,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42007,7 +42273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42016,7 +42282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42030,7 +42296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42039,7 +42305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42053,7 +42319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42062,7 +42328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42076,7 +42342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42085,7 +42351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42099,7 +42365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42108,7 +42374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42122,7 +42388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42131,7 +42397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42145,7 +42411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42154,7 +42420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42168,7 +42434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42177,7 +42443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42191,7 +42457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42200,7 +42466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42214,7 +42480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42223,7 +42489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 688,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42237,7 +42503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42246,7 +42512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42260,7 +42526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42269,7 +42535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42283,7 +42549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42292,7 +42558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42306,7 +42572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42315,7 +42581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42329,7 +42595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42338,7 +42604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42352,7 +42618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42361,7 +42627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42375,7 +42641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42384,7 +42650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 702,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42398,7 +42664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42407,7 +42673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42421,7 +42687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42430,7 +42696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42444,7 +42710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42453,7 +42719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42467,7 +42733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42476,7 +42742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42490,7 +42756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42499,7 +42765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42513,7 +42779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42522,7 +42788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42536,7 +42802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42545,7 +42811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42559,7 +42825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42568,7 +42834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42582,7 +42848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42591,7 +42857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42605,7 +42871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42614,7 +42880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42628,7 +42894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42637,7 +42903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42651,7 +42917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42660,7 +42926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42674,7 +42940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42683,7 +42949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42697,7 +42963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42706,7 +42972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42720,7 +42986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42729,7 +42995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42743,7 +43009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42752,7 +43018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42766,7 +43032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42775,7 +43041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42789,7 +43055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42798,7 +43064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42812,7 +43078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42821,7 +43087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42835,7 +43101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42844,7 +43110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42858,7 +43124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42867,7 +43133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42881,7 +43147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42890,7 +43156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42904,7 +43170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42913,7 +43179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42927,7 +43193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42936,7 +43202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42950,7 +43216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42959,7 +43225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42973,7 +43239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -42982,7 +43248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42996,7 +43262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43005,7 +43271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43019,7 +43285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43028,7 +43294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43042,7 +43308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43051,7 +43317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43065,7 +43331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43074,7 +43340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43088,7 +43354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43097,7 +43363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43111,7 +43377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43120,7 +43386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43134,7 +43400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43143,7 +43409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43157,7 +43423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43166,7 +43432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43180,7 +43446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43189,7 +43455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43203,7 +43469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43212,7 +43478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 756,
+        "line": 764,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43226,7 +43492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43235,7 +43501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43249,7 +43515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43258,7 +43524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43272,7 +43538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43281,7 +43547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43295,7 +43561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43304,7 +43570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43318,7 +43584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43327,7 +43593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43341,7 +43607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43350,7 +43616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43364,7 +43630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43373,7 +43639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43387,7 +43653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43396,7 +43662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43410,7 +43676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43419,7 +43685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 784,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43433,7 +43699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43442,7 +43708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43456,7 +43722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43465,7 +43731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43479,7 +43745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43488,7 +43754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43502,7 +43768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43511,7 +43777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43525,7 +43791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43534,7 +43800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43548,7 +43814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43557,7 +43823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43571,7 +43837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43580,7 +43846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43594,7 +43860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43603,7 +43869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43617,7 +43883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43626,7 +43892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43640,7 +43906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43649,7 +43915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43663,7 +43929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43672,7 +43938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43686,7 +43952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43695,7 +43961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43709,7 +43975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43718,7 +43984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43732,7 +43998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43741,7 +44007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43755,7 +44021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43764,7 +44030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43778,7 +44044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43787,7 +44053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43801,7 +44067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43810,7 +44076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43824,7 +44090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43833,7 +44099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43847,7 +44113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43856,7 +44122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43870,7 +44136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43879,7 +44145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43893,7 +44159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43902,7 +44168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43916,7 +44182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43925,7 +44191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43939,7 +44205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43948,7 +44214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43962,7 +44228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43971,7 +44237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43985,7 +44251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -43994,7 +44260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 800,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44008,7 +44274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44017,7 +44283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44031,7 +44297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44040,7 +44306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44054,7 +44320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44063,7 +44329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44077,7 +44343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44086,7 +44352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44100,7 +44366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44109,7 +44375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 886,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44123,7 +44389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44132,7 +44398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 886,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44146,7 +44412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44155,7 +44421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 886,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44169,7 +44435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44178,7 +44444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 891,
+        "line": 899,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44192,7 +44458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44201,7 +44467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 891,
+        "line": 899,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44215,7 +44481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44224,7 +44490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 891,
+        "line": 899,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44238,7 +44504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44247,7 +44513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44261,7 +44527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44270,7 +44536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44284,7 +44550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44293,7 +44559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44307,7 +44573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44316,7 +44582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44330,7 +44596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44339,7 +44605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44353,7 +44619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44362,7 +44628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44376,7 +44642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44385,7 +44651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 897,
+        "line": 905,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44399,7 +44665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44408,7 +44674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 906,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44422,7 +44688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44431,7 +44697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 906,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44445,7 +44711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44454,7 +44720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 906,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44468,7 +44734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44477,7 +44743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 917,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44491,7 +44757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44500,7 +44766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 917,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44514,7 +44780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44523,7 +44789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 917,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44537,7 +44803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44546,7 +44812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 917,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44560,7 +44826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44569,7 +44835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 930,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44583,7 +44849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44592,7 +44858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 930,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44606,7 +44872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44615,7 +44881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44629,7 +44895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44638,7 +44904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44652,7 +44918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44661,7 +44927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44675,7 +44941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44684,7 +44950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44698,7 +44964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44707,7 +44973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44721,7 +44987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44730,7 +44996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44744,7 +45010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44753,7 +45019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44767,7 +45033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44776,7 +45042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 938,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44790,7 +45056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44799,7 +45065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 949,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44813,7 +45079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44822,7 +45088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 949,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44836,7 +45102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44845,7 +45111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 949,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44859,7 +45125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44868,7 +45134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 949,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44882,7 +45148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44891,7 +45157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44905,7 +45171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44914,7 +45180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44928,7 +45194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44937,7 +45203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44951,7 +45217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44960,7 +45226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44974,7 +45240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -44983,7 +45249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44997,7 +45263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45006,7 +45272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45020,7 +45286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45029,7 +45295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45043,7 +45309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45052,7 +45318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 967,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45066,7 +45332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45075,7 +45341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 971,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45089,7 +45355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45098,7 +45364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 971,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45112,7 +45378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45121,7 +45387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 971,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45135,7 +45401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45144,7 +45410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 976,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45158,7 +45424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45167,7 +45433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 976,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45181,7 +45447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45190,7 +45456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 976,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45204,7 +45470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45213,7 +45479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 976,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45227,7 +45493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45236,7 +45502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 976,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45250,7 +45516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45259,7 +45525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 983,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45273,7 +45539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45282,7 +45548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 983,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45296,7 +45562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45305,7 +45571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 983,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45319,7 +45585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45328,7 +45594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 988,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45342,7 +45608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45351,7 +45617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 988,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45365,7 +45631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45374,7 +45640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 988,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45388,7 +45654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45397,7 +45663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45411,7 +45677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45420,7 +45686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45434,7 +45700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45443,7 +45709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45457,7 +45723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45466,7 +45732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45480,7 +45746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45489,7 +45755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45503,7 +45769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45512,7 +45778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1037,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45526,7 +45792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45535,7 +45801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1037,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45549,7 +45815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45558,7 +45824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45572,7 +45838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45581,7 +45847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45595,7 +45861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45604,7 +45870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45618,7 +45884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45627,7 +45893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45641,7 +45907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45650,7 +45916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45664,7 +45930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45673,7 +45939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45687,7 +45953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45696,7 +45962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45710,7 +45976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45719,7 +45985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45733,7 +45999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45742,7 +46008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45756,7 +46022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45765,7 +46031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45779,7 +46045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45788,7 +46054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45802,7 +46068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45811,7 +46077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45825,7 +46091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45834,7 +46100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45848,7 +46114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45857,7 +46123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45871,7 +46137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45880,7 +46146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45894,7 +46160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45903,7 +46169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45917,7 +46183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45926,7 +46192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1046,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45940,7 +46206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45949,7 +46215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45963,7 +46229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45972,7 +46238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45986,7 +46252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -45995,7 +46261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46009,7 +46275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46018,7 +46284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46032,7 +46298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46041,7 +46307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46055,7 +46321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46064,7 +46330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46078,7 +46344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46087,7 +46353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46101,7 +46367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46110,7 +46376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46124,7 +46390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46133,7 +46399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46147,7 +46413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46156,7 +46422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46170,7 +46436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46179,7 +46445,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46193,7 +46459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46202,7 +46468,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46216,7 +46482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46225,7 +46491,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46239,7 +46505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46248,7 +46514,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46262,7 +46528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46271,7 +46537,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46285,7 +46551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46294,7 +46560,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46308,7 +46574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46317,7 +46583,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46331,7 +46597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46340,7 +46606,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46354,7 +46620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46363,7 +46629,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46377,7 +46643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46386,7 +46652,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46400,7 +46666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46409,7 +46675,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46423,7 +46689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46432,7 +46698,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46446,7 +46712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46455,7 +46721,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46469,7 +46735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46478,7 +46744,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46492,7 +46758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46501,7 +46767,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46515,7 +46781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46524,7 +46790,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46538,7 +46804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46547,7 +46813,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46561,7 +46827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46570,7 +46836,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46584,7 +46850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46593,7 +46859,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46607,7 +46873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46616,7 +46882,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46630,7 +46896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46639,7 +46905,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46653,7 +46919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46662,7 +46928,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46676,7 +46942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46685,7 +46951,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46699,7 +46965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46708,7 +46974,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46722,7 +46988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46731,7 +46997,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46745,7 +47011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46754,7 +47020,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46768,7 +47034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 554,
+            "handler_line": 558,
             "kind": "try",
             "line": 10
           }
@@ -46777,7 +47043,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48377,6 +48643,50 @@
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/postprocess.py"
       },
       {
         "branch_context": [],
@@ -50560,33 +50870,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1594
+            "line": 1602
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1595,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1631
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1632,
+        "line": 1603,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50606,6 +50897,25 @@
         "imported": "nodes",
         "kind": "static_import",
         "line": 1640,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 1647
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1648,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51980,33 +52290,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1594
+            "line": 1602
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1595,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1631
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1632,
+        "line": 1603,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52026,6 +52317,25 @@
         "imported": "nodes",
         "kind": "static_import",
         "line": 1640,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 1647
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1648,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52155,6 +52465,7 @@
       "easyuse_anima/aio/legacy_generation.py",
       "easyuse_anima/aio/model_preparation.py",
       "easyuse_anima/aio/output.py",
+      "easyuse_anima/aio/postprocess.py",
       "easyuse_anima/aio/preview.py",
       "easyuse_anima/aio/resources.py",
       "easyuse_anima/aio/sampling.py",
@@ -52239,6 +52550,7 @@
       "easyuse_anima/aio/legacy_generation.py",
       "easyuse_anima/aio/model_preparation.py",
       "easyuse_anima/aio/output.py",
+      "easyuse_anima/aio/postprocess.py",
       "easyuse_anima/aio/preview.py",
       "easyuse_anima/aio/resources.py",
       "easyuse_anima/aio/sampling.py",
@@ -53484,7 +53796,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1099,
+        "line": 1107,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53493,7 +53805,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2315,
+        "line": 2299,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53502,7 +53814,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2318,
+        "line": 2302,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53511,7 +53823,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2321,
+        "line": 2305,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53520,7 +53832,16 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2324,
+        "line": 2308,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_bind_aio_postprocess_runtime",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 2311,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53529,7 +53850,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2327,
+        "line": 2314,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53538,7 +53859,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2330,
+        "line": 2317,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53547,7 +53868,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2333,
+        "line": 2320,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53556,7 +53877,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2336,
+        "line": 2323,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53565,7 +53886,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2339,
+        "line": 2326,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53574,7 +53895,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2342,
+        "line": 2329,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53583,7 +53904,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2345,
+        "line": 2332,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53592,7 +53913,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2348,
+        "line": 2335,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53601,7 +53922,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2351,
+        "line": 2338,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53610,7 +53931,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2354,
+        "line": 2341,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53619,7 +53940,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2357,
+        "line": 2344,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53628,7 +53949,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2361,
+        "line": 2348,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53637,7 +53958,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2364,
+        "line": 2351,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53646,7 +53967,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2368,
+        "line": 2355,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53655,7 +53976,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2371,
+        "line": 2358,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53664,7 +53985,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2375,
+        "line": 2362,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53673,7 +53994,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2378,
+        "line": 2365,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53682,7 +54003,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2381,
+        "line": 2368,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53691,7 +54012,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2384,
+        "line": 2371,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53700,7 +54021,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2387,
+        "line": 2374,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53709,7 +54030,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2390,
+        "line": 2377,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53718,7 +54039,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2397,
+        "line": 2384,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53727,7 +54048,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2403,
+        "line": 2390,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53736,7 +54057,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2408,
+        "line": 2395,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53745,7 +54066,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2412,
+        "line": 2399,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54259,13 +54580,13 @@
       },
       {
         "kind": "dict",
-        "line": 1161,
+        "line": 1169,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1150,
+        "line": 1158,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "21f8c97ab6a61a03d8eca3aac1864e2c565c3b46",
+    "base_commit": "5a86162f9063373aedc1718dc6cb5d1cd6a93fee",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -44,7 +44,8 @@
       "B-11c11",
       "B-11c12",
       "B-11c13",
-      "B-11c14"
+      "B-11c14",
+      "B-11c15"
     ]
   },
   "enums": {
@@ -79,14 +80,14 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 285,
+    "nodes_canonical_bindings": 287,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 22,
+    "root_residual_functions": 21,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
-    "runtime_binders": 29,
+    "runtime_binders": 30,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -126,6 +127,7 @@
     "_bind_aio_legacy_generation_runtime",
     "_bind_aio_generation_normalization_runtime",
     "_bind_aio_usdu_planning_runtime",
+    "_bind_aio_postprocess_runtime",
     "_bind_aio_resource_runtime",
     "_bind_aio_model_preparation_runtime",
     "_bind_aio_sampling_runtime",
@@ -297,6 +299,9 @@
     "IMAGE_UPSCALE_METHODS": [
       "easyuse_anima.aio.generation_normalization"
     ],
+    "LATENT_ALIGN": [
+      "easyuse_anima.aio.postprocess"
+    ],
     "MAX_SEED": [
       "easyuse_anima.aio.generation_normalization",
       "easyuse_anima.aio.sampling"
@@ -431,6 +436,9 @@
     "_aio_usdu_prompt_without_general": [
       "easyuse_anima.aio.conditioning"
     ],
+    "_align_down": [
+      "easyuse_anima.aio.postprocess"
+    ],
     "_align_nearest": [
       "easyuse_anima.aio.usdu"
     ],
@@ -497,6 +505,7 @@
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.output",
+      "easyuse_anima.aio.postprocess",
       "easyuse_anima.aio.sampling",
       "easyuse_anima.aio.usdu",
       "easyuse_anima.nodes.lora_nodes",
@@ -511,6 +520,7 @@
       "easyuse_anima.aio.generation_normalization",
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.output",
+      "easyuse_anima.aio.postprocess",
       "easyuse_anima.aio.sampling",
       "easyuse_anima.nodes.regional_nodes",
       "easyuse_anima.prompt.regional"
@@ -519,6 +529,7 @@
       "easyuse_anima.aio.generation_normalization",
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.output",
+      "easyuse_anima.aio.postprocess",
       "easyuse_anima.aio.resources",
       "easyuse_anima.aio.sampling",
       "easyuse_anima.aio.usdu",
@@ -2161,6 +2172,35 @@
       "lifecycle_state": "transitional"
     },
     {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.postprocess:transitional_private_seam",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_aio_final_fit_size": "_aio_final_fit_size",
+        "_bind_aio_postprocess_runtime": "_bind_aio_postprocess_runtime"
+      },
+      "classification": "transitional_private_seam",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.postprocess",
+      "target_state": "canonical",
+      "identity_requirement": "required",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.postprocess",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "nodes.py residual runtime"
+      ],
+      "evidence": [
+        "AST:nodes.py direct runtime load"
+      ],
+      "removal_gates": [
+        "canonical production consumer migration",
+        "focused monkeypatch and identity contract review",
+        "separate B-10b or B-11 rollback unit"
+      ],
+      "lifecycle_state": "transitional"
+    },
+    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.preview:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -2401,6 +2441,7 @@
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.model_preparation",
         "canonical runtime resolver: easyuse_anima.aio.output",
+        "canonical runtime resolver: easyuse_anima.aio.postprocess",
         "canonical runtime resolver: easyuse_anima.aio.preview",
         "canonical runtime resolver: easyuse_anima.aio.resources",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
@@ -2421,6 +2462,7 @@
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.model_preparation string runtime lookup",
         "AST:easyuse_anima.aio.output string runtime lookup",
+        "AST:easyuse_anima.aio.postprocess string runtime lookup",
         "AST:easyuse_anima.aio.preview string runtime lookup",
         "AST:easyuse_anima.aio.resources string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
@@ -2461,12 +2503,14 @@
       "known_consumers": [
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
+        "canonical runtime resolver: easyuse_anima.aio.postprocess",
         "canonical runtime resolver: easyuse_anima.aio.preview",
         "canonical runtime resolver: easyuse_anima.aio.usdu"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
+        "AST:easyuse_anima.aio.postprocess string runtime lookup",
         "AST:easyuse_anima.aio.preview string runtime lookup",
         "AST:easyuse_anima.aio.usdu string runtime lookup"
       ],
@@ -2755,10 +2799,12 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.postprocess",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.postprocess string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -4065,7 +4111,6 @@
       "surface": "nodes_root_residuals",
       "kind": "functions",
       "symbols": {
-        "_aio_final_fit_size": "_aio_final_fit_size",
         "_apply_aio_final_fit": "_apply_aio_final_fit",
         "_comfy_clip_loader_types": "_comfy_clip_loader_types",
         "_comfy_diffusion_model_names": "_comfy_diffusion_model_names",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -21,6 +21,7 @@ import nodes
 from easyuse_anima import workflow
 from easyuse_anima.aio import (
     generation_normalization as aio_generation_normalization,
+    postprocess as aio_postprocess,
     resources as aio_resources,
     sampling as aio_sampling,
     usdu as aio_usdu,
@@ -1063,6 +1064,89 @@ class AioUsduTilePlanningMoveContractTests(unittest.TestCase):
             package_name = package_nodes.__package__
             package_usdu = sys.modules[f"{package_name}.easyuse_anima.aio.usdu"]
             self._assert_contract(package_nodes, package_usdu)
+
+
+class AioFinalFitPlanningMoveContractTests(unittest.TestCase):
+    MOVED_NAMES = (
+        "_aio_final_fit_size",
+        "_bind_aio_postprocess_runtime",
+    )
+
+    def _assert_contract(self, root_module, canonical_module):
+        for name in self.MOVED_NAMES:
+            with self.subTest(name=name):
+                self.assertIs(getattr(root_module, name), getattr(canonical_module, name))
+
+        disabled = {"enabled": False, "mode": "megapixels"}
+        with (
+            patch.object(root_module, "_as_bool", return_value=False) as as_bool,
+            patch.object(root_module, "_as_float") as as_float,
+            patch.object(root_module, "_as_int") as as_int,
+            patch.object(root_module, "sqrt") as sqrt,
+            patch.object(root_module, "_align_down") as align_down,
+        ):
+            self.assertEqual(
+                canonical_module._aio_final_fit_size(0, -3, disabled),
+                (1, 1, 1.0),
+            )
+        as_bool.assert_called_once_with(False, False)
+        as_float.assert_not_called()
+        as_int.assert_not_called()
+        sqrt.assert_not_called()
+        align_down.assert_not_called()
+
+        no_downscale = {"enabled": True, "mode": "unknown", "max_long_edge": 2048}
+        with (
+            patch.object(root_module, "_as_bool", return_value=True),
+            patch.object(root_module, "_as_int", return_value=2048) as as_int,
+            patch.object(root_module, "_as_float") as as_float,
+            patch.object(root_module, "sqrt") as sqrt,
+            patch.object(root_module, "_align_down") as align_down,
+        ):
+            self.assertEqual(
+                canonical_module._aio_final_fit_size(1024, 512, no_downscale),
+                (1024, 512, 1.0),
+            )
+        as_int.assert_called_once_with(2048, 2048)
+        as_float.assert_not_called()
+        sqrt.assert_not_called()
+        align_down.assert_not_called()
+
+        megapixels = {"enabled": True, "mode": "megapixels", "max_megapixels": 4}
+        original = dict(megapixels)
+        expected_scale = math.sqrt(4_000_000.0 / 12_000_000.0)
+        with (
+            patch.object(root_module, "_as_bool", return_value=True),
+            patch.object(root_module, "_as_float", return_value=4.0) as as_float,
+            patch.object(root_module, "_as_int") as as_int,
+            patch.object(root_module, "sqrt", wraps=math.sqrt) as sqrt,
+            patch.object(root_module, "LATENT_ALIGN", 32),
+            patch.object(root_module, "_align_down", side_effect=(2304, 1728)) as align_down,
+        ):
+            result = canonical_module._aio_final_fit_size(4000, 3000, megapixels)
+        self.assertEqual(result, (2304, 1728, expected_scale))
+        self.assertEqual(megapixels, original)
+        as_float.assert_called_once_with(4, 4.0)
+        as_int.assert_not_called()
+        sqrt.assert_called_once_with(4_000_000.0 / 12_000_000.0)
+        self.assertEqual(
+            align_down.call_args_list,
+            [
+                call(round(4000 * expected_scale), 32),
+                call(round(3000 * expected_scale), 32),
+            ],
+        )
+
+    def test_root_aliases_and_call_time_helpers(self):
+        self._assert_contract(nodes, aio_postprocess)
+
+    def test_package_aliases_and_call_time_helpers(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_postprocess = sys.modules[
+                f"{package_name}.easyuse_anima.aio.postprocess"
+            ]
+            self._assert_contract(package_nodes, package_postprocess)
 
 
 class AioSeedNormalizationMoveContractTests(unittest.TestCase):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "90e21ddec7a46ab748af1c646973c57d4625ecb5")
-        # Issue #184 B-11c14 moves only the Detailer enabled-target predicate
-        # to the existing generation-normalization owner.
-        self.assertEqual(report["top_level"]["function_count"], 22)
+        self.assertEqual(report["git_blob_sha1"], "bac2b80fa25e96d203376423229014e0c5036a45")
+        # Issue #184 B-11c15 moves only final-fit size planning to the
+        # canonical postprocess owner.
+        self.assertEqual(report["top_level"]["function_count"], 21)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_416)
+        self.assertEqual(report["line_count"], 2_403)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 82)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 82)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 82)
+        self.assertEqual(report["inventory"]["module_count"], 83)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 83)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 83)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
         self.assertTrue(
@@ -705,6 +705,7 @@ ignored/
                 "easyuse_anima/aio/generation_settings.py",
                 "easyuse_anima/aio/model_preparation.py",
                 "easyuse_anima/aio/output.py",
+                "easyuse_anima/aio/postprocess.py",
                 "easyuse_anima/aio/preview.py",
                 "easyuse_anima/aio/resources.py",
                 "easyuse_anima/aio/sampling.py",

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "21f8c97ab6a61a03d8eca3aac1864e2c565c3b46"
+BASE_COMMIT = "5a86162f9063373aedc1718dc6cb5d1cd6a93fee"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1317,6 +1317,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c12",
                 "B-11c13",
                 "B-11c14",
+                "B-11c15",
             ],
         },
         "enums": {
@@ -1329,14 +1330,14 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 285,
+            "nodes_canonical_bindings": 287,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 22,
+            "root_residual_functions": 21,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
-            "runtime_binders": 29,
+            "runtime_binders": 30,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -1567,7 +1568,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 29)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 30)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_string_runtime_resolvers_keep_production_seams_transitional(self):

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -20,6 +20,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.aio.generation_values",
     "easyuse_anima.aio.model_preparation",
     "easyuse_anima.aio.output",
+    "easyuse_anima.aio.postprocess",
     "easyuse_anima.aio.preview",
     "easyuse_anima.aio.sampling",
     "easyuse_anima.aio.generation_sampling",


### PR DESCRIPTION
## 변경 요약

- B-11c15 단일 Move로 `_aio_final_fit_size`를 신규 canonical owner `easyuse_anima.aio.postprocess`로 이동합니다.
- root `nodes.py`에는 relative/flat direct identity alias와 call-time replacement를 위한 postprocess binder만 유지합니다.

## 작업 전 inventory

### Symbol / caller

- `_aio_final_fit_size`
  - 현재 surface: `nodes.py` private root definition
  - production caller: root `_apply_aio_final_fit` 1곳
  - direct behavior tests: `tests/test_aio_nodes.py` 2곳
  - string resolver/public mapping/export/API/frontend/workflow consumer: 없음
- 후속 chain: `_apply_aio_final_fit` → `_run_aio_postprocess_stage` → legacy-generation root runtime lookup
- 이번 PR에서는 apply/stage를 이동하지 않습니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical 함수 identity를 유지합니다.
- 신규 `_bind_aio_postprocess_runtime`이 root `_as_bool`, `_as_float`, `_as_int`, `sqrt`, `_align_down`, `LATENT_ALIGN`을 사용 시점에 resolve합니다.
- mutable state, cache, I/O, logger, optional dependency, settings mutation이 없습니다.
- width/height clamp, disabled/scale 조기 반환, mode 분기, width-before-height alignment 호출 순서를 유지합니다.

## Allowed-file boundary

- production: `nodes.py`, 신규 `easyuse_anima/aio/postprocess.py`
- contract/analyzer: `tests/test_node_contracts.py`, `tests/test_python_package_skeleton.py`, `tests/test_python_backend_analyzer.py`, `tests/test_nodes_module_analyzer.py`, `tests/test_python_compatibility_surface.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 예상 계약 delta

- canonical bindings: `285 → 287`
- root/top-level residual functions: `22 → 21`
- runtime binders: `29 → 30`
- runtime resolver names: `268 → 270`
- shipped/runtime-closure modules: `82 → 83`
- globals 26, preamble imports 6: 변화 없음
- `nodes.py` line count: `2416 → 2403`

## 금지 경계

- `AIO_FINAL_FIT_MODES` 이동/변경 금지: normalization/schema vocabulary로 별도 ownership 단위입니다.
- `_apply_aio_final_fit`, `_run_aio_postprocess_stage`, resize helper 이동 금지
- 계산/clamp/round/alignment/mode fallback 및 평가 순서 변경 금지
- `generation_normalization.py`, `legacy_generation.py`, schema/frontend/workflow 변경 금지
- canonical-to-root import 또는 정적 helper import 금지
- 다른 residual, Contract, Behavior 변경 결합 금지

## 검증

- focused `unittest`: 38개 통과
  - 첫 실행에서 신규 binder 때문에 남아 있던 고정 개수 계약 `29`를 발견해 `30`으로 수정
  - identity, relative/flat import, call-time helper replacement, 조기 반환, mode 분기, 평가/정렬 순서, 기존 final-fit/postprocess behavior, package/analyzer/import boundary 확인
- 독립 read-only diff review: 문서의 resolver 고유 이름 수 `271` 오기 1건을 fixture 기준 `270`으로 수정한 뒤 P1-P3 finding 없음
- exact remote head `8da51c976ef9553084ac5e8dd2acc9733590b119`:
  - `tools/check_project.ps1 -Profile full` 통과
  - Python `910`개 통과
  - frontend `114`개 통과
  - Pyright baseline ratchet, Python import boundary, `git diff --check` 통과
  - Ruff `109`건은 G-01 report-only 기존 baseline이며 blocking failure 없음
- Live ComfyUI/browser smoke: private pure planning Move 범위에서는 수행하지 않음

## 주요 변경 파일

- `easyuse_anima/aio/postprocess.py`: final-fit 크기 계획 canonical owner와 runtime binder
- `nodes.py`: relative/flat direct alias, 기존 root body 제거, binder 연결
- `tests/test_node_contracts.py`: identity·late seam·평가 순서 계약
- package/analyzer/compatibility fixtures 및 아키텍처 문서: 새 owner와 실제 수치 반영

## 남은 위험 / 미확인

- 실제 ComfyUI API/module/browser smoke는 수행하지 않았습니다. 이 PR은 stdlib-only pure planning Move이며 기존 behavior 계약과 package/import gate로 검증했습니다.
- final-fit 적용, resize, stage 실행과 `AIO_FINAL_FIT_MODES` ownership은 의도적으로 root/기존 owner에 남아 후속 단위에서 별도 검토합니다.

## 상태

- Ready 후보: 독립 리뷰 및 exact-head full 검증 완료
