### PR TITLE
refactor: move final-fit application

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `5a86162f9063373aedc1718dc6cb5d1cd6a93fee`
+- Integrated `dev` snapshot commit: `05beee12624971a784251fc9f4242a213d9accf4`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c14 / `5a86162`; B-11c15 final-fit size planning Move in PR #309 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c15 / `05beee1`; B-11c16 final-fit application Move in PR #310 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,416
-  lines after B-11c14.
-- The mechanical extraction has removed 10,247
-  lines, approximately 80.9% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,403
+  lines after B-11c15.
+- The mechanical extraction has removed 10,260
+  lines, approximately 81.0% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -74,8 +74,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   `98812ef`. B-11c12 moved only the two live USDU tile planners to a dedicated
   owner in PR #306 / `7c2fdd5`. B-11c13 removed only the dead private root
   `_aio_usdu_tile_size` wrapper in PR #307 / `21f8c97`. B-11c14 moved only the
-  Detailer enabled-target predicate in PR #308 / `5a86162`. B-11c15 moves only
-  final-fit size planning in PR #309.
+  Detailer enabled-target predicate in PR #308 / `5a86162`. B-11c15 moved only
+  final-fit size planning in PR #309 / `05beee1`. B-11c16 moves only final-fit
+  application in PR #310.
 
 ### Current quality baseline
 
@@ -317,7 +318,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 final-fit size planning Move PR #309 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 final-fit application Move PR #310 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -898,6 +899,10 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     alignment, and latent-alignment seams remain call-time resolved. Final-fit
     application, resize, postprocess stage execution, and
     `AIO_FINAL_FIT_MODES` ownership remain separate.
+  - B-11c16 moves only `_apply_aio_final_fit` to the existing postprocess owner
+    in PR #310. Root image-size, final-fit planning, coercion, and shared resize
+    seams remain call-time resolved; postprocess stage execution and the shared
+    resize helper remain root-owned.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,15 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `5a86162f9063373aedc1718dc6cb5d1cd6a93fee`
+  `05beee12624971a784251fc9f4242a213d9accf4`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c14 are integrated through PR #308. B-11c is
+- Current state: B-11a through B-11c15 are integrated through PR #309. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c15 final-fit size planning Move is tracked by PR
-  #309.
+  the final root shim; B-11c16 final-fit application Move is tracked by PR #310.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -76,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 287 in B-11c15
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 288 in B-11c16
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -85,10 +84,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 21 functions, 0 classes, and 26 assigned
-  globals in B-11c15 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 20 functions, 0 classes, and 26 assigned
+  globals in B-11c16 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 270, including
+- root names reached by those canonical runtime resolvers: 271, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -388,6 +387,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - PR #309 does not move or change `AIO_FINAL_FIT_MODES`, final-fit application,
   resize behavior, postprocess stage execution, logging, metadata, schema, or
   workflow behavior.
+
+### B-11c16 final-fit application alias
+
+- Canonical owner: `easyuse_anima.aio.postprocess` for
+  `_apply_aio_final_fit`.
+- The private root function remains a transitional direct alias in relative
+  package and flat import modes. Root `_run_aio_postprocess_stage` continues to
+  call that alias, so its existing replacement seam is preserved.
+- The existing postprocess binder resolves `_as_bool`, `_image_tensor_size`,
+  `_aio_final_fit_size`, `_as_int`, `_as_float`, and
+  `_resize_image_to_size_if_needed` at use time. Fit-copy behavior, metadata
+  insertion and coercion order, no-scale short-circuit, resize method fallback,
+  and the actual resize-result `applied` override are unchanged.
+- PR #310 does not move or change the shared resize helper, postprocess stage,
+  `AIO_FINAL_FIT_MODES`, logging, schema, defaults, or workflow behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/postprocess.py
+++ b/easyuse_anima/aio/postprocess.py
@@ -72,4 +72,56 @@ def _aio_final_fit_size(
     return max(1, target_width), max(1, target_height), scale
 
 
+def _apply_aio_final_fit(
+    image,
+    postprocess_settings: dict[str, Any],
+) -> tuple[Any, dict[str, Any]]:
+    fit_settings = postprocess_settings.get("fit", {})
+    if not isinstance(fit_settings, dict):
+        fit_settings = {}
+    fit_settings = dict(fit_settings)
+    fit_settings["enabled"] = _runtime_helper("_as_bool")(
+        postprocess_settings.get("enabled"),
+        False,
+    )
+    width, height = _runtime_helper("_image_tensor_size")(image, 0, 0)
+    target_width, target_height, scale = _runtime_helper("_aio_final_fit_size")(
+        width,
+        height,
+        fit_settings,
+    )
+    metadata = {
+        "enabled": _runtime_helper("_as_bool")(
+            postprocess_settings.get("enabled"),
+            False,
+        ),
+        "mode": str(fit_settings.get("mode") or "max_long_edge"),
+        "max_long_edge": _runtime_helper("_as_int")(
+            fit_settings.get("max_long_edge"),
+            2048,
+        ),
+        "max_megapixels": _runtime_helper("_as_float")(
+            fit_settings.get("max_megapixels"),
+            4.0,
+        ),
+        "method": str(fit_settings.get("method") or "bicubic"),
+        "applied": scale < 1.0,
+        "scale": float(scale),
+        "width": int(width),
+        "height": int(height),
+        "target_width": int(target_width),
+        "target_height": int(target_height),
+    }
+    if scale >= 1.0:
+        return image, metadata
+    output, resized = _runtime_helper("_resize_image_to_size_if_needed")(
+        image,
+        target_width,
+        target_height,
+        str(fit_settings.get("method") or "bicubic"),
+    )
+    metadata["applied"] = bool(resized)
+    return output, metadata
+
+
 __all__ = ()

--- a/nodes.py
+++ b/nodes.py
@@ -50,6 +50,7 @@ try:
         _bind_aio_usdu_planning_runtime as _bind_aio_usdu_planning_runtime,
     )
     from .easyuse_anima.aio.postprocess import (
+        _apply_aio_final_fit as _apply_aio_final_fit,
         _aio_final_fit_size as _aio_final_fit_size,
         _bind_aio_postprocess_runtime as _bind_aio_postprocess_runtime,
     )
@@ -598,6 +599,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _bind_aio_usdu_planning_runtime as _bind_aio_usdu_planning_runtime,
     )
     from easyuse_anima.aio.postprocess import (
+        _apply_aio_final_fit as _apply_aio_final_fit,
         _aio_final_fit_size as _aio_final_fit_size,
         _bind_aio_postprocess_runtime as _bind_aio_postprocess_runtime,
     )
@@ -1769,39 +1771,6 @@ def _run_aio_highres_stage(
         "applied_scale": float(applied_scale),
         "sampler": _prompt_data_json_safe(stage_sampler),
     }
-
-
-def _apply_aio_final_fit(image, postprocess_settings: dict[str, Any]) -> tuple[Any, dict[str, Any]]:
-    fit_settings = postprocess_settings.get("fit", {})
-    if not isinstance(fit_settings, dict):
-        fit_settings = {}
-    fit_settings = dict(fit_settings)
-    fit_settings["enabled"] = _as_bool(postprocess_settings.get("enabled"), False)
-    width, height = _image_tensor_size(image, 0, 0)
-    target_width, target_height, scale = _aio_final_fit_size(width, height, fit_settings)
-    metadata = {
-        "enabled": _as_bool(postprocess_settings.get("enabled"), False),
-        "mode": str(fit_settings.get("mode") or "max_long_edge"),
-        "max_long_edge": _as_int(fit_settings.get("max_long_edge"), 2048),
-        "max_megapixels": _as_float(fit_settings.get("max_megapixels"), 4.0),
-        "method": str(fit_settings.get("method") or "bicubic"),
-        "applied": scale < 1.0,
-        "scale": float(scale),
-        "width": int(width),
-        "height": int(height),
-        "target_width": int(target_width),
-        "target_height": int(target_height),
-    }
-    if scale >= 1.0:
-        return image, metadata
-    output, resized = _resize_image_to_size_if_needed(
-        image,
-        target_width,
-        target_height,
-        str(fit_settings.get("method") or "bicubic"),
-    )
-    metadata["applied"] = bool(resized)
-    return output, metadata
 
 
 def _run_aio_postprocess_stage(image, postprocess_settings: dict[str, Any]) -> tuple[Any, dict[str, Any]]:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -15322,6 +15322,37 @@
         "target": "easyuse_anima/aio/postprocess.py"
       },
       {
+        "alias": "_apply_aio_final_fit",
+        "bound_name": "_apply_aio_final_fit",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_apply_aio_final_fit",
+          "target": "easyuse_anima/aio/postprocess.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
+        "kind": "static_from",
+        "line": 52,
+        "name": "_apply_aio_final_fit",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.postprocess",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
         "alias": "_bind_aio_postprocess_runtime",
         "bound_name": "_bind_aio_postprocess_runtime",
         "branch_context": [
@@ -15374,7 +15405,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15405,7 +15436,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15436,7 +15467,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15467,7 +15498,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15498,7 +15529,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15529,7 +15560,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15560,7 +15591,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15591,7 +15622,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15622,7 +15653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15653,7 +15684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15684,7 +15715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15715,7 +15746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15746,7 +15777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15777,7 +15808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15808,7 +15839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15839,7 +15870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15870,7 +15901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15901,7 +15932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 77,
+        "line": 78,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15932,7 +15963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 77,
+        "line": 78,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15963,7 +15994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 77,
+        "line": 78,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15994,7 +16025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 77,
+        "line": 78,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16025,7 +16056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 77,
+        "line": 78,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16056,7 +16087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 77,
+        "line": 78,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16087,7 +16118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 77,
+        "line": 78,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16118,7 +16149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 77,
+        "line": 78,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16149,7 +16180,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 77,
+        "line": 78,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16180,7 +16211,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 77,
+        "line": 78,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16211,7 +16242,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 77,
+        "line": 78,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16242,7 +16273,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 77,
+        "line": 78,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16273,7 +16304,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16304,7 +16335,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16335,7 +16366,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16366,7 +16397,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16397,7 +16428,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16428,7 +16459,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16459,7 +16490,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16490,7 +16521,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16521,7 +16552,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16552,7 +16583,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 91,
+        "line": 92,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16583,7 +16614,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 103,
+        "line": 104,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16614,7 +16645,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 103,
+        "line": 104,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16645,7 +16676,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 103,
+        "line": 104,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16676,7 +16707,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 103,
+        "line": 104,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16707,7 +16738,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 103,
+        "line": 104,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16738,7 +16769,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 103,
+        "line": 104,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16769,7 +16800,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 103,
+        "line": 104,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16800,7 +16831,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 103,
+        "line": 104,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16831,7 +16862,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 103,
+        "line": 104,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16862,7 +16893,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 103,
+        "line": 104,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16893,7 +16924,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16924,7 +16955,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16955,7 +16986,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16986,7 +17017,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17017,7 +17048,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17048,7 +17079,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17079,7 +17110,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17110,7 +17141,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17141,7 +17172,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17172,7 +17203,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17203,7 +17234,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17234,7 +17265,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17265,7 +17296,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 129,
+        "line": 130,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17296,7 +17327,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 129,
+        "line": 130,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17327,7 +17358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 129,
+        "line": 130,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17358,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 134,
+        "line": 135,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 134,
+        "line": 135,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 134,
+        "line": 135,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 134,
+        "line": 135,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 134,
+        "line": 135,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 141,
+        "line": 142,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 142,
+        "line": 143,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 142,
+        "line": 143,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 142,
+        "line": 143,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 142,
+        "line": 143,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 162,
+        "line": 163,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 162,
+        "line": 163,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 162,
+        "line": 163,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 162,
+        "line": 163,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 162,
+        "line": 163,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 162,
+        "line": 163,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 162,
+        "line": 163,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 180,
+        "line": 181,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 216,
+        "line": 217,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 244,
+        "line": 245,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 244,
+        "line": 245,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 244,
+        "line": 245,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 244,
+        "line": 245,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 244,
+        "line": 245,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 244,
+        "line": 245,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 244,
+        "line": 245,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 244,
+        "line": 245,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 244,
+        "line": 245,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 260,
+        "line": 261,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 366,
+        "line": 367,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 366,
+        "line": 367,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 366,
+        "line": 367,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 377,
+        "line": 378,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 377,
+        "line": 378,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 377,
+        "line": 378,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 377,
+        "line": 378,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 390,
+        "line": 391,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 390,
+        "line": 391,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 415,
+        "line": 416,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 415,
+        "line": 416,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 415,
+        "line": 416,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 415,
+        "line": 416,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 415,
+        "line": 416,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 423,
+        "line": 424,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 423,
+        "line": 424,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 427,
+        "line": 428,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 431,
+        "line": 432,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 431,
+        "line": 432,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 431,
+        "line": 432,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 436,
+        "line": 437,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 436,
+        "line": 437,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 436,
+        "line": 437,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 436,
+        "line": 437,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 436,
+        "line": 437,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 443,
+        "line": 444,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 443,
+        "line": 444,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 443,
+        "line": 444,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 448,
+        "line": 449,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 448,
+        "line": 449,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 448,
+        "line": 449,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 466,
+        "line": 467,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 466,
+        "line": 467,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 466,
+        "line": 467,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 466,
+        "line": 467,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 466,
+        "line": 467,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 489,
+        "line": 490,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 489,
+        "line": 490,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 493,
+        "line": 494,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 493,
+        "line": 494,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 515,
+        "line": 516,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 515,
+        "line": 516,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 515,
+        "line": 516,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 515,
+        "line": 516,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 515,
+        "line": 516,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 515,
+        "line": 516,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 515,
+        "line": 516,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 515,
+        "line": 516,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 525,
+        "line": 526,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 525,
+        "line": 526,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 529,
+        "line": 530,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 529,
+        "line": 530,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 536,
+        "line": 537,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 536,
+        "line": 537,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24104,7 +24135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24119,7 +24150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24138,7 +24169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24153,7 +24184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24172,7 +24203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24187,7 +24218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24206,7 +24237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24221,7 +24252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24240,7 +24271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24255,7 +24286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24274,7 +24305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24289,7 +24320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24308,7 +24339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24323,7 +24354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24342,7 +24373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24357,7 +24388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24376,7 +24407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24391,7 +24422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24410,7 +24441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24425,7 +24456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24444,7 +24475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24459,7 +24490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24478,7 +24509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24493,7 +24524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24512,7 +24543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24527,7 +24558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24546,7 +24577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24561,7 +24592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24580,7 +24611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24595,7 +24626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24614,7 +24645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24629,7 +24660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24648,7 +24679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24663,7 +24694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24682,7 +24713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24697,7 +24728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24716,7 +24747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24731,7 +24762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24750,7 +24781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24765,7 +24796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24784,7 +24815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24799,7 +24830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24818,7 +24849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24833,7 +24864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24852,7 +24883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24867,7 +24898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24886,7 +24917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24901,7 +24932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24920,7 +24951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24935,7 +24966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24954,7 +24985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -24969,7 +25000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24988,7 +25019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25003,7 +25034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25022,7 +25053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25037,7 +25068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25056,7 +25087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25071,7 +25102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25090,7 +25121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25105,7 +25136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25124,7 +25155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25139,8 +25170,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 600,
+        "line": 601,
         "name": "_aio_final_fit_size",
+        "optional": false,
+        "requested": "easyuse_anima.aio.postprocess",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "alias": "_apply_aio_final_fit",
+        "bound_name": "_apply_aio_final_fit",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 559,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_apply_aio_final_fit",
+          "target": "easyuse_anima/aio/postprocess.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
+        "kind": "static_from",
+        "line": 601,
+        "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
         "role": "compatibility_fallback",
@@ -25158,7 +25223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25173,7 +25238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 600,
+        "line": 601,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25192,7 +25257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25207,7 +25272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 604,
+        "line": 606,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25226,7 +25291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25241,7 +25306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 604,
+        "line": 606,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25260,7 +25325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25275,7 +25340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 604,
+        "line": 606,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25294,7 +25359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25309,7 +25374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 604,
+        "line": 606,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25328,7 +25393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25343,7 +25408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25362,7 +25427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25377,7 +25442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25396,7 +25461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25411,7 +25476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25430,7 +25495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25445,7 +25510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25464,7 +25529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25479,7 +25544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25498,7 +25563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25513,7 +25578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25532,7 +25597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25547,7 +25612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25566,7 +25631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25581,7 +25646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25600,7 +25665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25615,7 +25680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25634,7 +25699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25649,7 +25714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25668,7 +25733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25683,7 +25748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25702,7 +25767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25717,7 +25782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25736,7 +25801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25751,7 +25816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25770,7 +25835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25785,7 +25850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25804,7 +25869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25819,7 +25884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25838,7 +25903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25853,7 +25918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25872,7 +25937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25887,7 +25952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25906,7 +25971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25921,7 +25986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25940,7 +26005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25955,7 +26020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25974,7 +26039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -25989,7 +26054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26008,7 +26073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26023,7 +26088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26042,7 +26107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26057,7 +26122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26076,7 +26141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26091,7 +26156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26110,7 +26175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26125,7 +26190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26144,7 +26209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26159,7 +26224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26178,7 +26243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26193,7 +26258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26212,7 +26277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26227,7 +26292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26246,7 +26311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26261,7 +26326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26280,7 +26345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26295,7 +26360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26314,7 +26379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26329,7 +26394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26348,7 +26413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26363,7 +26428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26382,7 +26447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26397,7 +26462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26416,7 +26481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26431,7 +26496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26450,7 +26515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26465,7 +26530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26484,7 +26549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26499,7 +26564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26518,7 +26583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26533,7 +26598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26552,7 +26617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26567,7 +26632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26586,7 +26651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26601,7 +26666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26620,7 +26685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26635,7 +26700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26654,7 +26719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26669,7 +26734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26688,7 +26753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26703,7 +26768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26722,7 +26787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26737,7 +26802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26756,7 +26821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26771,7 +26836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26790,7 +26855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26805,7 +26870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26824,7 +26889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26839,7 +26904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26858,7 +26923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26873,7 +26938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26892,7 +26957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26907,7 +26972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26926,7 +26991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26941,7 +27006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26960,7 +27025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -26975,7 +27040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26994,7 +27059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27009,7 +27074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27028,7 +27093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27043,7 +27108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27062,7 +27127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27077,7 +27142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27096,7 +27161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27111,7 +27176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27130,7 +27195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27145,7 +27210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27164,7 +27229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27179,7 +27244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27198,7 +27263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27213,7 +27278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27232,7 +27297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27247,7 +27312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27266,7 +27331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27281,7 +27346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27300,7 +27365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27315,7 +27380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27334,7 +27399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27349,7 +27414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27368,7 +27433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27383,7 +27448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 682,
+        "line": 684,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27402,7 +27467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27417,7 +27482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 682,
+        "line": 684,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27436,7 +27501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27451,7 +27516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 682,
+        "line": 684,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27470,7 +27535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27485,7 +27550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 682,
+        "line": 684,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27504,7 +27569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27519,7 +27584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 682,
+        "line": 684,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27538,7 +27603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27553,7 +27618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 689,
+        "line": 691,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -27572,7 +27637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27587,7 +27652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27606,7 +27671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27621,7 +27686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27640,7 +27705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27655,7 +27720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27674,7 +27739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27689,7 +27754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27708,7 +27773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27723,7 +27788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27742,7 +27807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27757,7 +27822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27776,7 +27841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27791,7 +27856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27810,7 +27875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27825,7 +27890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27844,7 +27909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27859,7 +27924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27878,7 +27943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27893,7 +27958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27912,7 +27977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27927,7 +27992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27946,7 +28011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27961,7 +28026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27980,7 +28045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -27995,7 +28060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28014,7 +28079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28029,7 +28094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28048,7 +28113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28063,7 +28128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28082,7 +28147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28097,7 +28162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28116,7 +28181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28131,7 +28196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28150,7 +28215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28165,7 +28230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28184,7 +28249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28199,7 +28264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28218,7 +28283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28233,7 +28298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28252,7 +28317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28267,7 +28332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28286,7 +28351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28301,7 +28366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28320,7 +28385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28335,7 +28400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28354,7 +28419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28369,7 +28434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28388,7 +28453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28403,7 +28468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28422,7 +28487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28437,7 +28502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28456,7 +28521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28471,7 +28536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28490,7 +28555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28505,7 +28570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28524,7 +28589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28539,7 +28604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28558,7 +28623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28573,7 +28638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28592,7 +28657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28607,7 +28672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28626,7 +28691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28641,7 +28706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28660,7 +28725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28675,7 +28740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28694,7 +28759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28709,7 +28774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28728,7 +28793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28743,7 +28808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28762,7 +28827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28777,7 +28842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28796,7 +28861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28811,7 +28876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28830,7 +28895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28845,7 +28910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28864,7 +28929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28879,7 +28944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28898,7 +28963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28913,7 +28978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28932,7 +28997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28947,7 +29012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28966,7 +29031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -28981,7 +29046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29000,7 +29065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29015,7 +29080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29034,7 +29099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29049,7 +29114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29068,7 +29133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29083,7 +29148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29102,7 +29167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29117,7 +29182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29136,7 +29201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29151,7 +29216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29170,7 +29235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29185,7 +29250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29204,7 +29269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29219,7 +29284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29238,7 +29303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29253,7 +29318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29272,7 +29337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29287,7 +29352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29306,7 +29371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29321,7 +29386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29340,7 +29405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29355,7 +29420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29374,7 +29439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29389,7 +29454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29408,7 +29473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29423,7 +29488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29442,7 +29507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29457,7 +29522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29476,7 +29541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29491,7 +29556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29510,7 +29575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29525,7 +29590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29544,7 +29609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29559,7 +29624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29578,7 +29643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29593,7 +29658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29612,7 +29677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29627,7 +29692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29646,7 +29711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29661,7 +29726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29680,7 +29745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29695,7 +29760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29714,7 +29779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29729,7 +29794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29748,7 +29813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29763,7 +29828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29782,7 +29847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29797,7 +29862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29816,7 +29881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29831,7 +29896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29850,7 +29915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29865,7 +29930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29884,7 +29949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29899,7 +29964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29918,7 +29983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29933,7 +29998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29952,7 +30017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -29967,7 +30032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29986,7 +30051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30001,7 +30066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30020,7 +30085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30035,7 +30100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30054,7 +30119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30069,7 +30134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30088,7 +30153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30103,7 +30168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30122,7 +30187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30137,7 +30202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30156,7 +30221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30171,7 +30236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30190,7 +30255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30205,7 +30270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30224,7 +30289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30239,7 +30304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30258,7 +30323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30273,7 +30338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30292,7 +30357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30307,7 +30372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30326,7 +30391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30341,7 +30406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30360,7 +30425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30375,7 +30440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30394,7 +30459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30409,7 +30474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30428,7 +30493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30443,7 +30508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30462,7 +30527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30477,7 +30542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30496,7 +30561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30511,7 +30576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30530,7 +30595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30545,7 +30610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30564,7 +30629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30579,7 +30644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30598,7 +30663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30613,7 +30678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30632,7 +30697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30647,7 +30712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30666,7 +30731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30681,7 +30746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 888,
+        "line": 890,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30700,7 +30765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30715,7 +30780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 888,
+        "line": 890,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30734,7 +30799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30749,7 +30814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 888,
+        "line": 890,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30768,7 +30833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30783,7 +30848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 888,
+        "line": 890,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30802,7 +30867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30817,7 +30882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30836,7 +30901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30851,7 +30916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30870,7 +30935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30885,7 +30950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30904,7 +30969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30919,7 +30984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 899,
+        "line": 901,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -30938,7 +31003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30953,7 +31018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 899,
+        "line": 901,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -30972,7 +31037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -30987,7 +31052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 899,
+        "line": 901,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31006,7 +31071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31021,7 +31086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31040,7 +31105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31055,7 +31120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31074,7 +31139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31089,7 +31154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31108,7 +31173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31123,7 +31188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31142,7 +31207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31157,7 +31222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31176,7 +31241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31191,7 +31256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31210,7 +31275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31225,7 +31290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31244,7 +31309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31259,7 +31324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31278,7 +31343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31293,7 +31358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31312,7 +31377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31327,7 +31392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31346,7 +31411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31361,7 +31426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31380,7 +31445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31395,7 +31460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31414,7 +31479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31429,7 +31494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31448,7 +31513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31463,7 +31528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31482,7 +31547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31497,7 +31562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31516,7 +31581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31531,7 +31596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31550,7 +31615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31565,7 +31630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31584,7 +31649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31599,7 +31664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31618,7 +31683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31633,7 +31698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31652,7 +31717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31667,7 +31732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31686,7 +31751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31701,7 +31766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31720,7 +31785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31735,7 +31800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31754,7 +31819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31769,7 +31834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31788,7 +31853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31803,7 +31868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31822,7 +31887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31837,7 +31902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31856,7 +31921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31871,7 +31936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31890,7 +31955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31905,7 +31970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31924,7 +31989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31939,7 +32004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31958,7 +32023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -31973,7 +32038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -31992,7 +32057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32007,7 +32072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32026,7 +32091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32041,7 +32106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32060,7 +32125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32075,7 +32140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32094,7 +32159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32109,7 +32174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32128,7 +32193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32143,7 +32208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32162,7 +32227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32177,7 +32242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32196,7 +32261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32211,7 +32276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32230,7 +32295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32245,7 +32310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32264,7 +32329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32279,7 +32344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32298,7 +32363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32313,7 +32378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32332,7 +32397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32347,7 +32412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32366,7 +32431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32381,7 +32446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32400,7 +32465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32415,7 +32480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32434,7 +32499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32449,7 +32514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32468,7 +32533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32483,7 +32548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32502,7 +32567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32517,7 +32582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32536,7 +32601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32551,7 +32616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32570,7 +32635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32585,7 +32650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32604,7 +32669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32619,7 +32684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32638,7 +32703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32653,7 +32718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32672,7 +32737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32687,7 +32752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32706,7 +32771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32721,7 +32786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32740,7 +32805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32755,7 +32820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32774,7 +32839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32789,7 +32854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32808,7 +32873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32823,7 +32888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32842,7 +32907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32857,7 +32922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32876,7 +32941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32891,7 +32956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1039,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -32910,7 +32975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32925,7 +32990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1039,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -32944,7 +33009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32959,7 +33024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1043,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -32978,7 +33043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -32993,7 +33058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1043,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33012,7 +33077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33027,7 +33092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33046,7 +33111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33061,7 +33126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33080,7 +33145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33095,7 +33160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33114,7 +33179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33129,7 +33194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33148,7 +33213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33163,7 +33228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33182,7 +33247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33197,7 +33262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33216,7 +33281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33231,7 +33296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33250,7 +33315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33265,7 +33330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33284,7 +33349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33299,7 +33364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33318,7 +33383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33333,7 +33398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33352,7 +33417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33367,7 +33432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33386,7 +33451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33401,7 +33466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33420,7 +33485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33435,7 +33500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33454,7 +33519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33469,7 +33534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33488,7 +33553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33503,7 +33568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33522,7 +33587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33537,7 +33602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33556,7 +33621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33571,7 +33636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33590,7 +33655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33605,7 +33670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33624,7 +33689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33639,7 +33704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33658,7 +33723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33673,7 +33738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33692,7 +33757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33707,7 +33772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33726,7 +33791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33741,7 +33806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33760,7 +33825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33775,7 +33840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33794,7 +33859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33809,7 +33874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -33828,7 +33893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33843,7 +33908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -33862,7 +33927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33877,7 +33942,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -33896,7 +33961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33911,7 +33976,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -33930,7 +33995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33945,7 +34010,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1078,
+        "line": 1080,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -33964,7 +34029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -33979,7 +34044,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -33998,7 +34063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34013,7 +34078,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34032,7 +34097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34047,7 +34112,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34066,7 +34131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34081,7 +34146,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1086,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34100,7 +34165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34115,7 +34180,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1086,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34134,7 +34199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34149,7 +34214,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34168,7 +34233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34183,7 +34248,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34202,7 +34267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34217,7 +34282,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34236,7 +34301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34251,7 +34316,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34270,7 +34335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34285,7 +34350,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34304,7 +34369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34319,7 +34384,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34338,7 +34403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34353,7 +34418,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34372,7 +34437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34387,7 +34452,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34406,7 +34471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34421,7 +34486,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34440,7 +34505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34455,7 +34520,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34474,7 +34539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34489,7 +34554,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34508,7 +34573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34523,7 +34588,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34542,7 +34607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34557,7 +34622,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34576,7 +34641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34591,7 +34656,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34610,7 +34675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34625,7 +34690,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34644,7 +34709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34659,7 +34724,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34678,7 +34743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34693,7 +34758,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34712,7 +34777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34727,7 +34792,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34746,7 +34811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -34761,7 +34826,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34779,7 +34844,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1602
+            "line": 1604
           }
         ],
         "classification": "external",
@@ -34787,7 +34852,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1603,
+        "line": 1605,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -34804,7 +34869,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1639
+            "line": 1641
           }
         ],
         "classification": "external",
@@ -34812,7 +34877,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1640,
+        "line": 1642,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -34829,7 +34894,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1647
+            "line": 1649
           }
         ],
         "classification": "external",
@@ -34837,7 +34902,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1648,
+        "line": 1650,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -37857,13 +37922,13 @@
       },
       {
         "is_package": false,
-        "loc": 75,
+        "loc": 127,
         "module": "easyuse_anima.aio.postprocess",
-        "normalized_git_blob_sha1": "cd64ef7da8506791842b393fc27c3032e6167610",
+        "normalized_git_blob_sha1": "e2b8d08cee93c99986abb88b06c9ec6252b93936",
         "path": "easyuse_anima/aio/postprocess.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 3,
+          "function_count": 4,
           "global_count": 3
         }
       },
@@ -38469,13 +38534,13 @@
       },
       {
         "is_package": false,
-        "loc": 2403,
+        "loc": 2372,
         "module": "nodes",
-        "normalized_git_blob_sha1": "bac2b80fa25e96d203376423229014e0c5036a45",
+        "normalized_git_blob_sha1": "9756102e49f8a070a6a2d83a543e5fa1ff70528c",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 21,
+          "function_count": 20,
           "global_count": 26
         }
       },
@@ -39835,7 +39900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -39844,7 +39909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39858,7 +39923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -39867,7 +39932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39881,7 +39946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -39890,7 +39955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39904,7 +39969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -39913,7 +39978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39927,7 +39992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -39936,7 +40001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39950,7 +40015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -39959,7 +40024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39973,7 +40038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -39982,7 +40047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39996,7 +40061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40005,7 +40070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 559,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40019,7 +40084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40028,7 +40093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40042,7 +40107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40051,7 +40116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40065,7 +40130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40074,7 +40139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40088,7 +40153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40097,7 +40162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40111,7 +40176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40120,7 +40185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40134,7 +40199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40143,7 +40208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40157,7 +40222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40166,7 +40231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40180,7 +40245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40189,7 +40254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40203,7 +40268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40212,7 +40277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40226,7 +40291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40235,7 +40300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40249,7 +40314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40258,7 +40323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40272,7 +40337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40281,7 +40346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40295,7 +40360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40304,7 +40369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40318,7 +40383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40327,7 +40392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40341,7 +40406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40350,7 +40415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40364,7 +40429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40373,7 +40438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40387,7 +40452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40396,7 +40461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40410,7 +40475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40419,7 +40484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40433,7 +40498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40442,7 +40507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40456,7 +40521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40465,7 +40530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40479,7 +40544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40488,7 +40553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40502,7 +40567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40511,7 +40576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40525,7 +40590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40534,7 +40599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 600,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40548,7 +40613,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
+        "kind": "static_from",
+        "line": 601,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40557,7 +40645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 600,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40571,7 +40659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40580,7 +40668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 604,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40594,7 +40682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40603,7 +40691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 604,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40617,7 +40705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40626,7 +40714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 604,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40640,7 +40728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40649,7 +40737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 604,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40663,7 +40751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40672,7 +40760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40686,7 +40774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40695,7 +40783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40709,7 +40797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40718,7 +40806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40732,7 +40820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40741,7 +40829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40755,7 +40843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40764,7 +40852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40778,7 +40866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40787,7 +40875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40801,7 +40889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40810,7 +40898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40824,7 +40912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40833,7 +40921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40847,7 +40935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40856,7 +40944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40870,7 +40958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40879,7 +40967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40893,7 +40981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40902,7 +40990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40916,7 +41004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40925,7 +41013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40939,7 +41027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40948,7 +41036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40962,7 +41050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40971,7 +41059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40985,7 +41073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -40994,7 +41082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41008,7 +41096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41017,7 +41105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41031,7 +41119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41040,7 +41128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41054,7 +41142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41063,7 +41151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41077,7 +41165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41086,7 +41174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41100,7 +41188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41109,7 +41197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41123,7 +41211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41132,7 +41220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41146,7 +41234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41155,7 +41243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41169,7 +41257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41178,7 +41266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41192,7 +41280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41201,7 +41289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41215,7 +41303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41224,7 +41312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 625,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41238,7 +41326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41247,7 +41335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41261,7 +41349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41270,7 +41358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41284,7 +41372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41293,7 +41381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41307,7 +41395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41316,7 +41404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41330,7 +41418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41339,7 +41427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41353,7 +41441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41362,7 +41450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41376,7 +41464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41385,7 +41473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41399,7 +41487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41408,7 +41496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41422,7 +41510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41431,7 +41519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41445,7 +41533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41454,7 +41542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41468,7 +41556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41477,7 +41565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41491,7 +41579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41500,7 +41588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41514,7 +41602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41523,7 +41611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41537,7 +41625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41546,7 +41634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41560,7 +41648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41569,7 +41657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41583,7 +41671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41592,7 +41680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41606,7 +41694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41615,7 +41703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41629,7 +41717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41638,7 +41726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41652,7 +41740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41661,7 +41749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41675,7 +41763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41684,7 +41772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41698,7 +41786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41707,7 +41795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41721,7 +41809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41730,7 +41818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41744,7 +41832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41753,7 +41841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41767,7 +41855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41776,7 +41864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41790,7 +41878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41799,7 +41887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41813,7 +41901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41822,7 +41910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41836,7 +41924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41845,7 +41933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41859,7 +41947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41868,7 +41956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41882,7 +41970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41891,7 +41979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41905,7 +41993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41914,7 +42002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41928,7 +42016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41937,7 +42025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41951,7 +42039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41960,7 +42048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41974,7 +42062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -41983,7 +42071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41997,7 +42085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42006,7 +42094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42020,7 +42108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42029,7 +42117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42043,7 +42131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42052,7 +42140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 682,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42066,7 +42154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42075,7 +42163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 682,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42089,7 +42177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42098,7 +42186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 682,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42112,7 +42200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42121,7 +42209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 682,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42135,7 +42223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42144,7 +42232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 682,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42158,7 +42246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42167,7 +42255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 689,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42181,7 +42269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42190,7 +42278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42204,7 +42292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42213,7 +42301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42227,7 +42315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42236,7 +42324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42250,7 +42338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42259,7 +42347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42273,7 +42361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42282,7 +42370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42296,7 +42384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42305,7 +42393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42319,7 +42407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42328,7 +42416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42342,7 +42430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42351,7 +42439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42365,7 +42453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42374,7 +42462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42388,7 +42476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42397,7 +42485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42411,7 +42499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42420,7 +42508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42434,7 +42522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42443,7 +42531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42457,7 +42545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42466,7 +42554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42480,7 +42568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42489,7 +42577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42503,7 +42591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42512,7 +42600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42526,7 +42614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42535,7 +42623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42549,7 +42637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42558,7 +42646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42572,7 +42660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42581,7 +42669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42595,7 +42683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42604,7 +42692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42618,7 +42706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42627,7 +42715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42641,7 +42729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42650,7 +42738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42664,7 +42752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42673,7 +42761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42687,7 +42775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42696,7 +42784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42710,7 +42798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42719,7 +42807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42733,7 +42821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42742,7 +42830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42756,7 +42844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42765,7 +42853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42779,7 +42867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42788,7 +42876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42802,7 +42890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42811,7 +42899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42825,7 +42913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42834,7 +42922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42848,7 +42936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42857,7 +42945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42871,7 +42959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42880,7 +42968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42894,7 +42982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42903,7 +42991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42917,7 +43005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42926,7 +43014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42940,7 +43028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42949,7 +43037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42963,7 +43051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42972,7 +43060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42986,7 +43074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -42995,7 +43083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43009,7 +43097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43018,7 +43106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43032,7 +43120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43041,7 +43129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43055,7 +43143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43064,7 +43152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43078,7 +43166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43087,7 +43175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43101,7 +43189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43110,7 +43198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43124,7 +43212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43133,7 +43221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43147,7 +43235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43156,7 +43244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43170,7 +43258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43179,7 +43267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43193,7 +43281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43202,7 +43290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43216,7 +43304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43225,7 +43313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43239,7 +43327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43248,7 +43336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43262,7 +43350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43271,7 +43359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43285,7 +43373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43294,7 +43382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43308,7 +43396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43317,7 +43405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43331,7 +43419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43340,7 +43428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43354,7 +43442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43363,7 +43451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43377,7 +43465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43386,7 +43474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43400,7 +43488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43409,7 +43497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43423,7 +43511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43432,7 +43520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43446,7 +43534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43455,7 +43543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43469,7 +43557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43478,7 +43566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 764,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43492,7 +43580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43501,7 +43589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43515,7 +43603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43524,7 +43612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43538,7 +43626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43547,7 +43635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43561,7 +43649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43570,7 +43658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43584,7 +43672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43593,7 +43681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43607,7 +43695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43616,7 +43704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43630,7 +43718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43639,7 +43727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43653,7 +43741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43662,7 +43750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43676,7 +43764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43685,7 +43773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 792,
+        "line": 794,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43699,7 +43787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43708,7 +43796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43722,7 +43810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43731,7 +43819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43745,7 +43833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43754,7 +43842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43768,7 +43856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43777,7 +43865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43791,7 +43879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43800,7 +43888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43814,7 +43902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43823,7 +43911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43837,7 +43925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43846,7 +43934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43860,7 +43948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43869,7 +43957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43883,7 +43971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43892,7 +43980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43906,7 +43994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43915,7 +44003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43929,7 +44017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43938,7 +44026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43952,7 +44040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43961,7 +44049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43975,7 +44063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -43984,7 +44072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43998,7 +44086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44007,7 +44095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44021,7 +44109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44030,7 +44118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44044,7 +44132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44053,7 +44141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44067,7 +44155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44076,7 +44164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44090,7 +44178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44099,7 +44187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44113,7 +44201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44122,7 +44210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44136,7 +44224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44145,7 +44233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44159,7 +44247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44168,7 +44256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44182,7 +44270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44191,7 +44279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44205,7 +44293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44214,7 +44302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44228,7 +44316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44237,7 +44325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44251,7 +44339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44260,7 +44348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44274,7 +44362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44283,7 +44371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 888,
+        "line": 890,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44297,7 +44385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44306,7 +44394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 888,
+        "line": 890,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44320,7 +44408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44329,7 +44417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 888,
+        "line": 890,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44343,7 +44431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44352,7 +44440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 888,
+        "line": 890,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44366,7 +44454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44375,7 +44463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44389,7 +44477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44398,7 +44486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44412,7 +44500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44421,7 +44509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44435,7 +44523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44444,7 +44532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 899,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44458,7 +44546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44467,7 +44555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 899,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44481,7 +44569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44490,7 +44578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 899,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44504,7 +44592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44513,7 +44601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44527,7 +44615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44536,7 +44624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44550,7 +44638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44559,7 +44647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44573,7 +44661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44582,7 +44670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44596,7 +44684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44605,7 +44693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44619,7 +44707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44628,7 +44716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44642,7 +44730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44651,7 +44739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44665,7 +44753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44674,7 +44762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44688,7 +44776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44697,7 +44785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44711,7 +44799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44720,7 +44808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44734,7 +44822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44743,7 +44831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44757,7 +44845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44766,7 +44854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44780,7 +44868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44789,7 +44877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44803,7 +44891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44812,7 +44900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44826,7 +44914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44835,7 +44923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44849,7 +44937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44858,7 +44946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44872,7 +44960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44881,7 +44969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44895,7 +44983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44904,7 +44992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44918,7 +45006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44927,7 +45015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44941,7 +45029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44950,7 +45038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44964,7 +45052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44973,7 +45061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44987,7 +45075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -44996,7 +45084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45010,7 +45098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45019,7 +45107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45033,7 +45121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45042,7 +45130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45056,7 +45144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45065,7 +45153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45079,7 +45167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45088,7 +45176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45102,7 +45190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45111,7 +45199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45125,7 +45213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45134,7 +45222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 957,
+        "line": 959,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45148,7 +45236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45157,7 +45245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45171,7 +45259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45180,7 +45268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45194,7 +45282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45203,7 +45291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45217,7 +45305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45226,7 +45314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45240,7 +45328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45249,7 +45337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45263,7 +45351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45272,7 +45360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45286,7 +45374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45295,7 +45383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45309,7 +45397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45318,7 +45406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45332,7 +45420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45341,7 +45429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45355,7 +45443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45364,7 +45452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45378,7 +45466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45387,7 +45475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45401,7 +45489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45410,7 +45498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45424,7 +45512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45433,7 +45521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45447,7 +45535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45456,7 +45544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45470,7 +45558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45479,7 +45567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45493,7 +45581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45502,7 +45590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 984,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45516,7 +45604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45525,7 +45613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45539,7 +45627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45548,7 +45636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45562,7 +45650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45571,7 +45659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45585,7 +45673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45594,7 +45682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45608,7 +45696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45617,7 +45705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45631,7 +45719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45640,7 +45728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45654,7 +45742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45663,7 +45751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45677,7 +45765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45686,7 +45774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45700,7 +45788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45709,7 +45797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45723,7 +45811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45732,7 +45820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45746,7 +45834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45755,7 +45843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45769,7 +45857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45778,7 +45866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1039,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45792,7 +45880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45801,7 +45889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1039,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45815,7 +45903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45824,7 +45912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1043,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45838,7 +45926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45847,7 +45935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1043,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45861,7 +45949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45870,7 +45958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45884,7 +45972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45893,7 +45981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45907,7 +45995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45916,7 +46004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45930,7 +46018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45939,7 +46027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45953,7 +46041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45962,7 +46050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45976,7 +46064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -45985,7 +46073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45999,7 +46087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46008,7 +46096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46022,7 +46110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46031,7 +46119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46045,7 +46133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46054,7 +46142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46068,7 +46156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46077,7 +46165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46091,7 +46179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46100,7 +46188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46114,7 +46202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46123,7 +46211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46137,7 +46225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46146,7 +46234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46160,7 +46248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46169,7 +46257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46183,7 +46271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46192,7 +46280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1046,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46206,7 +46294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46215,7 +46303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46229,7 +46317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46238,7 +46326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46252,7 +46340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46261,7 +46349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46275,7 +46363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46284,7 +46372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46298,7 +46386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46307,7 +46395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46321,7 +46409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46330,7 +46418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46344,7 +46432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46353,7 +46441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46367,7 +46455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46376,7 +46464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46390,7 +46478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46399,7 +46487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46413,7 +46501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46422,7 +46510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46436,7 +46524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46445,7 +46533,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46459,7 +46547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46468,7 +46556,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46482,7 +46570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46491,7 +46579,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1078,
+        "line": 1080,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46505,7 +46593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46514,7 +46602,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46528,7 +46616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46537,7 +46625,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46551,7 +46639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46560,7 +46648,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46574,7 +46662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46583,7 +46671,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46597,7 +46685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46606,7 +46694,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46620,7 +46708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46629,7 +46717,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46643,7 +46731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46652,7 +46740,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46666,7 +46754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46675,7 +46763,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46689,7 +46777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46698,7 +46786,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46712,7 +46800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46721,7 +46809,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46735,7 +46823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46744,7 +46832,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46758,7 +46846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46767,7 +46855,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46781,7 +46869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46790,7 +46878,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46804,7 +46892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46813,7 +46901,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46827,7 +46915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46836,7 +46924,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46850,7 +46938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46859,7 +46947,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46873,7 +46961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46882,7 +46970,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46896,7 +46984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46905,7 +46993,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46919,7 +47007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46928,7 +47016,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46942,7 +47030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46951,7 +47039,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46965,7 +47053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46974,7 +47062,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46988,7 +47076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -46997,7 +47085,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47011,7 +47099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -47020,7 +47108,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47034,7 +47122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 559,
             "kind": "try",
             "line": 10
           }
@@ -47043,7 +47131,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50870,14 +50958,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1602
+            "line": 1604
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1603,
+        "line": 1605,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50889,14 +50977,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1639
+            "line": 1641
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1640,
+        "line": 1642,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50908,14 +50996,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1647
+            "line": 1649
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1648,
+        "line": 1650,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52290,14 +52378,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1602
+            "line": 1604
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1603,
+        "line": 1605,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52309,14 +52397,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1639
+            "line": 1641
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1640,
+        "line": 1642,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52328,14 +52416,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1647
+            "line": 1649
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1648,
+        "line": 1650,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53796,7 +53884,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1107,
+        "line": 1109,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53805,7 +53893,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2299,
+        "line": 2268,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53814,7 +53902,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2302,
+        "line": 2271,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53823,7 +53911,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2305,
+        "line": 2274,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53832,7 +53920,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2308,
+        "line": 2277,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53841,7 +53929,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2311,
+        "line": 2280,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53850,7 +53938,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2314,
+        "line": 2283,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53859,7 +53947,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2317,
+        "line": 2286,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53868,7 +53956,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2320,
+        "line": 2289,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53877,7 +53965,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2323,
+        "line": 2292,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53886,7 +53974,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2326,
+        "line": 2295,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53895,7 +53983,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2329,
+        "line": 2298,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53904,7 +53992,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2332,
+        "line": 2301,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53913,7 +54001,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2335,
+        "line": 2304,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53922,7 +54010,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2338,
+        "line": 2307,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53931,7 +54019,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2341,
+        "line": 2310,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53940,7 +54028,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2344,
+        "line": 2313,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53949,7 +54037,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2348,
+        "line": 2317,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53958,7 +54046,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2351,
+        "line": 2320,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53967,7 +54055,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2355,
+        "line": 2324,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53976,7 +54064,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2358,
+        "line": 2327,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53985,7 +54073,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2362,
+        "line": 2331,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53994,7 +54082,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2365,
+        "line": 2334,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54003,7 +54091,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2368,
+        "line": 2337,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54012,7 +54100,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2371,
+        "line": 2340,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54021,7 +54109,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2374,
+        "line": 2343,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54030,7 +54118,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2377,
+        "line": 2346,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54039,7 +54127,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2384,
+        "line": 2353,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54048,7 +54136,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2390,
+        "line": 2359,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54057,7 +54145,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2395,
+        "line": 2364,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54066,7 +54154,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2399,
+        "line": 2368,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54580,13 +54668,13 @@
       },
       {
         "kind": "dict",
-        "line": 1169,
+        "line": 1171,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1158,
+        "line": 1160,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "5a86162f9063373aedc1718dc6cb5d1cd6a93fee",
+    "base_commit": "05beee12624971a784251fc9f4242a213d9accf4",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -45,7 +45,8 @@
       "B-11c12",
       "B-11c13",
       "B-11c14",
-      "B-11c15"
+      "B-11c15",
+      "B-11c16"
     ]
   },
   "enums": {
@@ -80,11 +81,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 287,
+    "nodes_canonical_bindings": 288,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 21,
+    "root_residual_functions": 20,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -389,6 +390,9 @@
     ],
     "_aio_detailer_target_order": [
       "easyuse_anima.aio.generation_normalization"
+    ],
+    "_aio_final_fit_size": [
+      "easyuse_anima.aio.postprocess"
     ],
     "_aio_first_pass_cache_key": [
       "easyuse_anima.aio.legacy_generation"
@@ -712,6 +716,7 @@
     ],
     "_image_tensor_size": [
       "easyuse_anima.aio.legacy_generation",
+      "easyuse_anima.aio.postprocess",
       "easyuse_anima.aio.preview",
       "easyuse_anima.aio.usdu"
     ],
@@ -950,7 +955,8 @@
       "easyuse_anima.aio.legacy_generation"
     ],
     "_resize_image_to_size_if_needed": [
-      "easyuse_anima.aio.legacy_generation"
+      "easyuse_anima.aio.legacy_generation",
+      "easyuse_anima.aio.postprocess"
     ],
     "_resolution_label": [
       "easyuse_anima.nodes.prompt_advanced_nodes"
@@ -2176,6 +2182,7 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_aio_final_fit_size": "_aio_final_fit_size",
+        "_apply_aio_final_fit": "_apply_aio_final_fit",
         "_bind_aio_postprocess_runtime": "_bind_aio_postprocess_runtime"
       },
       "classification": "transitional_private_seam",
@@ -2188,10 +2195,12 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime"
+        "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.postprocess"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load"
+        "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.postprocess string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -4111,7 +4120,6 @@
       "surface": "nodes_root_residuals",
       "kind": "functions",
       "symbols": {
-        "_apply_aio_final_fit": "_apply_aio_final_fit",
         "_comfy_clip_loader_types": "_comfy_clip_loader_types",
         "_comfy_diffusion_model_names": "_comfy_diffusion_model_names",
         "_comfy_max_resolution": "_comfy_max_resolution",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1068,6 +1068,7 @@ class AioUsduTilePlanningMoveContractTests(unittest.TestCase):
 
 class AioFinalFitPlanningMoveContractTests(unittest.TestCase):
     MOVED_NAMES = (
+        "_apply_aio_final_fit",
         "_aio_final_fit_size",
         "_bind_aio_postprocess_runtime",
     )
@@ -1136,6 +1137,169 @@ class AioFinalFitPlanningMoveContractTests(unittest.TestCase):
                 call(round(3000 * expected_scale), 32),
             ],
         )
+
+        image = object()
+        source_fit = {
+            "mode": "max_long_edge",
+            "max_long_edge": "1920",
+            "max_megapixels": "4.25",
+            "method": "",
+        }
+        source_settings = {"enabled": "enabled", "fit": source_fit}
+        events = []
+        copied_fits = []
+
+        def record(name, result):
+            def side_effect(*args):
+                events.append((name, args))
+                return result
+
+            return side_effect
+
+        def final_fit_size(width, height, fit_settings):
+            events.append(("final_fit_size", (width, height, dict(fit_settings))))
+            copied_fits.append(fit_settings)
+            return 640, 480, 1.0
+
+        with (
+            patch.object(
+                root_module,
+                "_as_bool",
+                side_effect=record("as_bool", True),
+            ),
+            patch.object(
+                root_module,
+                "_image_tensor_size",
+                side_effect=record("image_tensor_size", (640, 480)),
+            ) as image_tensor_size,
+            patch.object(
+                root_module,
+                "_aio_final_fit_size",
+                side_effect=final_fit_size,
+            ),
+            patch.object(
+                root_module,
+                "_as_int",
+                side_effect=record("as_int", 1920),
+            ),
+            patch.object(
+                root_module,
+                "_as_float",
+                side_effect=record("as_float", 4.25),
+            ),
+            patch.object(root_module, "_resize_image_to_size_if_needed") as resize,
+        ):
+            output, metadata = canonical_module._apply_aio_final_fit(
+                image,
+                source_settings,
+            )
+
+        self.assertIs(output, image)
+        self.assertEqual(
+            [name for name, _ in events],
+            [
+                "as_bool",
+                "image_tensor_size",
+                "final_fit_size",
+                "as_bool",
+                "as_int",
+                "as_float",
+            ],
+        )
+        image_tensor_size.assert_called_once_with(image, 0, 0)
+        self.assertEqual(
+            copied_fits,
+            [
+                {
+                    "mode": "max_long_edge",
+                    "max_long_edge": "1920",
+                    "max_megapixels": "4.25",
+                    "method": "",
+                    "enabled": True,
+                }
+            ],
+        )
+        self.assertIsNot(copied_fits[0], source_fit)
+        self.assertEqual(
+            source_fit,
+            {
+                "mode": "max_long_edge",
+                "max_long_edge": "1920",
+                "max_megapixels": "4.25",
+                "method": "",
+            },
+        )
+        self.assertEqual(source_settings["enabled"], "enabled")
+        self.assertEqual(
+            list(metadata),
+            [
+                "enabled",
+                "mode",
+                "max_long_edge",
+                "max_megapixels",
+                "method",
+                "applied",
+                "scale",
+                "width",
+                "height",
+                "target_width",
+                "target_height",
+            ],
+        )
+        self.assertEqual(
+            metadata,
+            {
+                "enabled": True,
+                "mode": "max_long_edge",
+                "max_long_edge": 1920,
+                "max_megapixels": 4.25,
+                "method": "bicubic",
+                "applied": False,
+                "scale": 1.0,
+                "width": 640,
+                "height": 480,
+                "target_width": 640,
+                "target_height": 480,
+            },
+        )
+        resize.assert_not_called()
+
+        invalid_fit = ["not", "a", "mapping"]
+        invalid_settings = {"enabled": 1, "fit": invalid_fit}
+        with (
+            patch.object(root_module, "_as_bool", return_value=True) as as_bool,
+            patch.object(
+                root_module,
+                "_image_tensor_size",
+                return_value=(640, 480),
+            ),
+            patch.object(
+                root_module,
+                "_aio_final_fit_size",
+                return_value=(320, 240, 0.5),
+            ) as final_fit,
+            patch.object(root_module, "_as_int", return_value=2048),
+            patch.object(root_module, "_as_float", return_value=4.0),
+            patch.object(
+                root_module,
+                "_resize_image_to_size_if_needed",
+                return_value=("resized", False),
+            ) as resize,
+        ):
+            output, metadata = canonical_module._apply_aio_final_fit(
+                image,
+                invalid_settings,
+            )
+
+        self.assertEqual(output, "resized")
+        self.assertEqual(invalid_settings, {"enabled": 1, "fit": invalid_fit})
+        self.assertEqual(as_bool.call_args_list, [call(1, False), call(1, False)])
+        final_fit.assert_called_once_with(640, 480, {"enabled": True})
+        resize.assert_called_once_with(image, 320, 240, "bicubic")
+        self.assertFalse(metadata["applied"])
+        self.assertEqual(metadata["scale"], 0.5)
+        self.assertEqual(metadata["target_width"], 320)
+        self.assertEqual(metadata["target_height"], 240)
 
     def test_root_aliases_and_call_time_helpers(self):
         self._assert_contract(nodes, aio_postprocess)

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "bac2b80fa25e96d203376423229014e0c5036a45")
-        # Issue #184 B-11c15 moves only final-fit size planning to the
+        self.assertEqual(report["git_blob_sha1"], "9756102e49f8a070a6a2d83a543e5fa1ff70528c")
+        # Issue #184 B-11c16 moves only final-fit application to the
         # canonical postprocess owner.
-        self.assertEqual(report["top_level"]["function_count"], 21)
+        self.assertEqual(report["top_level"]["function_count"], 20)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_403)
+        self.assertEqual(report["line_count"], 2_372)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "5a86162f9063373aedc1718dc6cb5d1cd6a93fee"
+BASE_COMMIT = "05beee12624971a784251fc9f4242a213d9accf4"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1318,6 +1318,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c13",
                 "B-11c14",
                 "B-11c15",
+                "B-11c16",
             ],
         },
         "enums": {
@@ -1330,11 +1331,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 287,
+            "nodes_canonical_bindings": 288,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 21,
+            "root_residual_functions": 20,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c16 단일 Move로 `_apply_aio_final_fit`만 기존 canonical owner `easyuse_anima.aio.postprocess`로 이동합니다.
- root `nodes.py`에는 relative/flat direct identity alias를 유지하고, 기존 postprocess binder로 root replacement seam을 사용 시점에 resolve합니다.

## 작업 전 inventory

### Symbol / caller

- `_apply_aio_final_fit`
  - 현재 surface: `nodes.py` private root definition
  - production caller: root `_run_aio_postprocess_stage` 1곳
  - string resolver/public mapping/export/API/frontend/workflow consumer: 없음
  - direct test seam: `tests/test_aio_nodes.py::test_postprocess_stage_applies_final_fit`가 root binding을 교체
- `_aio_final_fit_size`
  - 이미 `easyuse_anima.aio.postprocess` canonical owner에 존재하지만, root monkeypatch 호환을 위해 이동된 apply에서도 root 이름을 runtime-resolve합니다.
- `_resize_image_to_size_if_needed`
  - root highres stage, root apply, `easyuse_anima.aio.legacy_generation` 문자열 resolver가 공유합니다.
  - postprocess 전용이 아니므로 이번 PR에서는 이동하지 않습니다.
- `_image_tensor_size`
  - postprocess 외 preview/USDU/upscale/legacy가 공유하므로 root runtime seam으로 유지합니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical `_apply_aio_final_fit` identity를 유지합니다.
- 기존 `_bind_aio_postprocess_runtime` 하나를 재사용합니다. 새 binder나 mutable global은 추가하지 않습니다.
- 사용 시점 root seam: `_as_bool`, `_image_tensor_size`, `_aio_final_fit_size`, `_as_int`, `_as_float`, `_resize_image_to_size_if_needed`.
- fit shallow copy, 두 번의 `_as_bool`, metadata 삽입/강제변환 순서, no-scale 조기 반환, resize method 재계산, 실제 resized 결과의 `applied` 덮어쓰기를 그대로 보존합니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/postprocess.py`, `nodes.py`
- contract/analyzer: `tests/test_node_contracts.py`, `tests/test_python_compatibility_surface.py`, `tests/test_nodes_module_analyzer.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 예상 계약 delta

- canonical bindings: `287 → 288`
- root/top-level residual functions: `21 → 20`
- runtime binders: `30` 유지
- runtime resolver names: `270 → 271` (`_aio_final_fit_size` 신규)
- shipped/runtime-closure modules: `83` 유지
- globals 26, preamble imports 6: 변화 없음
- `nodes.py` line count: `2403 → 2372`

## 금지 경계

- `_resize_image_to_size_if_needed`, `_run_aio_postprocess_stage` 이동/변경 금지
- `AIO_FINAL_FIT_MODES`, schema/default/metadata 의미 및 resize behavior 변경 금지
- `easyuse_anima.aio.legacy_generation`, `tests/test_aio_nodes.py`, package/backend analyzer 계약 변경 금지
- canonical helper 직접 호출 또는 resize helper 정적 import 금지: root monkeypatch seam을 바꿉니다.
- 다른 residual, Contract, Behavior 변경 결합 금지

## 검증

- focused `unittest`: 41개 통과
  - relative/flat identity, root helper replacement, 평가/metadata 순서, shallow-copy/input 비변경, no-scale/downscale, 기존 final-fit/postprocess/legacy behavior, package/analyzer/import boundary 확인
- canonical `easyuse_anima/aio/postprocess.py` Ruff 통과
- 독립 read-only diff review: P1-P3 finding 없음
- exact remote head `7b0303f85c84d4dc5951fd0349d8e526c9731ace`:
  - `tools/check_project.ps1 -Profile full` 통과
  - Python `910`개 통과
  - frontend `114`개 통과
  - Pyright baseline ratchet, Python import boundary, `git diff --check` 통과
  - Ruff `109`건은 G-01 report-only 기존 baseline이며 blocking failure 없음
- Live ComfyUI/browser smoke: private postprocess Move 범위에서는 수행하지 않음

## 주요 변경 파일

- `easyuse_anima/aio/postprocess.py`: final-fit application canonical owner
- `nodes.py`: relative/flat direct alias와 기존 root body 제거
- `tests/test_node_contracts.py`: identity·late seam·평가/metadata 순서·입력 비변경 계약
- analyzer/compatibility fixtures 및 아키텍처 문서: 실제 owner와 수치 반영

## 남은 위험 / 미확인

- 실제 ComfyUI API/module/browser smoke는 수행하지 않았습니다. 이 PR은 기존 binder를 재사용하는 private Move이며 behavior·package·import 계약으로 검증했습니다.
- 공유 resize helper와 postprocess stage는 의도적으로 root에 남아 후속 단위에서 별도 검토합니다.

## 상태

- Ready 후보: 독립 리뷰 및 exact-head full 검증 완료
