### PR TITLE
refactor: move diffusion model name wrapper

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `05beee12624971a784251fc9f4242a213d9accf4`
+- Integrated `dev` snapshot commit: `f4ab6eb094fcdad900f535f79805f912ec67ffaa`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c15 / `05beee1`; B-11c16 final-fit application Move in PR #310 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c16 / `f4ab6eb`; B-11c17 diffusion-model name wrapper Move in PR #311 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,403
-  lines after B-11c15.
-- The mechanical extraction has removed 10,260
-  lines, approximately 81.0% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,372
+  lines after B-11c16.
+- The mechanical extraction has removed 10,291
+  lines, approximately 81.3% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -75,8 +75,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   owner in PR #306 / `7c2fdd5`. B-11c13 removed only the dead private root
   `_aio_usdu_tile_size` wrapper in PR #307 / `21f8c97`. B-11c14 moved only the
   Detailer enabled-target predicate in PR #308 / `5a86162`. B-11c15 moved only
-  final-fit size planning in PR #309 / `05beee1`. B-11c16 moves only final-fit
-  application in PR #310.
+  final-fit size planning in PR #309 / `05beee1`. B-11c16 moved only final-fit
+  application in PR #310 / `f4ab6eb`. B-11c17 moves only the diffusion-model
+  name wrapper in PR #311.
 
 ### Current quality baseline
 
@@ -318,7 +319,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 final-fit application Move PR #310 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 diffusion-model name wrapper Move PR #311 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -903,6 +904,10 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     in PR #310. Root image-size, final-fit planning, coercion, and shared resize
     seams remain call-time resolved; postprocess stage execution and the shared
     resize helper remain root-owned.
+  - B-11c17 moves only `_comfy_diffusion_model_names` to the existing AiO
+    resource owner in PR #311. The default-candidate tuple, folder lookup, and
+    domain-neutral adapter remain call-time root seams; the other resource-name
+    wrappers remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,15 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `05beee12624971a784251fc9f4242a213d9accf4`
+  `f4ab6eb094fcdad900f535f79805f912ec67ffaa`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c15 are integrated through PR #309. B-11c is
+- Current state: B-11a through B-11c16 are integrated through PR #310. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c16 final-fit application Move is tracked by PR #310.
+  the final root shim; B-11c17 diffusion-model name wrapper Move is tracked by
+  PR #311.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,7 +76,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 288 in B-11c16
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 289 in B-11c17
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -84,10 +85,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 20 functions, 0 classes, and 26 assigned
-  globals in B-11c16 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 19 functions, 0 classes, and 26 assigned
+  globals in B-11c17 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 271, including
+- root names reached by those canonical runtime resolvers: 273, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -402,6 +403,22 @@ convenience-node compatibility; it remains unmapped and is not public support.
   and the actual resize-result `applied` override are unchanged.
 - PR #310 does not move or change the shared resize helper, postprocess stage,
   `AIO_FINAL_FIT_MODES`, logging, schema, defaults, or workflow behavior.
+
+### B-11c17 diffusion-model name wrapper alias
+
+- Canonical owner: `easyuse_anima.aio.resources` for
+  `_comfy_diffusion_model_names`.
+- The private root wrapper remains a transitional direct alias in relative
+  package and flat import modes. `EasyUseAnimaInput.INPUT_TYPES` continues to
+  resolve that root name at call time.
+- The existing resource binder resolves
+  `ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES`,
+  `_adapter_comfy_diffusion_model_names`, and `_folder_path_names` at use time.
+  Candidate order, folder key, fallback type/copy policy, and adapter result are
+  unchanged.
+- PR #311 does not move or change the infrastructure adapter, constants, folder
+  lookup, other resource-name wrappers, INPUT_TYPES, schema, defaults, or
+  workflow behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/resources.py
+++ b/easyuse_anima/aio/resources.py
@@ -58,6 +58,13 @@ def _normalize_aio_input_settings(value) -> dict[str, Any]:
     return settings
 
 
+def _comfy_diffusion_model_names() -> list[str]:
+    return _runtime_helper("_adapter_comfy_diffusion_model_names")(
+        _runtime_helper("ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES"),
+        _runtime_helper("_folder_path_names"),
+    )
+
+
 def _preferred_name_default(names: list[str], candidates: tuple[str, ...]) -> str:
     if not names:
         return candidates[0] if candidates else ""

--- a/nodes.py
+++ b/nodes.py
@@ -115,6 +115,7 @@ try:
     )
     from .easyuse_anima.aio.resources import (
         _bind_aio_resource_runtime as _bind_aio_resource_runtime,
+        _comfy_diffusion_model_names as _comfy_diffusion_model_names,
         _load_aio_resources_from_input_context as _load_aio_resources_from_input_context,
         _load_aio_sam3_context as _load_aio_sam3_context,
         _load_checkpoint_with_comfy as _load_checkpoint_with_comfy,
@@ -664,6 +665,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     )
     from easyuse_anima.aio.resources import (
         _bind_aio_resource_runtime as _bind_aio_resource_runtime,
+        _comfy_diffusion_model_names as _comfy_diffusion_model_names,
         _load_aio_resources_from_input_context as _load_aio_resources_from_input_context,
         _load_aio_sam3_context as _load_aio_sam3_context,
         _load_checkpoint_with_comfy as _load_checkpoint_with_comfy,
@@ -1606,13 +1608,6 @@ def _comfy_max_resolution() -> int:
     except Exception:
         comfy_nodes = None
     return _adapter_comfy_max_resolution(comfy_nodes)
-
-
-def _comfy_diffusion_model_names() -> list[str]:
-    return _adapter_comfy_diffusion_model_names(
-        ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES,
-        _folder_path_names,
-    )
 
 
 def _comfy_text_encoder_names() -> list[str]:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6783,7 +6783,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 168,
+            "line": 175,
             "type_checking": false
           },
           {
@@ -6791,7 +6791,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 169
+            "line": 176
           }
         ],
         "classification": "external",
@@ -6799,7 +6799,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 170,
+        "line": 177,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -16934,6 +16934,37 @@
         "target": "easyuse_anima/aio/resources.py"
       },
       {
+        "alias": "_comfy_diffusion_model_names",
+        "bound_name": "_comfy_diffusion_model_names",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_comfy_diffusion_model_names",
+          "target": "easyuse_anima/aio/resources.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
+        "kind": "static_from",
+        "line": 116,
+        "name": "_comfy_diffusion_model_names",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.resources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
         "alias": "_load_aio_resources_from_input_context",
         "bound_name": "_load_aio_resources_from_input_context",
         "branch_context": [
@@ -17296,7 +17327,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 130,
+        "line": 131,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17327,7 +17358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 130,
+        "line": 131,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17358,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 130,
+        "line": 131,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 135,
+        "line": 136,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 135,
+        "line": 136,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 135,
+        "line": 136,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 135,
+        "line": 136,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 135,
+        "line": 136,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 142,
+        "line": 143,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 143,
+        "line": 144,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 143,
+        "line": 144,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 143,
+        "line": 144,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 143,
+        "line": 144,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 163,
+        "line": 164,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 163,
+        "line": 164,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 163,
+        "line": 164,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 163,
+        "line": 164,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 163,
+        "line": 164,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 163,
+        "line": 164,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 163,
+        "line": 164,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 181,
+        "line": 182,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 217,
+        "line": 218,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 245,
+        "line": 246,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 261,
+        "line": 262,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 341,
+        "line": 342,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 341,
+        "line": 342,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 341,
+        "line": 342,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 341,
+        "line": 342,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 347,
+        "line": 348,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 347,
+        "line": 348,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 347,
+        "line": 348,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 367,
+        "line": 368,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 367,
+        "line": 368,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 367,
+        "line": 368,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 391,
+        "line": 392,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 391,
+        "line": 392,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 399,
+        "line": 400,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 399,
+        "line": 400,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 399,
+        "line": 400,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 399,
+        "line": 400,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 399,
+        "line": 400,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 399,
+        "line": 400,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 399,
+        "line": 400,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 399,
+        "line": 400,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 424,
+        "line": 425,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 424,
+        "line": 425,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 428,
+        "line": 429,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 432,
+        "line": 433,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 432,
+        "line": 433,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 432,
+        "line": 433,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 444,
+        "line": 445,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 444,
+        "line": 445,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 444,
+        "line": 445,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 449,
+        "line": 450,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 449,
+        "line": 450,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 449,
+        "line": 450,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 467,
+        "line": 468,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 467,
+        "line": 468,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 467,
+        "line": 468,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 467,
+        "line": 468,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 467,
+        "line": 468,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 494,
+        "line": 495,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 494,
+        "line": 495,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 516,
+        "line": 517,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 516,
+        "line": 517,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 516,
+        "line": 517,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 516,
+        "line": 517,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 516,
+        "line": 517,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 516,
+        "line": 517,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 516,
+        "line": 517,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 516,
+        "line": 517,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24116,7 +24147,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24135,7 +24166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24150,7 +24181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24169,7 +24200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24184,7 +24215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24203,7 +24234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24218,7 +24249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24237,7 +24268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24252,7 +24283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24271,7 +24302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24286,7 +24317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24305,7 +24336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24320,7 +24351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24339,7 +24370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24354,7 +24385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24373,7 +24404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24388,7 +24419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24407,7 +24438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24422,7 +24453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24441,7 +24472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24456,7 +24487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24475,7 +24506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24490,7 +24521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24509,7 +24540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24524,7 +24555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24543,7 +24574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24558,7 +24589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24577,7 +24608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24592,7 +24623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24611,7 +24642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24626,7 +24657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24645,7 +24676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24660,7 +24691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24679,7 +24710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24694,7 +24725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24713,7 +24744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24728,7 +24759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24747,7 +24778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24762,7 +24793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24781,7 +24812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24796,7 +24827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24815,7 +24846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24830,7 +24861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24849,7 +24880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24864,7 +24895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24883,7 +24914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24898,7 +24929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24917,7 +24948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24932,7 +24963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24951,7 +24982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -24966,7 +24997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24985,7 +25016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25000,7 +25031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25019,7 +25050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25034,7 +25065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 594,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25053,7 +25084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25068,7 +25099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 596,
+        "line": 597,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25087,7 +25118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25102,7 +25133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 596,
+        "line": 597,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25121,7 +25152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25136,7 +25167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 596,
+        "line": 597,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25155,7 +25186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25170,7 +25201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 601,
+        "line": 602,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25189,7 +25220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25204,7 +25235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 601,
+        "line": 602,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25223,7 +25254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25238,7 +25269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 601,
+        "line": 602,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25257,7 +25288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25272,7 +25303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 606,
+        "line": 607,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25291,7 +25322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25306,7 +25337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 606,
+        "line": 607,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25325,7 +25356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25340,7 +25371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 606,
+        "line": 607,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25359,7 +25390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25374,7 +25405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 606,
+        "line": 607,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25393,7 +25424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25408,7 +25439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25427,7 +25458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25442,7 +25473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25461,7 +25492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25476,7 +25507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25495,7 +25526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25510,7 +25541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25529,7 +25560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25544,7 +25575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25563,7 +25594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25578,7 +25609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25597,7 +25628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25612,7 +25643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25631,7 +25662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25646,7 +25677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25665,7 +25696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25680,7 +25711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25699,7 +25730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25714,7 +25745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25733,7 +25764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25748,7 +25779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25767,7 +25798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25782,7 +25813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25801,7 +25832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25816,7 +25847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25835,7 +25866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25850,7 +25881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25869,7 +25900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25884,7 +25915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25903,7 +25934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25918,7 +25949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25937,7 +25968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25952,7 +25983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25971,7 +26002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -25986,7 +26017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26005,7 +26036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26020,7 +26051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26039,7 +26070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26054,7 +26085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26073,7 +26104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26088,7 +26119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26107,7 +26138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26122,7 +26153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26141,7 +26172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26156,7 +26187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26175,7 +26206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26190,7 +26221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26209,7 +26240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26224,7 +26255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26243,7 +26274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26258,7 +26289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26277,7 +26308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26292,7 +26323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26311,7 +26342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26326,7 +26357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26345,7 +26376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26360,7 +26391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26379,7 +26410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26394,7 +26425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26413,7 +26444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26428,7 +26459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26447,7 +26478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26462,7 +26493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26481,7 +26512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26496,7 +26527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26515,7 +26546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26530,7 +26561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26549,7 +26580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26564,7 +26595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26583,7 +26614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26598,7 +26629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26617,7 +26648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26632,7 +26663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26651,7 +26682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26666,7 +26697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26685,7 +26716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26700,7 +26731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26719,7 +26750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26734,7 +26765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26753,7 +26784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26768,7 +26799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26787,7 +26818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26802,7 +26833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26821,7 +26852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26836,7 +26867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26855,7 +26886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26870,7 +26901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26889,7 +26920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26904,7 +26935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26923,7 +26954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26938,8 +26969,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "name": "_bind_aio_resource_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.aio.resources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": "_comfy_diffusion_model_names",
+        "bound_name": "_comfy_diffusion_model_names",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 560,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_comfy_diffusion_model_names",
+          "target": "easyuse_anima/aio/resources.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
+        "kind": "static_from",
+        "line": 666,
+        "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
         "role": "compatibility_fallback",
@@ -26957,7 +27022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -26972,7 +27037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26991,7 +27056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27006,7 +27071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27025,7 +27090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27040,7 +27105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27059,7 +27124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27074,7 +27139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27093,7 +27158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27108,7 +27173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27127,7 +27192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27142,7 +27207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27161,7 +27226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27176,7 +27241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27195,7 +27260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27210,7 +27275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27229,7 +27294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27244,7 +27309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27263,7 +27328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27278,7 +27343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27297,7 +27362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27312,7 +27377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27331,7 +27396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27346,7 +27411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27365,7 +27430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27380,7 +27445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27399,7 +27464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27414,7 +27479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27433,7 +27498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27448,7 +27513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 684,
+        "line": 686,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27467,7 +27532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27482,7 +27547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 684,
+        "line": 686,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27501,7 +27566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27516,7 +27581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 684,
+        "line": 686,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27535,7 +27600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27550,7 +27615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 684,
+        "line": 686,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27569,7 +27634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27584,7 +27649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 684,
+        "line": 686,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27603,7 +27668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27618,7 +27683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 691,
+        "line": 693,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -27637,7 +27702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27652,7 +27717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27671,7 +27736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27686,7 +27751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27705,7 +27770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27720,7 +27785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27739,7 +27804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27754,7 +27819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27773,7 +27838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27788,7 +27853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27807,7 +27872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27822,7 +27887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27841,7 +27906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27856,7 +27921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27875,7 +27940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27890,7 +27955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27909,7 +27974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27924,7 +27989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27943,7 +28008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27958,7 +28023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27977,7 +28042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -27992,7 +28057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28011,7 +28076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28026,7 +28091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28045,7 +28110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28060,7 +28125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28079,7 +28144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28094,7 +28159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28113,7 +28178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28128,7 +28193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28147,7 +28212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28162,7 +28227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28181,7 +28246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28196,7 +28261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28215,7 +28280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28230,7 +28295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28249,7 +28314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28264,7 +28329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28283,7 +28348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28298,7 +28363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28317,7 +28382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28332,7 +28397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28351,7 +28416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28366,7 +28431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28385,7 +28450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28400,7 +28465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28419,7 +28484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28434,7 +28499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28453,7 +28518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28468,7 +28533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28487,7 +28552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28502,7 +28567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28521,7 +28586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28536,7 +28601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28555,7 +28620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28570,7 +28635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28589,7 +28654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28604,7 +28669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28623,7 +28688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28638,7 +28703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28657,7 +28722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28672,7 +28737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28691,7 +28756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28706,7 +28771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28725,7 +28790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28740,7 +28805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28759,7 +28824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28774,7 +28839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28793,7 +28858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28808,7 +28873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28827,7 +28892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28842,7 +28907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28861,7 +28926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28876,7 +28941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28895,7 +28960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28910,7 +28975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28929,7 +28994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28944,7 +29009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28963,7 +29028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -28978,7 +29043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28997,7 +29062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29012,7 +29077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29031,7 +29096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29046,7 +29111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29065,7 +29130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29080,7 +29145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29099,7 +29164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29114,7 +29179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29133,7 +29198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29148,7 +29213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29167,7 +29232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29182,7 +29247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29201,7 +29266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29216,7 +29281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29235,7 +29300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29250,7 +29315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29269,7 +29334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29284,7 +29349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29303,7 +29368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29318,7 +29383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29337,7 +29402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29352,7 +29417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29371,7 +29436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29386,7 +29451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29405,7 +29470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29420,7 +29485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29439,7 +29504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29454,7 +29519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29473,7 +29538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29488,7 +29553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29507,7 +29572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29522,7 +29587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29541,7 +29606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29556,7 +29621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29575,7 +29640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29590,7 +29655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29609,7 +29674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29624,7 +29689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29643,7 +29708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29658,7 +29723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29677,7 +29742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29692,7 +29757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29711,7 +29776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29726,7 +29791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29745,7 +29810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29760,7 +29825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29779,7 +29844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29794,7 +29859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29813,7 +29878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29828,7 +29893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29847,7 +29912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29862,7 +29927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29881,7 +29946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29896,7 +29961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29915,7 +29980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29930,7 +29995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29949,7 +30014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29964,7 +30029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29983,7 +30048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -29998,7 +30063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30017,7 +30082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30032,7 +30097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30051,7 +30116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30066,7 +30131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30085,7 +30150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30100,7 +30165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30119,7 +30184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30134,7 +30199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30153,7 +30218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30168,7 +30233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30187,7 +30252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30202,7 +30267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30221,7 +30286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30236,7 +30301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30255,7 +30320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30270,7 +30335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30289,7 +30354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30304,7 +30369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30323,7 +30388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30338,7 +30403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30357,7 +30422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30372,7 +30437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30391,7 +30456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30406,7 +30471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30425,7 +30490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30440,7 +30505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30459,7 +30524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30474,7 +30539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30493,7 +30558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30508,7 +30573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30527,7 +30592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30542,7 +30607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30561,7 +30626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30576,7 +30641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30595,7 +30660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30610,7 +30675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30629,7 +30694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30644,7 +30709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30663,7 +30728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30678,7 +30743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30697,7 +30762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30712,7 +30777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30731,7 +30796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30746,7 +30811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 890,
+        "line": 892,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30765,7 +30830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30780,7 +30845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 890,
+        "line": 892,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30799,7 +30864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30814,7 +30879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 890,
+        "line": 892,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30833,7 +30898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30848,7 +30913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 890,
+        "line": 892,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30867,7 +30932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30882,7 +30947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30901,7 +30966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30916,7 +30981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30935,7 +31000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30950,7 +31015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30969,7 +31034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -30984,7 +31049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 901,
+        "line": 903,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31003,7 +31068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31018,7 +31083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 901,
+        "line": 903,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31037,7 +31102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31052,7 +31117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 901,
+        "line": 903,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31071,7 +31136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31086,7 +31151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31105,7 +31170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31120,7 +31185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31139,7 +31204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31154,7 +31219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31173,7 +31238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31188,7 +31253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31207,7 +31272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31222,7 +31287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31241,7 +31306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31256,7 +31321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31275,7 +31340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31290,7 +31355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31309,7 +31374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31324,7 +31389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31343,7 +31408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31358,7 +31423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31377,7 +31442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31392,7 +31457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31411,7 +31476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31426,7 +31491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31445,7 +31510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31460,7 +31525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31479,7 +31544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31494,7 +31559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31513,7 +31578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31528,7 +31593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31547,7 +31612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31562,7 +31627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31581,7 +31646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31596,7 +31661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31615,7 +31680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31630,7 +31695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31649,7 +31714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31664,7 +31729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31683,7 +31748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31698,7 +31763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31717,7 +31782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31732,7 +31797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31751,7 +31816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31766,7 +31831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31785,7 +31850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31800,7 +31865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31819,7 +31884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31834,7 +31899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31853,7 +31918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31868,7 +31933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31887,7 +31952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31902,7 +31967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31921,7 +31986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31936,7 +32001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31955,7 +32020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -31970,7 +32035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31989,7 +32054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32004,7 +32069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32023,7 +32088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32038,7 +32103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32057,7 +32122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32072,7 +32137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32091,7 +32156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32106,7 +32171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32125,7 +32190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32140,7 +32205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32159,7 +32224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32174,7 +32239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32193,7 +32258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32208,7 +32273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32227,7 +32292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32242,7 +32307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32261,7 +32326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32276,7 +32341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32295,7 +32360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32310,7 +32375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32329,7 +32394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32344,7 +32409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32363,7 +32428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32378,7 +32443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32397,7 +32462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32412,7 +32477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32431,7 +32496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32446,7 +32511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32465,7 +32530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32480,7 +32545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32499,7 +32564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32514,7 +32579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32533,7 +32598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32548,7 +32613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32567,7 +32632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32582,7 +32647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32601,7 +32666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32616,7 +32681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32635,7 +32700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32650,7 +32715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32669,7 +32734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32684,7 +32749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32703,7 +32768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32718,7 +32783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32737,7 +32802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32752,7 +32817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32771,7 +32836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32786,7 +32851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32805,7 +32870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32820,7 +32885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32839,7 +32904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32854,7 +32919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32873,7 +32938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32888,7 +32953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32907,7 +32972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32922,7 +32987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32941,7 +33006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32956,7 +33021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1041,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -32975,7 +33040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -32990,7 +33055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1041,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33009,7 +33074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33024,7 +33089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1045,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33043,7 +33108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33058,7 +33123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1045,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33077,7 +33142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33092,7 +33157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33111,7 +33176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33126,7 +33191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33145,7 +33210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33160,7 +33225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33179,7 +33244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33194,7 +33259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33213,7 +33278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33228,7 +33293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33247,7 +33312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33262,7 +33327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33281,7 +33346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33296,7 +33361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33315,7 +33380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33330,7 +33395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33349,7 +33414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33364,7 +33429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33383,7 +33448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33398,7 +33463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33417,7 +33482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33432,7 +33497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33451,7 +33516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33466,7 +33531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33485,7 +33550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33500,7 +33565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33519,7 +33584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33534,7 +33599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33553,7 +33618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33568,7 +33633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33587,7 +33652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33602,7 +33667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33621,7 +33686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33636,7 +33701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33655,7 +33720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33670,7 +33735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33689,7 +33754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33704,7 +33769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33723,7 +33788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33738,7 +33803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33757,7 +33822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33772,7 +33837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33791,7 +33856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33806,7 +33871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33825,7 +33890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33840,7 +33905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33859,7 +33924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33874,7 +33939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -33893,7 +33958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33908,7 +33973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -33927,7 +33992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33942,7 +34007,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -33961,7 +34026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -33976,7 +34041,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -33995,7 +34060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34010,7 +34075,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1082,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34029,7 +34094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34044,7 +34109,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34063,7 +34128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34078,7 +34143,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34097,7 +34162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34112,7 +34177,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34131,7 +34196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34146,7 +34211,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1088,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34165,7 +34230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34180,7 +34245,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1088,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34199,7 +34264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34214,7 +34279,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34233,7 +34298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34248,7 +34313,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34267,7 +34332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34282,7 +34347,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34301,7 +34366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34316,7 +34381,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34335,7 +34400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34350,7 +34415,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34369,7 +34434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34384,7 +34449,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34403,7 +34468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34418,7 +34483,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34437,7 +34502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34452,7 +34517,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34471,7 +34536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34486,7 +34551,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34505,7 +34570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34520,7 +34585,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34539,7 +34604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34554,7 +34619,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34573,7 +34638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34588,7 +34653,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34607,7 +34672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34622,7 +34687,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34641,7 +34706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34656,7 +34721,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34675,7 +34740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34690,7 +34755,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34709,7 +34774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34724,7 +34789,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34743,7 +34808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34758,7 +34823,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34777,7 +34842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34792,7 +34857,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34811,7 +34876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -34826,7 +34891,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34844,7 +34909,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1604
+            "line": 1606
           }
         ],
         "classification": "external",
@@ -34852,7 +34917,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1605,
+        "line": 1607,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -34869,7 +34934,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1641
+            "line": 1636
           }
         ],
         "classification": "external",
@@ -34877,7 +34942,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1642,
+        "line": 1637,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -34894,7 +34959,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1649
+            "line": 1644
           }
         ],
         "classification": "external",
@@ -34902,7 +34967,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1650,
+        "line": 1645,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -37946,13 +38011,13 @@
       },
       {
         "is_package": false,
-        "loc": 251,
+        "loc": 258,
         "module": "easyuse_anima.aio.resources",
-        "normalized_git_blob_sha1": "612ebcf6af82a8fad8feb2cddf646a1e6d88ab12",
+        "normalized_git_blob_sha1": "f4374d4e36ef87fe0e0eea7e52d271d249c4e8a9",
         "path": "easyuse_anima/aio/resources.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 13,
+          "function_count": 14,
           "global_count": 3
         }
       },
@@ -38534,13 +38599,13 @@
       },
       {
         "is_package": false,
-        "loc": 2372,
+        "loc": 2367,
         "module": "nodes",
-        "normalized_git_blob_sha1": "9756102e49f8a070a6a2d83a543e5fa1ff70528c",
+        "normalized_git_blob_sha1": "71771f6ae5d0047243c78b5acc656d6db41c27ed",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 20,
+          "function_count": 19,
           "global_count": 26
         }
       },
@@ -39900,7 +39965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -39909,7 +39974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39923,7 +39988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -39932,7 +39997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39946,7 +40011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -39955,7 +40020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39969,7 +40034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -39978,7 +40043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39992,7 +40057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40001,7 +40066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40015,7 +40080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40024,7 +40089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40038,7 +40103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40047,7 +40112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40061,7 +40126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40070,7 +40135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 560,
+        "line": 561,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40084,7 +40149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40093,7 +40158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40107,7 +40172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40116,7 +40181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40130,7 +40195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40139,7 +40204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40153,7 +40218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40162,7 +40227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40176,7 +40241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40185,7 +40250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40199,7 +40264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40208,7 +40273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40222,7 +40287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40231,7 +40296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40245,7 +40310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40254,7 +40319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40268,7 +40333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40277,7 +40342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40291,7 +40356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40300,7 +40365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40314,7 +40379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40323,7 +40388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40337,7 +40402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40346,7 +40411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40360,7 +40425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40369,7 +40434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40383,7 +40448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40392,7 +40457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40406,7 +40471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40415,7 +40480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40429,7 +40494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40438,7 +40503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40452,7 +40517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40461,7 +40526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40475,7 +40540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40484,7 +40549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40498,7 +40563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40507,7 +40572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40521,7 +40586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40530,7 +40595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 596,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40544,7 +40609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40553,7 +40618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 596,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40567,7 +40632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40576,7 +40641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 596,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40590,7 +40655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40599,7 +40664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 601,
+        "line": 602,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40613,7 +40678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40622,7 +40687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 601,
+        "line": 602,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40636,7 +40701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40645,7 +40710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 601,
+        "line": 602,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40659,7 +40724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40668,7 +40733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 606,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40682,7 +40747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40691,7 +40756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 606,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40705,7 +40770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40714,7 +40779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 606,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40728,7 +40793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40737,7 +40802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 606,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40751,7 +40816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40760,7 +40825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40774,7 +40839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40783,7 +40848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40797,7 +40862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40806,7 +40871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40820,7 +40885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40829,7 +40894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40843,7 +40908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40852,7 +40917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40866,7 +40931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40875,7 +40940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40889,7 +40954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40898,7 +40963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40912,7 +40977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40921,7 +40986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40935,7 +41000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40944,7 +41009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40958,7 +41023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40967,7 +41032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40981,7 +41046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -40990,7 +41055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41004,7 +41069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41013,7 +41078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41027,7 +41092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41036,7 +41101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41050,7 +41115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41059,7 +41124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41073,7 +41138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41082,7 +41147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41096,7 +41161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41105,7 +41170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41119,7 +41184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41128,7 +41193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41142,7 +41207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41151,7 +41216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41165,7 +41230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41174,7 +41239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41188,7 +41253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41197,7 +41262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41211,7 +41276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41220,7 +41285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41234,7 +41299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41243,7 +41308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41257,7 +41322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41266,7 +41331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41280,7 +41345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41289,7 +41354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41303,7 +41368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41312,7 +41377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 627,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41326,7 +41391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41335,7 +41400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41349,7 +41414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41358,7 +41423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41372,7 +41437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41381,7 +41446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41395,7 +41460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41404,7 +41469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41418,7 +41483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41427,7 +41492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41441,7 +41506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41450,7 +41515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41464,7 +41529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41473,7 +41538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41487,7 +41552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41496,7 +41561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41510,7 +41575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41519,7 +41584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41533,7 +41598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41542,7 +41607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 641,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41556,7 +41621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41565,7 +41630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41579,7 +41644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41588,7 +41653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41602,7 +41667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41611,7 +41676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41625,7 +41690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41634,7 +41699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41648,7 +41713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41657,7 +41722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41671,7 +41736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41680,7 +41745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41694,7 +41759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41703,7 +41768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41717,7 +41782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41726,7 +41791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41740,7 +41805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41749,7 +41814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41763,7 +41828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41772,7 +41837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 653,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41786,7 +41851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41795,7 +41860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41809,7 +41874,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
+        "kind": "static_from",
+        "line": 666,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41818,7 +41906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41832,7 +41920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41841,7 +41929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41855,7 +41943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41864,7 +41952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41878,7 +41966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41887,7 +41975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41901,7 +41989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41910,7 +41998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41924,7 +42012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41933,7 +42021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41947,7 +42035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41956,7 +42044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41970,7 +42058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -41979,7 +42067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41993,7 +42081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42002,7 +42090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42016,7 +42104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42025,7 +42113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42039,7 +42127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42048,7 +42136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 665,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42062,7 +42150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42071,7 +42159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42085,7 +42173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42094,7 +42182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42108,7 +42196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42117,7 +42205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42131,7 +42219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42140,7 +42228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 684,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42154,7 +42242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42163,7 +42251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 684,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42177,7 +42265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42186,7 +42274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 684,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42200,7 +42288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42209,7 +42297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 684,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42223,7 +42311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42232,7 +42320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 684,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42246,7 +42334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42255,7 +42343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 691,
+        "line": 693,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42269,7 +42357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42278,7 +42366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42292,7 +42380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42301,7 +42389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42315,7 +42403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42324,7 +42412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42338,7 +42426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42347,7 +42435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42361,7 +42449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42370,7 +42458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42384,7 +42472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42393,7 +42481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42407,7 +42495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42416,7 +42504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42430,7 +42518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42439,7 +42527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42453,7 +42541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42462,7 +42550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42476,7 +42564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42485,7 +42573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42499,7 +42587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42508,7 +42596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42522,7 +42610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42531,7 +42619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42545,7 +42633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42554,7 +42642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42568,7 +42656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42577,7 +42665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42591,7 +42679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42600,7 +42688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42614,7 +42702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42623,7 +42711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42637,7 +42725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42646,7 +42734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42660,7 +42748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42669,7 +42757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42683,7 +42771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42692,7 +42780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42706,7 +42794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42715,7 +42803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42729,7 +42817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42738,7 +42826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42752,7 +42840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42761,7 +42849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42775,7 +42863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42784,7 +42872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42798,7 +42886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42807,7 +42895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42821,7 +42909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42830,7 +42918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42844,7 +42932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42853,7 +42941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42867,7 +42955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42876,7 +42964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42890,7 +42978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42899,7 +42987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42913,7 +43001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42922,7 +43010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42936,7 +43024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42945,7 +43033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42959,7 +43047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42968,7 +43056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42982,7 +43070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -42991,7 +43079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43005,7 +43093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43014,7 +43102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43028,7 +43116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43037,7 +43125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43051,7 +43139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43060,7 +43148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43074,7 +43162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43083,7 +43171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43097,7 +43185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43106,7 +43194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43120,7 +43208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43129,7 +43217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43143,7 +43231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43152,7 +43240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43166,7 +43254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43175,7 +43263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43189,7 +43277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43198,7 +43286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43212,7 +43300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43221,7 +43309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43235,7 +43323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43244,7 +43332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43258,7 +43346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43267,7 +43355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43281,7 +43369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43290,7 +43378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43304,7 +43392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43313,7 +43401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43327,7 +43415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43336,7 +43424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43350,7 +43438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43359,7 +43447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43373,7 +43461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43382,7 +43470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43396,7 +43484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43405,7 +43493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43419,7 +43507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43428,7 +43516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43442,7 +43530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43451,7 +43539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43465,7 +43553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43474,7 +43562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43488,7 +43576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43497,7 +43585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43511,7 +43599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43520,7 +43608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43534,7 +43622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43543,7 +43631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43557,7 +43645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43566,7 +43654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 766,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43580,7 +43668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43589,7 +43677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43603,7 +43691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43612,7 +43700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43626,7 +43714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43635,7 +43723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43649,7 +43737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43658,7 +43746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43672,7 +43760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43681,7 +43769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43695,7 +43783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43704,7 +43792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43718,7 +43806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43727,7 +43815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43741,7 +43829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43750,7 +43838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43764,7 +43852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43773,7 +43861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 794,
+        "line": 796,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43787,7 +43875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43796,7 +43884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43810,7 +43898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43819,7 +43907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43833,7 +43921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43842,7 +43930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43856,7 +43944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43865,7 +43953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43879,7 +43967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43888,7 +43976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43902,7 +43990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43911,7 +43999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43925,7 +44013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43934,7 +44022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43948,7 +44036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43957,7 +44045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43971,7 +44059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -43980,7 +44068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43994,7 +44082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44003,7 +44091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44017,7 +44105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44026,7 +44114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44040,7 +44128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44049,7 +44137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44063,7 +44151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44072,7 +44160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44086,7 +44174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44095,7 +44183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44109,7 +44197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44118,7 +44206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44132,7 +44220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44141,7 +44229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44155,7 +44243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44164,7 +44252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44178,7 +44266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44187,7 +44275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44201,7 +44289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44210,7 +44298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44224,7 +44312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44233,7 +44321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44247,7 +44335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44256,7 +44344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44270,7 +44358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44279,7 +44367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44293,7 +44381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44302,7 +44390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44316,7 +44404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44325,7 +44413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44339,7 +44427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44348,7 +44436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44362,7 +44450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44371,7 +44459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 890,
+        "line": 892,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44385,7 +44473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44394,7 +44482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 890,
+        "line": 892,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44408,7 +44496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44417,7 +44505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 890,
+        "line": 892,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44431,7 +44519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44440,7 +44528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 890,
+        "line": 892,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44454,7 +44542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44463,7 +44551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44477,7 +44565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44486,7 +44574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44500,7 +44588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44509,7 +44597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44523,7 +44611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44532,7 +44620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 901,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44546,7 +44634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44555,7 +44643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 901,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44569,7 +44657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44578,7 +44666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 901,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44592,7 +44680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44601,7 +44689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44615,7 +44703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44624,7 +44712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44638,7 +44726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44647,7 +44735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44661,7 +44749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44670,7 +44758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44684,7 +44772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44693,7 +44781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44707,7 +44795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44716,7 +44804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44730,7 +44818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44739,7 +44827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44753,7 +44841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44762,7 +44850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44776,7 +44864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44785,7 +44873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44799,7 +44887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44808,7 +44896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44822,7 +44910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44831,7 +44919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44845,7 +44933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44854,7 +44942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44868,7 +44956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44877,7 +44965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44891,7 +44979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44900,7 +44988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44914,7 +45002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44923,7 +45011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44937,7 +45025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44946,7 +45034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 940,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44960,7 +45048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44969,7 +45057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44983,7 +45071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -44992,7 +45080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45006,7 +45094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45015,7 +45103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45029,7 +45117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45038,7 +45126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45052,7 +45140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45061,7 +45149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45075,7 +45163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45084,7 +45172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45098,7 +45186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45107,7 +45195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45121,7 +45209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45130,7 +45218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45144,7 +45232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45153,7 +45241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45167,7 +45255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45176,7 +45264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45190,7 +45278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45199,7 +45287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45213,7 +45301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45222,7 +45310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 959,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45236,7 +45324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45245,7 +45333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45259,7 +45347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45268,7 +45356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45282,7 +45370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45291,7 +45379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45305,7 +45393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45314,7 +45402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45328,7 +45416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45337,7 +45425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45351,7 +45439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45360,7 +45448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45374,7 +45462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45383,7 +45471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45397,7 +45485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45406,7 +45494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45420,7 +45508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45429,7 +45517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45443,7 +45531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45452,7 +45540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45466,7 +45554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45475,7 +45563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45489,7 +45577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45498,7 +45586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45512,7 +45600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45521,7 +45609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45535,7 +45623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45544,7 +45632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45558,7 +45646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45567,7 +45655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45581,7 +45669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45590,7 +45678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 986,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45604,7 +45692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45613,7 +45701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45627,7 +45715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45636,7 +45724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45650,7 +45738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45659,7 +45747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45673,7 +45761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45682,7 +45770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45696,7 +45784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45705,7 +45793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45719,7 +45807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45728,7 +45816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45742,7 +45830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45751,7 +45839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45765,7 +45853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45774,7 +45862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45788,7 +45876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45797,7 +45885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45811,7 +45899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45820,7 +45908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45834,7 +45922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45843,7 +45931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45857,7 +45945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45866,7 +45954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45880,7 +45968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45889,7 +45977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45903,7 +45991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45912,7 +46000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45926,7 +46014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45935,7 +46023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45949,7 +46037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45958,7 +46046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45972,7 +46060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -45981,7 +46069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45995,7 +46083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46004,7 +46092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46018,7 +46106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46027,7 +46115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46041,7 +46129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46050,7 +46138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46064,7 +46152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46073,7 +46161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46087,7 +46175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46096,7 +46184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46110,7 +46198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46119,7 +46207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46133,7 +46221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46142,7 +46230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46156,7 +46244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46165,7 +46253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46179,7 +46267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46188,7 +46276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46202,7 +46290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46211,7 +46299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46225,7 +46313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46234,7 +46322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46248,7 +46336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46257,7 +46345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46271,7 +46359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46280,7 +46368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46294,7 +46382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46303,7 +46391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46317,7 +46405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46326,7 +46414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46340,7 +46428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46349,7 +46437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46363,7 +46451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46372,7 +46460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46386,7 +46474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46395,7 +46483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46409,7 +46497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46418,7 +46506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46432,7 +46520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46441,7 +46529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46455,7 +46543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46464,7 +46552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46478,7 +46566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46487,7 +46575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46501,7 +46589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46510,7 +46598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46524,7 +46612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46533,7 +46621,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46547,7 +46635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46556,7 +46644,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46570,7 +46658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46579,7 +46667,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46593,7 +46681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46602,7 +46690,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46616,7 +46704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46625,7 +46713,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46639,7 +46727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46648,7 +46736,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46662,7 +46750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46671,7 +46759,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1088,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46685,7 +46773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46694,7 +46782,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1088,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46708,7 +46796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46717,7 +46805,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46731,7 +46819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46740,7 +46828,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46754,7 +46842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46763,7 +46851,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46777,7 +46865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46786,7 +46874,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46800,7 +46888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46809,7 +46897,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46823,7 +46911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46832,7 +46920,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46846,7 +46934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46855,7 +46943,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46869,7 +46957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46878,7 +46966,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46892,7 +46980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46901,7 +46989,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46915,7 +47003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46924,7 +47012,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46938,7 +47026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46947,7 +47035,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46961,7 +47049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46970,7 +47058,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46984,7 +47072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -46993,7 +47081,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47007,7 +47095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -47016,7 +47104,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47030,7 +47118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -47039,7 +47127,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47053,7 +47141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -47062,7 +47150,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47076,7 +47164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -47085,7 +47173,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47099,7 +47187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -47108,7 +47196,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47122,7 +47210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 559,
+            "handler_line": 560,
             "kind": "try",
             "line": 10
           }
@@ -47131,7 +47219,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48986,7 +49074,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 168,
+            "line": 175,
             "type_checking": false
           },
           {
@@ -48994,14 +49082,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 169
+            "line": 176
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 170,
+        "line": 177,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -50958,14 +51046,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1604
+            "line": 1606
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1605,
+        "line": 1607,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50977,14 +51065,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1641
+            "line": 1636
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1642,
+        "line": 1637,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -50996,14 +51084,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1649
+            "line": 1644
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1650,
+        "line": 1645,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51781,7 +51869,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 168,
+            "line": 175,
             "type_checking": false
           },
           {
@@ -51789,14 +51877,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 169
+            "line": 176
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 170,
+        "line": 177,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -52378,14 +52466,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1604
+            "line": 1606
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1605,
+        "line": 1607,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52397,14 +52485,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1641
+            "line": 1636
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1642,
+        "line": 1637,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52416,14 +52504,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1649
+            "line": 1644
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1650,
+        "line": 1645,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53884,7 +53972,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1109,
+        "line": 1111,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53893,7 +53981,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2268,
+        "line": 2263,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53902,7 +53990,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2271,
+        "line": 2266,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53911,7 +53999,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2274,
+        "line": 2269,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53920,7 +54008,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2277,
+        "line": 2272,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53929,7 +54017,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2280,
+        "line": 2275,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53938,7 +54026,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2283,
+        "line": 2278,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53947,7 +54035,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2286,
+        "line": 2281,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53956,7 +54044,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2289,
+        "line": 2284,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53965,7 +54053,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2292,
+        "line": 2287,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53974,7 +54062,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2295,
+        "line": 2290,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53983,7 +54071,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2298,
+        "line": 2293,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53992,7 +54080,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2301,
+        "line": 2296,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54001,7 +54089,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2304,
+        "line": 2299,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54010,7 +54098,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2307,
+        "line": 2302,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54019,7 +54107,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2310,
+        "line": 2305,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54028,7 +54116,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2313,
+        "line": 2308,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54037,7 +54125,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2317,
+        "line": 2312,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54046,7 +54134,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2320,
+        "line": 2315,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54055,7 +54143,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2324,
+        "line": 2319,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54064,7 +54152,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2327,
+        "line": 2322,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54073,7 +54161,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2331,
+        "line": 2326,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54082,7 +54170,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2334,
+        "line": 2329,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54091,7 +54179,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2337,
+        "line": 2332,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54100,7 +54188,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2340,
+        "line": 2335,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54109,7 +54197,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2343,
+        "line": 2338,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54118,7 +54206,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2346,
+        "line": 2341,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54127,7 +54215,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2353,
+        "line": 2348,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54136,7 +54224,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2359,
+        "line": 2354,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54145,7 +54233,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2364,
+        "line": 2359,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54154,7 +54242,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2368,
+        "line": 2363,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54668,13 +54756,13 @@
       },
       {
         "kind": "dict",
-        "line": 1171,
+        "line": 1173,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1160,
+        "line": 1162,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "05beee12624971a784251fc9f4242a213d9accf4",
+    "base_commit": "f4ab6eb094fcdad900f535f79805f912ec67ffaa",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -46,7 +46,8 @@
       "B-11c13",
       "B-11c14",
       "B-11c15",
-      "B-11c16"
+      "B-11c16",
+      "B-11c17"
     ]
   },
   "enums": {
@@ -81,11 +82,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 288,
+    "nodes_canonical_bindings": 289,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 20,
+    "root_residual_functions": 19,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -228,6 +229,7 @@
       "easyuse_anima.nodes.aio_nodes"
     ],
     "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES": [
+      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "ANIMA_DEFAULT_VAE_CANDIDATES": [
@@ -340,6 +342,9 @@
     ],
     "_WEIGHTED_TOKEN_RE": [
       "easyuse_anima.prompt.fields"
+    ],
+    "_adapter_comfy_diffusion_model_names": [
+      "easyuse_anima.aio.resources"
     ],
     "_advanced_artist_field_prompt": [
       "easyuse_anima.aio.conditioning"
@@ -689,6 +694,9 @@
     ],
     "_find_spectrum_anima_mod_guidance_class": [
       "easyuse_anima.prompt.conditioning"
+    ],
+    "_folder_path_names": [
+      "easyuse_anima.aio.resources"
     ],
     "_format_strength": [
       "easyuse_anima.aio.output",
@@ -2255,6 +2263,7 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_bind_aio_resource_runtime": "_bind_aio_resource_runtime",
+        "_comfy_diffusion_model_names": "_comfy_diffusion_model_names",
         "_load_aio_resources_from_input_context": "_load_aio_resources_from_input_context",
         "_load_aio_sam3_context": "_load_aio_sam3_context",
         "_load_checkpoint_with_comfy": "_load_checkpoint_with_comfy",
@@ -2688,10 +2697,12 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime"
+        "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.resources"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load"
+        "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.resources string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -4121,7 +4132,6 @@
       "kind": "functions",
       "symbols": {
         "_comfy_clip_loader_types": "_comfy_clip_loader_types",
-        "_comfy_diffusion_model_names": "_comfy_diffusion_model_names",
         "_comfy_max_resolution": "_comfy_max_resolution",
         "_comfy_text_encoder_names": "_comfy_text_encoder_names",
         "_comfy_vae_names": "_comfy_vae_names",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1313,6 +1313,72 @@ class AioFinalFitPlanningMoveContractTests(unittest.TestCase):
             self._assert_contract(package_nodes, package_postprocess)
 
 
+class AioResourceNameMoveContractTests(unittest.TestCase):
+    def _assert_contract(self, root_module, canonical_module):
+        self.assertIs(
+            root_module._comfy_diffusion_model_names,
+            canonical_module._comfy_diffusion_model_names,
+        )
+
+        candidates = ("preferred.safetensors", "fallback.safetensors")
+        returned = ["runtime.safetensors"]
+        events = []
+
+        def folder_names(_folder, _fallback):
+            return ["runtime.safetensors"]
+
+        def adapter(candidate_values, folder_lookup):
+            events.append(("adapter_call", candidate_values, folder_lookup))
+            return returned
+
+        def resolver(name):
+            events.append(name)
+            return getattr(root_module, name)
+
+        with (
+            patch.object(
+                root_module,
+                "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+                candidates,
+            ),
+            patch.object(
+                root_module,
+                "_adapter_comfy_diffusion_model_names",
+                adapter,
+            ),
+            patch.object(root_module, "_folder_path_names", folder_names),
+        ):
+            canonical_module._bind_aio_resource_runtime(resolve_helper=resolver)
+            try:
+                result = canonical_module._comfy_diffusion_model_names()
+            finally:
+                canonical_module._bind_aio_resource_runtime(
+                    resolve_helper=lambda name: getattr(root_module, name)
+                )
+
+        self.assertIs(result, returned)
+        self.assertEqual(
+            events,
+            [
+                "_adapter_comfy_diffusion_model_names",
+                "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+                "_folder_path_names",
+                ("adapter_call", candidates, folder_names),
+            ],
+        )
+
+    def test_root_alias_and_call_time_dependencies(self):
+        self._assert_contract(nodes, aio_resources)
+
+    def test_package_alias_and_call_time_dependencies(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_resources = sys.modules[
+                f"{package_name}.easyuse_anima.aio.resources"
+            ]
+            self._assert_contract(package_nodes, package_resources)
+
+
 class AioSeedNormalizationMoveContractTests(unittest.TestCase):
     CONSTANT_NAMES = (
         "AIO_SPECIAL_SEED_RANDOM",

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "9756102e49f8a070a6a2d83a543e5fa1ff70528c")
-        # Issue #184 B-11c16 moves only final-fit application to the
-        # canonical postprocess owner.
-        self.assertEqual(report["top_level"]["function_count"], 20)
+        self.assertEqual(report["git_blob_sha1"], "71771f6ae5d0047243c78b5acc656d6db41c27ed")
+        # Issue #184 B-11c17 moves only the diffusion-model name wrapper to
+        # the canonical AiO resource owner.
+        self.assertEqual(report["top_level"]["function_count"], 19)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_372)
+        self.assertEqual(report["line_count"], 2_367)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "05beee12624971a784251fc9f4242a213d9accf4"
+BASE_COMMIT = "f4ab6eb094fcdad900f535f79805f912ec67ffaa"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1319,6 +1319,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c14",
                 "B-11c15",
                 "B-11c16",
+                "B-11c17",
             ],
         },
         "enums": {
@@ -1331,11 +1332,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 288,
+            "nodes_canonical_bindings": 289,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 20,
+            "root_residual_functions": 19,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c17 단일 Move로 root `_comfy_diffusion_model_names` wrapper만 기존 canonical owner `easyuse_anima.aio.resources`로 이동합니다.
- root `nodes.py`에는 relative/flat direct identity alias를 유지하고 기존 resource binder로 세 dependency를 사용 시점에 resolve합니다.

## 작업 전 inventory

### Symbol / caller

- `_comfy_diffusion_model_names`
  - 현재 surface: `nodes.py` private root definition
  - production consumer: `easyuse_anima.nodes.aio_nodes.EasyUseAnimaInput.INPUT_TYPES`가 매 호출 `_runtime_helper("_comfy_diffusion_model_names")()`로 root seam 조회
  - direct root production caller: 없음
  - direct root behavior test: `tests/test_comfy_adapters.py::ComfyRootCompatibilityTests.test_feature_specific_root_wrappers_inject_existing_constants_and_aliases`
- `_adapter_comfy_diffusion_model_names`
  - `easyuse_anima.infrastructure.comfy.resources._comfy_diffusion_model_names`의 별도 direct alias
  - 후보 tuple과 folder lookup을 받는 domain-neutral 2-argument adapter이며 이동 대상 wrapper와 identity/signature가 다름
  - 이번 PR에서는 이동·변경하지 않습니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical wrapper identity를 유지합니다.
- 기존 `_bind_aio_resource_runtime` 하나를 재사용합니다. 새 binder/global/module은 추가하지 않습니다.
- 사용 시점 root seam: `ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES`, `_adapter_comfy_diffusion_model_names`, `_folder_path_names`.
- mutable state, 직접 I/O, optional import는 없고 adapter 반환값·후보 순서·list 정책을 그대로 보존합니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/resources.py`, `nodes.py`
- contract/analyzer: `tests/test_node_contracts.py`, `tests/test_python_compatibility_surface.py`, `tests/test_nodes_module_analyzer.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 예상 계약 delta

- canonical bindings: `288 → 289`
- root/top-level residual functions: `20 → 19`
- runtime binders: `30` 유지
- runtime resolver names: `271 → 273` (`_adapter_comfy_diffusion_model_names`, `_folder_path_names` 신규)
- shipped/runtime-closure modules: `83` 유지
- globals 26, preamble imports 6: 변화 없음
- `nodes.py` line count: `2372 → 2367`

## 금지 경계

- `_comfy_text_encoder_names`, `_comfy_vae_names`, `_comfy_clip_loader_types` 동시 이동 금지
- infrastructure adapter signature/default/folder key `diffusion_models`/fallback 순서·type·copy 정책 변경 금지
- `ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES`, `_folder_path_names` 이동 금지
- eager `folder_paths`/Comfy import, INPUT_TYPES/default/schema/workflow 변경 금지
- 다른 residual, Contract, Behavior 변경 결합 금지

## 검증

- focused `unittest`: 38개 통과
  - relative/flat identity, call-time dependency 조회 순서, adapter 반환 identity, 기존 root adapter/INPUT_TYPES behavior, package/analyzer/import boundary 확인
- canonical `easyuse_anima/aio/resources.py` Ruff 통과
- 독립 read-only diff review: P1-P3 finding 없음
- exact remote head `b7229b90159528a32a08c7eb2c3296008eeba8b1`:
  - `tools/check_project.ps1 -Profile full` 통과
  - Python `912`개 통과
  - frontend `114`개 통과
  - Pyright baseline ratchet, Python import boundary, `git diff --check` 통과
  - Ruff `110`건은 G-01 report-only이며 blocking failure 없음
- Live ComfyUI/browser smoke: private resource-name Move 범위에서는 수행하지 않음

## 주요 변경 파일

- `easyuse_anima/aio/resources.py`: diffusion-model name wrapper canonical owner
- `nodes.py`: relative/flat direct alias와 기존 root body 제거
- `tests/test_node_contracts.py`: identity·late dependency·평가 순서·adapter 반환 계약
- analyzer/compatibility fixtures 및 아키텍처 문서: 실제 owner와 수치 반영

## 남은 위험 / 미확인

- 실제 ComfyUI API/module/browser smoke는 수행하지 않았습니다. 이 PR은 private resource-name Move이며 기존 root adapter/INPUT_TYPES 회귀와 package/import gate로 검증했습니다.
- full Ruff report는 이전 109건에서 110건이 되었습니다. 새 F401 한 건은 `_adapter_comfy_diffusion_model_names`가 정적 호출 대신 의도한 문자열 runtime resolver seam으로만 소비되기 때문이며 G-01 report-only 범위입니다.
- text encoder, VAE, CLIP resource wrapper는 별도 rollback 단위로 남겨 둡니다.

## 상태

- Ready 후보: 독립 리뷰 및 exact-head full 검증 완료
