### PR TITLE
refactor: move text encoder name wrapper

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `f4ab6eb094fcdad900f535f79805f912ec67ffaa`
+- Integrated `dev` snapshot commit: `82247d9b31cd477a3649c22c994fafe25c1fbd40`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c16 / `f4ab6eb`; B-11c17 diffusion-model name wrapper Move in PR #311 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c17 / `82247d9`; B-11c18 text-encoder name wrapper Move in PR #312 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,9 +42,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,372
-  lines after B-11c16.
-- The mechanical extraction has removed 10,291
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,367
+  lines after B-11c17.
+- The mechanical extraction has removed 10,296
   lines, approximately 81.3% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
@@ -76,8 +76,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   `_aio_usdu_tile_size` wrapper in PR #307 / `21f8c97`. B-11c14 moved only the
   Detailer enabled-target predicate in PR #308 / `5a86162`. B-11c15 moved only
   final-fit size planning in PR #309 / `05beee1`. B-11c16 moved only final-fit
-  application in PR #310 / `f4ab6eb`. B-11c17 moves only the diffusion-model
-  name wrapper in PR #311.
+  application in PR #310 / `f4ab6eb`. B-11c17 moved only the diffusion-model
+  name wrapper in PR #311 / `82247d9`. B-11c18 moves only the text-encoder name
+  wrapper in PR #312.
 
 ### Current quality baseline
 
@@ -319,7 +320,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 diffusion-model name wrapper Move PR #311 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 text-encoder name wrapper Move PR #312 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -907,6 +908,10 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
   - B-11c17 moves only `_comfy_diffusion_model_names` to the existing AiO
     resource owner in PR #311. The default-candidate tuple, folder lookup, and
     domain-neutral adapter remain call-time root seams; the other resource-name
+    wrappers remain separate.
+  - B-11c18 moves only `_comfy_text_encoder_names` to the existing AiO resource
+    owner in PR #312. The default-candidate tuple, folder lookup, and domain-
+    neutral adapter remain call-time root seams; the other resource-name
     wrappers remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,15 +3,15 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `f4ab6eb094fcdad900f535f79805f912ec67ffaa`
+  `82247d9b31cd477a3649c22c994fafe25c1fbd40`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c16 are integrated through PR #310. B-11c is
+- Current state: B-11a through B-11c17 are integrated through PR #311. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c17 diffusion-model name wrapper Move is tracked by
-  PR #311.
+  the final root shim; B-11c18 text-encoder name wrapper Move is tracked by PR
+  #312.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -76,7 +76,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 289 in B-11c17
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 290 in B-11c18
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -85,10 +85,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 19 functions, 0 classes, and 26 assigned
-  globals in B-11c17 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 18 functions, 0 classes, and 26 assigned
+  globals in B-11c18 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 273, including
+- root names reached by those canonical runtime resolvers: 274, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -417,6 +417,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
   Candidate order, folder key, fallback type/copy policy, and adapter result are
   unchanged.
 - PR #311 does not move or change the infrastructure adapter, constants, folder
+  lookup, other resource-name wrappers, INPUT_TYPES, schema, defaults, or
+  workflow behavior.
+
+### B-11c18 text-encoder name wrapper alias
+
+- Canonical owner: `easyuse_anima.aio.resources` for
+  `_comfy_text_encoder_names`.
+- The private root wrapper remains a transitional direct alias in relative
+  package and flat import modes. `EasyUseAnimaInput.INPUT_TYPES` continues to
+  resolve that root name at call time.
+- The existing resource binder resolves `_adapter_comfy_text_encoder_names`,
+  `ANIMA_DEFAULT_CLIP_CANDIDATES`, and `_folder_path_names` at use time.
+  Candidate order, folder key, fallback type/copy policy, and adapter result are
+  unchanged.
+- PR #312 does not move or change the infrastructure adapter, constants, folder
   lookup, other resource-name wrappers, INPUT_TYPES, schema, defaults, or
   workflow behavior.
 

--- a/easyuse_anima/aio/resources.py
+++ b/easyuse_anima/aio/resources.py
@@ -65,6 +65,13 @@ def _comfy_diffusion_model_names() -> list[str]:
     )
 
 
+def _comfy_text_encoder_names() -> list[str]:
+    return _runtime_helper("_adapter_comfy_text_encoder_names")(
+        _runtime_helper("ANIMA_DEFAULT_CLIP_CANDIDATES"),
+        _runtime_helper("_folder_path_names"),
+    )
+
+
 def _preferred_name_default(names: list[str], candidates: tuple[str, ...]) -> str:
     if not names:
         return candidates[0] if candidates else ""

--- a/nodes.py
+++ b/nodes.py
@@ -116,6 +116,7 @@ try:
     from .easyuse_anima.aio.resources import (
         _bind_aio_resource_runtime as _bind_aio_resource_runtime,
         _comfy_diffusion_model_names as _comfy_diffusion_model_names,
+        _comfy_text_encoder_names as _comfy_text_encoder_names,
         _load_aio_resources_from_input_context as _load_aio_resources_from_input_context,
         _load_aio_sam3_context as _load_aio_sam3_context,
         _load_checkpoint_with_comfy as _load_checkpoint_with_comfy,
@@ -666,6 +667,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.aio.resources import (
         _bind_aio_resource_runtime as _bind_aio_resource_runtime,
         _comfy_diffusion_model_names as _comfy_diffusion_model_names,
+        _comfy_text_encoder_names as _comfy_text_encoder_names,
         _load_aio_resources_from_input_context as _load_aio_resources_from_input_context,
         _load_aio_sam3_context as _load_aio_sam3_context,
         _load_checkpoint_with_comfy as _load_checkpoint_with_comfy,
@@ -1608,13 +1610,6 @@ def _comfy_max_resolution() -> int:
     except Exception:
         comfy_nodes = None
     return _adapter_comfy_max_resolution(comfy_nodes)
-
-
-def _comfy_text_encoder_names() -> list[str]:
-    return _adapter_comfy_text_encoder_names(
-        ANIMA_DEFAULT_CLIP_CANDIDATES,
-        _folder_path_names,
-    )
 
 
 def _comfy_vae_names() -> list[str]:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6783,7 +6783,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 175,
+            "line": 182,
             "type_checking": false
           },
           {
@@ -6791,7 +6791,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 176
+            "line": 183
           }
         ],
         "classification": "external",
@@ -6799,7 +6799,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 177,
+        "line": 184,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -16965,6 +16965,37 @@
         "target": "easyuse_anima/aio/resources.py"
       },
       {
+        "alias": "_comfy_text_encoder_names",
+        "bound_name": "_comfy_text_encoder_names",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_comfy_text_encoder_names",
+          "target": "easyuse_anima/aio/resources.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
+        "kind": "static_from",
+        "line": 116,
+        "name": "_comfy_text_encoder_names",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.resources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
         "alias": "_load_aio_resources_from_input_context",
         "bound_name": "_load_aio_resources_from_input_context",
         "branch_context": [
@@ -17327,7 +17358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 131,
+        "line": 132,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17358,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 131,
+        "line": 132,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 131,
+        "line": 132,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 143,
+        "line": 144,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 144,
+        "line": 145,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 144,
+        "line": 145,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 144,
+        "line": 145,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 144,
+        "line": 145,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 164,
+        "line": 165,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 164,
+        "line": 165,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 164,
+        "line": 165,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 164,
+        "line": 165,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 164,
+        "line": 165,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 164,
+        "line": 165,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 164,
+        "line": 165,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 182,
+        "line": 183,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 218,
+        "line": 219,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 246,
+        "line": 247,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 246,
+        "line": 247,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 246,
+        "line": 247,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 246,
+        "line": 247,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 246,
+        "line": 247,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 246,
+        "line": 247,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 246,
+        "line": 247,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 246,
+        "line": 247,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 246,
+        "line": 247,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 262,
+        "line": 263,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 342,
+        "line": 343,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 342,
+        "line": 343,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 342,
+        "line": 343,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 342,
+        "line": 343,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 348,
+        "line": 349,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 348,
+        "line": 349,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 348,
+        "line": 349,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 353,
+        "line": 354,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 353,
+        "line": 354,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 353,
+        "line": 354,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 359,
+        "line": 360,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 359,
+        "line": 360,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 359,
+        "line": 360,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 359,
+        "line": 360,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 359,
+        "line": 360,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 359,
+        "line": 360,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 359,
+        "line": 360,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 379,
+        "line": 380,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 379,
+        "line": 380,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 379,
+        "line": 380,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 379,
+        "line": 380,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 392,
+        "line": 393,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 392,
+        "line": 393,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 411,
+        "line": 412,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 411,
+        "line": 412,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 411,
+        "line": 412,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 411,
+        "line": 412,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 417,
+        "line": 418,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 417,
+        "line": 418,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 417,
+        "line": 418,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 417,
+        "line": 418,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 417,
+        "line": 418,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 425,
+        "line": 426,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 425,
+        "line": 426,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 429,
+        "line": 430,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 433,
+        "line": 434,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 433,
+        "line": 434,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 433,
+        "line": 434,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 445,
+        "line": 446,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 445,
+        "line": 446,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 445,
+        "line": 446,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 450,
+        "line": 451,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 450,
+        "line": 451,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 450,
+        "line": 451,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 468,
+        "line": 469,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 468,
+        "line": 469,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 468,
+        "line": 469,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 468,
+        "line": 469,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 468,
+        "line": 469,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 491,
+        "line": 492,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 491,
+        "line": 492,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 495,
+        "line": 496,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 495,
+        "line": 496,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 517,
+        "line": 518,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 517,
+        "line": 518,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 517,
+        "line": 518,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 517,
+        "line": 518,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 517,
+        "line": 518,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 517,
+        "line": 518,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 517,
+        "line": 518,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 517,
+        "line": 518,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 527,
+        "line": 528,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 527,
+        "line": 528,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24116,7 +24147,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24147,7 +24178,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24166,7 +24197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24181,7 +24212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24200,7 +24231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24215,7 +24246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24234,7 +24265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24249,7 +24280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24268,7 +24299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24283,7 +24314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24302,7 +24333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24317,7 +24348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24336,7 +24367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24351,7 +24382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24370,7 +24401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24385,7 +24416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24404,7 +24435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24419,7 +24450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24438,7 +24469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24453,7 +24484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 572,
+        "line": 573,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24472,7 +24503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24487,7 +24518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 572,
+        "line": 573,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24506,7 +24537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24521,7 +24552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24540,7 +24571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24555,7 +24586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24574,7 +24605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24589,7 +24620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24608,7 +24639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24623,7 +24654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24642,7 +24673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24657,7 +24688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24676,7 +24707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24691,7 +24722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24710,7 +24741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24725,7 +24756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24744,7 +24775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24759,7 +24790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24778,7 +24809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24793,7 +24824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24812,7 +24843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24827,7 +24858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24846,7 +24877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24861,7 +24892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24880,7 +24911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24895,7 +24926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24914,7 +24945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24929,7 +24960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24948,7 +24979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24963,7 +24994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24982,7 +25013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -24997,7 +25028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25016,7 +25047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25031,7 +25062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25050,7 +25081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25065,7 +25096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 594,
+        "line": 595,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25084,7 +25115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25099,7 +25130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25118,7 +25149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25133,7 +25164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25152,7 +25183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25167,7 +25198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25186,7 +25217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25201,7 +25232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 602,
+        "line": 603,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25220,7 +25251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25235,7 +25266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 602,
+        "line": 603,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25254,7 +25285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25269,7 +25300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 602,
+        "line": 603,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25288,7 +25319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25303,7 +25334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 607,
+        "line": 608,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25322,7 +25353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25337,7 +25368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 607,
+        "line": 608,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25356,7 +25387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25371,7 +25402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 607,
+        "line": 608,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25390,7 +25421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25405,7 +25436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 607,
+        "line": 608,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25424,7 +25455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25439,7 +25470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25458,7 +25489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25473,7 +25504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25492,7 +25523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25507,7 +25538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25526,7 +25557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25541,7 +25572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25560,7 +25591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25575,7 +25606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25594,7 +25625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25609,7 +25640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25628,7 +25659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25643,7 +25674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25662,7 +25693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25677,7 +25708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25696,7 +25727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25711,7 +25742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25730,7 +25761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25745,7 +25776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25764,7 +25795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25779,7 +25810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25798,7 +25829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25813,7 +25844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25832,7 +25863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25847,7 +25878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25866,7 +25897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25881,7 +25912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25900,7 +25931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25915,7 +25946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25934,7 +25965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25949,7 +25980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25968,7 +25999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -25983,7 +26014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26002,7 +26033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26017,7 +26048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26036,7 +26067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26051,7 +26082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26070,7 +26101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26085,7 +26116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26104,7 +26135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26119,7 +26150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26138,7 +26169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26153,7 +26184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26172,7 +26203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26187,7 +26218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26206,7 +26237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26221,7 +26252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26240,7 +26271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26255,7 +26286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26274,7 +26305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26289,7 +26320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26308,7 +26339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26323,7 +26354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26342,7 +26373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26357,7 +26388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26376,7 +26407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26391,7 +26422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26410,7 +26441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26425,7 +26456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26444,7 +26475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26459,7 +26490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26478,7 +26509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26493,7 +26524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26512,7 +26543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26527,7 +26558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26546,7 +26577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26561,7 +26592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26580,7 +26611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26595,7 +26626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26614,7 +26645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26629,7 +26660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26648,7 +26679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26663,7 +26694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26682,7 +26713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26697,7 +26728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26716,7 +26747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26731,7 +26762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26750,7 +26781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26765,7 +26796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26784,7 +26815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26799,7 +26830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26818,7 +26849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26833,7 +26864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26852,7 +26883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26867,7 +26898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26886,7 +26917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26901,7 +26932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26920,7 +26951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26935,7 +26966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26954,7 +26985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -26969,7 +27000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -26988,7 +27019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27003,8 +27034,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_comfy_diffusion_model_names",
+        "optional": false,
+        "requested": "easyuse_anima.aio.resources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": "_comfy_text_encoder_names",
+        "bound_name": "_comfy_text_encoder_names",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 561,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_comfy_text_encoder_names",
+          "target": "easyuse_anima/aio/resources.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
+        "kind": "static_from",
+        "line": 667,
+        "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
         "role": "compatibility_fallback",
@@ -27022,7 +27087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27037,7 +27102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27056,7 +27121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27071,7 +27136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27090,7 +27155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27105,7 +27170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27124,7 +27189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27139,7 +27204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27158,7 +27223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27173,7 +27238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27192,7 +27257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27207,7 +27272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27226,7 +27291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27241,7 +27306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27260,7 +27325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27275,7 +27340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27294,7 +27359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27309,7 +27374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27328,7 +27393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27343,7 +27408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27362,7 +27427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27377,7 +27442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27396,7 +27461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27411,7 +27476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27430,7 +27495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27445,7 +27510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27464,7 +27529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27479,7 +27544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27498,7 +27563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27513,7 +27578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 686,
+        "line": 688,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27532,7 +27597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27547,7 +27612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 686,
+        "line": 688,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27566,7 +27631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27581,7 +27646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 686,
+        "line": 688,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27600,7 +27665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27615,7 +27680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 686,
+        "line": 688,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27634,7 +27699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27649,7 +27714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 686,
+        "line": 688,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27668,7 +27733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27683,7 +27748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 693,
+        "line": 695,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -27702,7 +27767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27717,7 +27782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27736,7 +27801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27751,7 +27816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27770,7 +27835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27785,7 +27850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27804,7 +27869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27819,7 +27884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27838,7 +27903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27853,7 +27918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27872,7 +27937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27887,7 +27952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27906,7 +27971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27921,7 +27986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27940,7 +28005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27955,7 +28020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27974,7 +28039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -27989,7 +28054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28008,7 +28073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28023,7 +28088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28042,7 +28107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28057,7 +28122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28076,7 +28141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28091,7 +28156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28110,7 +28175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28125,7 +28190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28144,7 +28209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28159,7 +28224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28178,7 +28243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28193,7 +28258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28212,7 +28277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28227,7 +28292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28246,7 +28311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28261,7 +28326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28280,7 +28345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28295,7 +28360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28314,7 +28379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28329,7 +28394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28348,7 +28413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28363,7 +28428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28382,7 +28447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28397,7 +28462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28416,7 +28481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28431,7 +28496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28450,7 +28515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28465,7 +28530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28484,7 +28549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28499,7 +28564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28518,7 +28583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28533,7 +28598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28552,7 +28617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28567,7 +28632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28586,7 +28651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28601,7 +28666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28620,7 +28685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28635,7 +28700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28654,7 +28719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28669,7 +28734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28688,7 +28753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28703,7 +28768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28722,7 +28787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28737,7 +28802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28756,7 +28821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28771,7 +28836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28790,7 +28855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28805,7 +28870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28824,7 +28889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28839,7 +28904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28858,7 +28923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28873,7 +28938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28892,7 +28957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28907,7 +28972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28926,7 +28991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28941,7 +29006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28960,7 +29025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -28975,7 +29040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28994,7 +29059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29009,7 +29074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29028,7 +29093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29043,7 +29108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29062,7 +29127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29077,7 +29142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29096,7 +29161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29111,7 +29176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29130,7 +29195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29145,7 +29210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29164,7 +29229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29179,7 +29244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29198,7 +29263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29213,7 +29278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29232,7 +29297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29247,7 +29312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29266,7 +29331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29281,7 +29346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29300,7 +29365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29315,7 +29380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29334,7 +29399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29349,7 +29414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29368,7 +29433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29383,7 +29448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29402,7 +29467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29417,7 +29482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29436,7 +29501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29451,7 +29516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29470,7 +29535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29485,7 +29550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29504,7 +29569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29519,7 +29584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29538,7 +29603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29553,7 +29618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29572,7 +29637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29587,7 +29652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29606,7 +29671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29621,7 +29686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29640,7 +29705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29655,7 +29720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29674,7 +29739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29689,7 +29754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29708,7 +29773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29723,7 +29788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29742,7 +29807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29757,7 +29822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29776,7 +29841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29791,7 +29856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29810,7 +29875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29825,7 +29890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29844,7 +29909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29859,7 +29924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29878,7 +29943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29893,7 +29958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29912,7 +29977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29927,7 +29992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29946,7 +30011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29961,7 +30026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29980,7 +30045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -29995,7 +30060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30014,7 +30079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30029,7 +30094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30048,7 +30113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30063,7 +30128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30082,7 +30147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30097,7 +30162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30116,7 +30181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30131,7 +30196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30150,7 +30215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30165,7 +30230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30184,7 +30249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30199,7 +30264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30218,7 +30283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30233,7 +30298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30252,7 +30317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30267,7 +30332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30286,7 +30351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30301,7 +30366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30320,7 +30385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30335,7 +30400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30354,7 +30419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30369,7 +30434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30388,7 +30453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30403,7 +30468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30422,7 +30487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30437,7 +30502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30456,7 +30521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30471,7 +30536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30490,7 +30555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30505,7 +30570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30524,7 +30589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30539,7 +30604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30558,7 +30623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30573,7 +30638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30592,7 +30657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30607,7 +30672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30626,7 +30691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30641,7 +30706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30660,7 +30725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30675,7 +30740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30694,7 +30759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30709,7 +30774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30728,7 +30793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30743,7 +30808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30762,7 +30827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30777,7 +30842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30796,7 +30861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30811,7 +30876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 892,
+        "line": 894,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30830,7 +30895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30845,7 +30910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 892,
+        "line": 894,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30864,7 +30929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30879,7 +30944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 892,
+        "line": 894,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30898,7 +30963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30913,7 +30978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 892,
+        "line": 894,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30932,7 +30997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30947,7 +31012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -30966,7 +31031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -30981,7 +31046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31000,7 +31065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31015,7 +31080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31034,7 +31099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31049,7 +31114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 903,
+        "line": 905,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31068,7 +31133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31083,7 +31148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 903,
+        "line": 905,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31102,7 +31167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31117,7 +31182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 903,
+        "line": 905,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31136,7 +31201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31151,7 +31216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31170,7 +31235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31185,7 +31250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31204,7 +31269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31219,7 +31284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31238,7 +31303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31253,7 +31318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31272,7 +31337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31287,7 +31352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31306,7 +31371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31321,7 +31386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31340,7 +31405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31355,7 +31420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31374,7 +31439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31389,7 +31454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31408,7 +31473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31423,7 +31488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31442,7 +31507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31457,7 +31522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31476,7 +31541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31491,7 +31556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31510,7 +31575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31525,7 +31590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31544,7 +31609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31559,7 +31624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31578,7 +31643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31593,7 +31658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31612,7 +31677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31627,7 +31692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 942,
+        "line": 944,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31646,7 +31711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31661,7 +31726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 942,
+        "line": 944,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31680,7 +31745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31695,7 +31760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31714,7 +31779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31729,7 +31794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31748,7 +31813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31763,7 +31828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31782,7 +31847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31797,7 +31862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31816,7 +31881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31831,7 +31896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31850,7 +31915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31865,7 +31930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31884,7 +31949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31899,7 +31964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31918,7 +31983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31933,7 +31998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31952,7 +32017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -31967,7 +32032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -31986,7 +32051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32001,7 +32066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32020,7 +32085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32035,7 +32100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32054,7 +32119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32069,7 +32134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32088,7 +32153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32103,7 +32168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32122,7 +32187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32137,7 +32202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32156,7 +32221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32171,7 +32236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32190,7 +32255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32205,7 +32270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32224,7 +32289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32239,7 +32304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32258,7 +32323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32273,7 +32338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32292,7 +32357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32307,7 +32372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32326,7 +32391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32341,7 +32406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32360,7 +32425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32375,7 +32440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32394,7 +32459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32409,7 +32474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32428,7 +32493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32443,7 +32508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32462,7 +32527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32477,7 +32542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32496,7 +32561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32511,7 +32576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32530,7 +32595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32545,7 +32610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32564,7 +32629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32579,7 +32644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32598,7 +32663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32613,7 +32678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32632,7 +32697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32647,7 +32712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32666,7 +32731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32681,7 +32746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32700,7 +32765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32715,7 +32780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32734,7 +32799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32749,7 +32814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32768,7 +32833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32783,7 +32848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32802,7 +32867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32817,7 +32882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32836,7 +32901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32851,7 +32916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32870,7 +32935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32885,7 +32950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32904,7 +32969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32919,7 +32984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32938,7 +33003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32953,7 +33018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32972,7 +33037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -32987,7 +33052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33006,7 +33071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33021,7 +33086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1043,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33040,7 +33105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33055,7 +33120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1043,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33074,7 +33139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33089,7 +33154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1047,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33108,7 +33173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33123,7 +33188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1047,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33142,7 +33207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33157,7 +33222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33176,7 +33241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33191,7 +33256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33210,7 +33275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33225,7 +33290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33244,7 +33309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33259,7 +33324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33278,7 +33343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33293,7 +33358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33312,7 +33377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33327,7 +33392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33346,7 +33411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33361,7 +33426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33380,7 +33445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33395,7 +33460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33414,7 +33479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33429,7 +33494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33448,7 +33513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33463,7 +33528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33482,7 +33547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33497,7 +33562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33516,7 +33581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33531,7 +33596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33550,7 +33615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33565,7 +33630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33584,7 +33649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33599,7 +33664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33618,7 +33683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33633,7 +33698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33652,7 +33717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33667,7 +33732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33686,7 +33751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33701,7 +33766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33720,7 +33785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33735,7 +33800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33754,7 +33819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33769,7 +33834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33788,7 +33853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33803,7 +33868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33822,7 +33887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33837,7 +33902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33856,7 +33921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33871,7 +33936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33890,7 +33955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33905,7 +33970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33924,7 +33989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33939,7 +34004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -33958,7 +34023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -33973,7 +34038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -33992,7 +34057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34007,7 +34072,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34026,7 +34091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34041,7 +34106,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34060,7 +34125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34075,7 +34140,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1084,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34094,7 +34159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34109,7 +34174,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34128,7 +34193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34143,7 +34208,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34162,7 +34227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34177,7 +34242,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34196,7 +34261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34211,7 +34276,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1090,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34230,7 +34295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34245,7 +34310,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1090,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34264,7 +34329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34279,7 +34344,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34298,7 +34363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34313,7 +34378,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34332,7 +34397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34347,7 +34412,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34366,7 +34431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34381,7 +34446,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34400,7 +34465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34415,7 +34480,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34434,7 +34499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34449,7 +34514,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34468,7 +34533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34483,7 +34548,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34502,7 +34567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34517,7 +34582,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34536,7 +34601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34551,7 +34616,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34570,7 +34635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34585,7 +34650,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34604,7 +34669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34619,7 +34684,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34638,7 +34703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34653,7 +34718,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34672,7 +34737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34687,7 +34752,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34706,7 +34771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34721,7 +34786,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34740,7 +34805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34755,7 +34820,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34774,7 +34839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34789,7 +34854,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34808,7 +34873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34823,7 +34888,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34842,7 +34907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34857,7 +34922,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34876,7 +34941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -34891,7 +34956,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34909,7 +34974,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1606
+            "line": 1608
           }
         ],
         "classification": "external",
@@ -34917,7 +34982,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1607,
+        "line": 1609,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -34934,7 +34999,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1636
+            "line": 1631
           }
         ],
         "classification": "external",
@@ -34942,7 +35007,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1637,
+        "line": 1632,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -34959,7 +35024,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1644
+            "line": 1639
           }
         ],
         "classification": "external",
@@ -34967,7 +35032,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1645,
+        "line": 1640,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -38011,13 +38076,13 @@
       },
       {
         "is_package": false,
-        "loc": 258,
+        "loc": 265,
         "module": "easyuse_anima.aio.resources",
-        "normalized_git_blob_sha1": "f4374d4e36ef87fe0e0eea7e52d271d249c4e8a9",
+        "normalized_git_blob_sha1": "9b047ddabdb1268bb435ae533158f5cfbb30c971",
         "path": "easyuse_anima/aio/resources.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 14,
+          "function_count": 15,
           "global_count": 3
         }
       },
@@ -38599,13 +38664,13 @@
       },
       {
         "is_package": false,
-        "loc": 2367,
+        "loc": 2362,
         "module": "nodes",
-        "normalized_git_blob_sha1": "71771f6ae5d0047243c78b5acc656d6db41c27ed",
+        "normalized_git_blob_sha1": "7154f6a98467511193e1dafaf6832882be3c23ce",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 19,
+          "function_count": 18,
           "global_count": 26
         }
       },
@@ -39965,7 +40030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -39974,7 +40039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39988,7 +40053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -39997,7 +40062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40011,7 +40076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40020,7 +40085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40034,7 +40099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40043,7 +40108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40057,7 +40122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40066,7 +40131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40080,7 +40145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40089,7 +40154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40103,7 +40168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40112,7 +40177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40126,7 +40191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40135,7 +40200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 561,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40149,7 +40214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40158,7 +40223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 572,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40172,7 +40237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40181,7 +40246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 572,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40195,7 +40260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40204,7 +40269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40218,7 +40283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40227,7 +40292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40241,7 +40306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40250,7 +40315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40264,7 +40329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40273,7 +40338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40287,7 +40352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40296,7 +40361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40310,7 +40375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40319,7 +40384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40333,7 +40398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40342,7 +40407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40356,7 +40421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40365,7 +40430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40379,7 +40444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40388,7 +40453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40402,7 +40467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40411,7 +40476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40425,7 +40490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40434,7 +40499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40448,7 +40513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40457,7 +40522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40471,7 +40536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40480,7 +40545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40494,7 +40559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40503,7 +40568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40517,7 +40582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40526,7 +40591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40540,7 +40605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40549,7 +40614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40563,7 +40628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40572,7 +40637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 594,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40586,7 +40651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40595,7 +40660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40609,7 +40674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40618,7 +40683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40632,7 +40697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40641,7 +40706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40655,7 +40720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40664,7 +40729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 602,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40678,7 +40743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40687,7 +40752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 602,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40701,7 +40766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40710,7 +40775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 602,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40724,7 +40789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40733,7 +40798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 607,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40747,7 +40812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40756,7 +40821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 607,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40770,7 +40835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40779,7 +40844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 607,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40793,7 +40858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40802,7 +40867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 607,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40816,7 +40881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40825,7 +40890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40839,7 +40904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40848,7 +40913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40862,7 +40927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40871,7 +40936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40885,7 +40950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40894,7 +40959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40908,7 +40973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40917,7 +40982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40931,7 +40996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40940,7 +41005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40954,7 +41019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40963,7 +41028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40977,7 +41042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -40986,7 +41051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41000,7 +41065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41009,7 +41074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41023,7 +41088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41032,7 +41097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41046,7 +41111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41055,7 +41120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41069,7 +41134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41078,7 +41143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41092,7 +41157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41101,7 +41166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41115,7 +41180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41124,7 +41189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41138,7 +41203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41147,7 +41212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41161,7 +41226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41170,7 +41235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41184,7 +41249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41193,7 +41258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41207,7 +41272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41216,7 +41281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41230,7 +41295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41239,7 +41304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41253,7 +41318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41262,7 +41327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41276,7 +41341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41285,7 +41350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41299,7 +41364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41308,7 +41373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41322,7 +41387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41331,7 +41396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41345,7 +41410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41354,7 +41419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41368,7 +41433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41377,7 +41442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 628,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41391,7 +41456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41400,7 +41465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41414,7 +41479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41423,7 +41488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41437,7 +41502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41446,7 +41511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41460,7 +41525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41469,7 +41534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41483,7 +41548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41492,7 +41557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41506,7 +41571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41515,7 +41580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41529,7 +41594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41538,7 +41603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41552,7 +41617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41561,7 +41626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41575,7 +41640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41584,7 +41649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41598,7 +41663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41607,7 +41672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 642,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41621,7 +41686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41630,7 +41695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41644,7 +41709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41653,7 +41718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41667,7 +41732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41676,7 +41741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41690,7 +41755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41699,7 +41764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41713,7 +41778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41722,7 +41787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41736,7 +41801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41745,7 +41810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41759,7 +41824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41768,7 +41833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41782,7 +41847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41791,7 +41856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41805,7 +41870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41814,7 +41879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41828,7 +41893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41837,7 +41902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 654,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41851,7 +41916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41860,7 +41925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41874,7 +41939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41883,7 +41948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41897,7 +41962,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
+        "kind": "static_from",
+        "line": 667,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41906,7 +41994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41920,7 +42008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41929,7 +42017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41943,7 +42031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41952,7 +42040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41966,7 +42054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41975,7 +42063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41989,7 +42077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -41998,7 +42086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42012,7 +42100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42021,7 +42109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42035,7 +42123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42044,7 +42132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42058,7 +42146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42067,7 +42155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42081,7 +42169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42090,7 +42178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42104,7 +42192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42113,7 +42201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42127,7 +42215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42136,7 +42224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 666,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42150,7 +42238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42159,7 +42247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42173,7 +42261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42182,7 +42270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42196,7 +42284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42205,7 +42293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42219,7 +42307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42228,7 +42316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 686,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42242,7 +42330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42251,7 +42339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 686,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42265,7 +42353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42274,7 +42362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 686,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42288,7 +42376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42297,7 +42385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 686,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42311,7 +42399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42320,7 +42408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 686,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42334,7 +42422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42343,7 +42431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 693,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42357,7 +42445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42366,7 +42454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42380,7 +42468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42389,7 +42477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42403,7 +42491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42412,7 +42500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42426,7 +42514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42435,7 +42523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42449,7 +42537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42458,7 +42546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42472,7 +42560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42481,7 +42569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42495,7 +42583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42504,7 +42592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42518,7 +42606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42527,7 +42615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42541,7 +42629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42550,7 +42638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42564,7 +42652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42573,7 +42661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42587,7 +42675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42596,7 +42684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42610,7 +42698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42619,7 +42707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42633,7 +42721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42642,7 +42730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42656,7 +42744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42665,7 +42753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42679,7 +42767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42688,7 +42776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42702,7 +42790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42711,7 +42799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42725,7 +42813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42734,7 +42822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42748,7 +42836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42757,7 +42845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42771,7 +42859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42780,7 +42868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42794,7 +42882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42803,7 +42891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42817,7 +42905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42826,7 +42914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42840,7 +42928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42849,7 +42937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42863,7 +42951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42872,7 +42960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42886,7 +42974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42895,7 +42983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42909,7 +42997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42918,7 +43006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42932,7 +43020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42941,7 +43029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42955,7 +43043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42964,7 +43052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42978,7 +43066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -42987,7 +43075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43001,7 +43089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43010,7 +43098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43024,7 +43112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43033,7 +43121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43047,7 +43135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43056,7 +43144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43070,7 +43158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43079,7 +43167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43093,7 +43181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43102,7 +43190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43116,7 +43204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43125,7 +43213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43139,7 +43227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43148,7 +43236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43162,7 +43250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43171,7 +43259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43185,7 +43273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43194,7 +43282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43208,7 +43296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43217,7 +43305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43231,7 +43319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43240,7 +43328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43254,7 +43342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43263,7 +43351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43277,7 +43365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43286,7 +43374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43300,7 +43388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43309,7 +43397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43323,7 +43411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43332,7 +43420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43346,7 +43434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43355,7 +43443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43369,7 +43457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43378,7 +43466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43392,7 +43480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43401,7 +43489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43415,7 +43503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43424,7 +43512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43438,7 +43526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43447,7 +43535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43461,7 +43549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43470,7 +43558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43484,7 +43572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43493,7 +43581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43507,7 +43595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43516,7 +43604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43530,7 +43618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43539,7 +43627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43553,7 +43641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43562,7 +43650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43576,7 +43664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43585,7 +43673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43599,7 +43687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43608,7 +43696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43622,7 +43710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43631,7 +43719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43645,7 +43733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43654,7 +43742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 768,
+        "line": 770,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43668,7 +43756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43677,7 +43765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43691,7 +43779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43700,7 +43788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43714,7 +43802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43723,7 +43811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43737,7 +43825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43746,7 +43834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43760,7 +43848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43769,7 +43857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43783,7 +43871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43792,7 +43880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43806,7 +43894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43815,7 +43903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43829,7 +43917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43838,7 +43926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43852,7 +43940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43861,7 +43949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 796,
+        "line": 798,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43875,7 +43963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43884,7 +43972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43898,7 +43986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43907,7 +43995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43921,7 +44009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43930,7 +44018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43944,7 +44032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43953,7 +44041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43967,7 +44055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43976,7 +44064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43990,7 +44078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -43999,7 +44087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44013,7 +44101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44022,7 +44110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44036,7 +44124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44045,7 +44133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44059,7 +44147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44068,7 +44156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44082,7 +44170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44091,7 +44179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44105,7 +44193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44114,7 +44202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44128,7 +44216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44137,7 +44225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44151,7 +44239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44160,7 +44248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44174,7 +44262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44183,7 +44271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44197,7 +44285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44206,7 +44294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44220,7 +44308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44229,7 +44317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44243,7 +44331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44252,7 +44340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44266,7 +44354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44275,7 +44363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44289,7 +44377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44298,7 +44386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44312,7 +44400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44321,7 +44409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44335,7 +44423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44344,7 +44432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44358,7 +44446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44367,7 +44455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44381,7 +44469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44390,7 +44478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44404,7 +44492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44413,7 +44501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44427,7 +44515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44436,7 +44524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44450,7 +44538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44459,7 +44547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 892,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44473,7 +44561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44482,7 +44570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 892,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44496,7 +44584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44505,7 +44593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 892,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44519,7 +44607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44528,7 +44616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 892,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44542,7 +44630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44551,7 +44639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44565,7 +44653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44574,7 +44662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44588,7 +44676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44597,7 +44685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44611,7 +44699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44620,7 +44708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 903,
+        "line": 905,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44634,7 +44722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44643,7 +44731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 903,
+        "line": 905,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44657,7 +44745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44666,7 +44754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 903,
+        "line": 905,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44680,7 +44768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44689,7 +44777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44703,7 +44791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44712,7 +44800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44726,7 +44814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44735,7 +44823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44749,7 +44837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44758,7 +44846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44772,7 +44860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44781,7 +44869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44795,7 +44883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44804,7 +44892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44818,7 +44906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44827,7 +44915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44841,7 +44929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44850,7 +44938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44864,7 +44952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44873,7 +44961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44887,7 +44975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44896,7 +44984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44910,7 +44998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44919,7 +45007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44933,7 +45021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44942,7 +45030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44956,7 +45044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44965,7 +45053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44979,7 +45067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -44988,7 +45076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45002,7 +45090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45011,7 +45099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 942,
+        "line": 944,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45025,7 +45113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45034,7 +45122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 942,
+        "line": 944,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45048,7 +45136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45057,7 +45145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45071,7 +45159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45080,7 +45168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45094,7 +45182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45103,7 +45191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45117,7 +45205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45126,7 +45214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45140,7 +45228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45149,7 +45237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45163,7 +45251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45172,7 +45260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45186,7 +45274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45195,7 +45283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45209,7 +45297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45218,7 +45306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45232,7 +45320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45241,7 +45329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45255,7 +45343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45264,7 +45352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45278,7 +45366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45287,7 +45375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45301,7 +45389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45310,7 +45398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 961,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45324,7 +45412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45333,7 +45421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45347,7 +45435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45356,7 +45444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45370,7 +45458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45379,7 +45467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45393,7 +45481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45402,7 +45490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45416,7 +45504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45425,7 +45513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45439,7 +45527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45448,7 +45536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45462,7 +45550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45471,7 +45559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45485,7 +45573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45494,7 +45582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45508,7 +45596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45517,7 +45605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45531,7 +45619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45540,7 +45628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45554,7 +45642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45563,7 +45651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45577,7 +45665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45586,7 +45674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45600,7 +45688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45609,7 +45697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45623,7 +45711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45632,7 +45720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45646,7 +45734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45655,7 +45743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45669,7 +45757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45678,7 +45766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 988,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45692,7 +45780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45701,7 +45789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45715,7 +45803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45724,7 +45812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45738,7 +45826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45747,7 +45835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45761,7 +45849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45770,7 +45858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45784,7 +45872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45793,7 +45881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45807,7 +45895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45816,7 +45904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45830,7 +45918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45839,7 +45927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45853,7 +45941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45862,7 +45950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45876,7 +45964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45885,7 +45973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45899,7 +45987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45908,7 +45996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45922,7 +46010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45931,7 +46019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45945,7 +46033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45954,7 +46042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1043,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45968,7 +46056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -45977,7 +46065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1043,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45991,7 +46079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46000,7 +46088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1047,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46014,7 +46102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46023,7 +46111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1047,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46037,7 +46125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46046,7 +46134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46060,7 +46148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46069,7 +46157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46083,7 +46171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46092,7 +46180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46106,7 +46194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46115,7 +46203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46129,7 +46217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46138,7 +46226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46152,7 +46240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46161,7 +46249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46175,7 +46263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46184,7 +46272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46198,7 +46286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46207,7 +46295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46221,7 +46309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46230,7 +46318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46244,7 +46332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46253,7 +46341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46267,7 +46355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46276,7 +46364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46290,7 +46378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46299,7 +46387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46313,7 +46401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46322,7 +46410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46336,7 +46424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46345,7 +46433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46359,7 +46447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46368,7 +46456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1052,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46382,7 +46470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46391,7 +46479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46405,7 +46493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46414,7 +46502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46428,7 +46516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46437,7 +46525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46451,7 +46539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46460,7 +46548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46474,7 +46562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46483,7 +46571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46497,7 +46585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46506,7 +46594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46520,7 +46608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46529,7 +46617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46543,7 +46631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46552,7 +46640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46566,7 +46654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46575,7 +46663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46589,7 +46677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46598,7 +46686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46612,7 +46700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46621,7 +46709,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46635,7 +46723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46644,7 +46732,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46658,7 +46746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46667,7 +46755,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46681,7 +46769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46690,7 +46778,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46704,7 +46792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46713,7 +46801,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46727,7 +46815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46736,7 +46824,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46750,7 +46838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46759,7 +46847,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1090,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46773,7 +46861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46782,7 +46870,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1090,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46796,7 +46884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46805,7 +46893,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46819,7 +46907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46828,7 +46916,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46842,7 +46930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46851,7 +46939,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46865,7 +46953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46874,7 +46962,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46888,7 +46976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46897,7 +46985,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46911,7 +46999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46920,7 +47008,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46934,7 +47022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46943,7 +47031,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46957,7 +47045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46966,7 +47054,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46980,7 +47068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -46989,7 +47077,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47003,7 +47091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -47012,7 +47100,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47026,7 +47114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -47035,7 +47123,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47049,7 +47137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -47058,7 +47146,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47072,7 +47160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -47081,7 +47169,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47095,7 +47183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -47104,7 +47192,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47118,7 +47206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -47127,7 +47215,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47141,7 +47229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -47150,7 +47238,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47164,7 +47252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -47173,7 +47261,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47187,7 +47275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -47196,7 +47284,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47210,7 +47298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 560,
+            "handler_line": 561,
             "kind": "try",
             "line": 10
           }
@@ -47219,7 +47307,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49074,7 +49162,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 175,
+            "line": 182,
             "type_checking": false
           },
           {
@@ -49082,14 +49170,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 176
+            "line": 183
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 177,
+        "line": 184,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -51046,14 +51134,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1606
+            "line": 1608
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1607,
+        "line": 1609,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51065,14 +51153,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1636
+            "line": 1631
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1637,
+        "line": 1632,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51084,14 +51172,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1644
+            "line": 1639
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1645,
+        "line": 1640,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51869,7 +51957,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 175,
+            "line": 182,
             "type_checking": false
           },
           {
@@ -51877,14 +51965,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 176
+            "line": 183
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 177,
+        "line": 184,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -52466,14 +52554,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1606
+            "line": 1608
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1607,
+        "line": 1609,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52485,14 +52573,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1636
+            "line": 1631
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1637,
+        "line": 1632,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52504,14 +52592,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1644
+            "line": 1639
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1645,
+        "line": 1640,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53972,7 +54060,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1111,
+        "line": 1113,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53981,7 +54069,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2263,
+        "line": 2258,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53990,7 +54078,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2266,
+        "line": 2261,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -53999,7 +54087,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2269,
+        "line": 2264,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54008,7 +54096,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2272,
+        "line": 2267,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54017,7 +54105,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2275,
+        "line": 2270,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54026,7 +54114,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2278,
+        "line": 2273,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54035,7 +54123,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2281,
+        "line": 2276,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54044,7 +54132,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2284,
+        "line": 2279,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54053,7 +54141,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2287,
+        "line": 2282,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54062,7 +54150,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2290,
+        "line": 2285,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54071,7 +54159,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2293,
+        "line": 2288,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54080,7 +54168,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2296,
+        "line": 2291,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54089,7 +54177,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2299,
+        "line": 2294,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54098,7 +54186,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2302,
+        "line": 2297,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54107,7 +54195,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2305,
+        "line": 2300,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54116,7 +54204,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2308,
+        "line": 2303,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54125,7 +54213,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2312,
+        "line": 2307,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54134,7 +54222,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2315,
+        "line": 2310,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54143,7 +54231,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2319,
+        "line": 2314,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54152,7 +54240,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2322,
+        "line": 2317,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54161,7 +54249,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2326,
+        "line": 2321,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54170,7 +54258,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2329,
+        "line": 2324,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54179,7 +54267,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2332,
+        "line": 2327,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54188,7 +54276,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2335,
+        "line": 2330,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54197,7 +54285,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2338,
+        "line": 2333,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54206,7 +54294,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2341,
+        "line": 2336,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54215,7 +54303,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2348,
+        "line": 2343,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54224,7 +54312,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2354,
+        "line": 2349,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54233,7 +54321,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2359,
+        "line": 2354,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54242,7 +54330,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2363,
+        "line": 2358,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54756,13 +54844,13 @@
       },
       {
         "kind": "dict",
-        "line": 1173,
+        "line": 1175,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1162,
+        "line": 1164,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "f4ab6eb094fcdad900f535f79805f912ec67ffaa",
+    "base_commit": "82247d9b31cd477a3649c22c994fafe25c1fbd40",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -47,7 +47,8 @@
       "B-11c14",
       "B-11c15",
       "B-11c16",
-      "B-11c17"
+      "B-11c17",
+      "B-11c18"
     ]
   },
   "enums": {
@@ -82,11 +83,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 289,
+    "nodes_canonical_bindings": 290,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 19,
+    "root_residual_functions": 18,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -226,6 +227,7 @@
       "easyuse_anima.aio.resources"
     ],
     "ANIMA_DEFAULT_CLIP_CANDIDATES": [
+      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES": [
@@ -344,6 +346,9 @@
       "easyuse_anima.prompt.fields"
     ],
     "_adapter_comfy_diffusion_model_names": [
+      "easyuse_anima.aio.resources"
+    ],
+    "_adapter_comfy_text_encoder_names": [
       "easyuse_anima.aio.resources"
     ],
     "_advanced_artist_field_prompt": [
@@ -2264,6 +2269,7 @@
       "symbols": {
         "_bind_aio_resource_runtime": "_bind_aio_resource_runtime",
         "_comfy_diffusion_model_names": "_comfy_diffusion_model_names",
+        "_comfy_text_encoder_names": "_comfy_text_encoder_names",
         "_load_aio_resources_from_input_context": "_load_aio_resources_from_input_context",
         "_load_aio_sam3_context": "_load_aio_sam3_context",
         "_load_checkpoint_with_comfy": "_load_checkpoint_with_comfy",
@@ -4133,7 +4139,6 @@
       "symbols": {
         "_comfy_clip_loader_types": "_comfy_clip_loader_types",
         "_comfy_max_resolution": "_comfy_max_resolution",
-        "_comfy_text_encoder_names": "_comfy_text_encoder_names",
         "_comfy_vae_names": "_comfy_vae_names",
         "_consume_reserved_wildcard_next_seed": "_consume_reserved_wildcard_next_seed",
         "_encode_with_comfy_clip": "_encode_with_comfy_clip",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1378,6 +1378,66 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
             ]
             self._assert_contract(package_nodes, package_resources)
 
+    def _assert_text_encoder_contract(self, root_module, canonical_module):
+        self.assertIs(
+            root_module._comfy_text_encoder_names,
+            canonical_module._comfy_text_encoder_names,
+        )
+
+        candidates = ("preferred-clip.safetensors", "fallback-clip.safetensors")
+        returned = ["runtime-clip.safetensors"]
+        events = []
+
+        def folder_names(_folder, _fallback):
+            return ["runtime-clip.safetensors"]
+
+        def adapter(candidate_values, folder_lookup):
+            events.append(("adapter_call", candidate_values, folder_lookup))
+            return returned
+
+        def resolver(name):
+            events.append(name)
+            return getattr(root_module, name)
+
+        with (
+            patch.object(root_module, "ANIMA_DEFAULT_CLIP_CANDIDATES", candidates),
+            patch.object(
+                root_module,
+                "_adapter_comfy_text_encoder_names",
+                adapter,
+            ),
+            patch.object(root_module, "_folder_path_names", folder_names),
+        ):
+            canonical_module._bind_aio_resource_runtime(resolve_helper=resolver)
+            try:
+                result = canonical_module._comfy_text_encoder_names()
+            finally:
+                canonical_module._bind_aio_resource_runtime(
+                    resolve_helper=lambda name: getattr(root_module, name)
+                )
+
+        self.assertIs(result, returned)
+        self.assertEqual(
+            events,
+            [
+                "_adapter_comfy_text_encoder_names",
+                "ANIMA_DEFAULT_CLIP_CANDIDATES",
+                "_folder_path_names",
+                ("adapter_call", candidates, folder_names),
+            ],
+        )
+
+    def test_text_encoder_root_alias_and_call_time_dependencies(self):
+        self._assert_text_encoder_contract(nodes, aio_resources)
+
+    def test_text_encoder_package_alias_and_call_time_dependencies(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_resources = sys.modules[
+                f"{package_name}.easyuse_anima.aio.resources"
+            ]
+            self._assert_text_encoder_contract(package_nodes, package_resources)
+
 
 class AioSeedNormalizationMoveContractTests(unittest.TestCase):
     CONSTANT_NAMES = (

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "71771f6ae5d0047243c78b5acc656d6db41c27ed")
-        # Issue #184 B-11c17 moves only the diffusion-model name wrapper to
+        self.assertEqual(report["git_blob_sha1"], "7154f6a98467511193e1dafaf6832882be3c23ce")
+        # Issue #184 B-11c18 moves only the text-encoder name wrapper to
         # the canonical AiO resource owner.
-        self.assertEqual(report["top_level"]["function_count"], 19)
+        self.assertEqual(report["top_level"]["function_count"], 18)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_367)
+        self.assertEqual(report["line_count"], 2_362)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "f4ab6eb094fcdad900f535f79805f912ec67ffaa"
+BASE_COMMIT = "82247d9b31cd477a3649c22c994fafe25c1fbd40"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1320,6 +1320,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c15",
                 "B-11c16",
                 "B-11c17",
+                "B-11c18",
             ],
         },
         "enums": {
@@ -1332,11 +1333,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 289,
+            "nodes_canonical_bindings": 290,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 19,
+            "root_residual_functions": 18,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c18 단일 Move로 root `_comfy_text_encoder_names` wrapper만 기존 canonical owner `easyuse_anima.aio.resources`로 이동합니다.
- root `nodes.py`에는 relative/flat direct identity alias를 유지하고 기존 resource binder로 세 dependency를 사용 시점에 resolve합니다.

## 작업 전 inventory

### Symbol / caller

- `_comfy_text_encoder_names`
  - 현재 surface: `nodes.py` private root definition
  - production consumer: `easyuse_anima.nodes.aio_nodes.EasyUseAnimaInput.INPUT_TYPES`가 매 호출 `_runtime_helper("_comfy_text_encoder_names")()`로 root seam 조회
  - direct root production caller: 없음
  - direct root behavior test: `tests/test_comfy_adapters.py::ComfyRootCompatibilityTests.test_feature_specific_root_wrappers_inject_existing_constants_and_aliases`
- `_adapter_comfy_text_encoder_names`
  - `easyuse_anima.infrastructure.comfy.resources._comfy_text_encoder_names`의 별도 direct alias
  - 후보 tuple과 folder lookup을 받는 domain-neutral 2-argument adapter이며 이동 대상 wrapper와 identity/signature가 다름
  - 이번 PR에서는 이동·변경하지 않습니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical wrapper identity를 유지합니다.
- 기존 `_bind_aio_resource_runtime` 하나를 재사용합니다. 새 binder/global/module은 추가하지 않습니다.
- 사용 시점 root seam: `ANIMA_DEFAULT_CLIP_CANDIDATES`, `_adapter_comfy_text_encoder_names`, `_folder_path_names`.
- mutable state, 직접 I/O, optional import는 없고 adapter 반환값·후보 순서·list 정책을 그대로 보존합니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/resources.py`, `nodes.py`
- contract/analyzer: `tests/test_node_contracts.py`, `tests/test_python_compatibility_surface.py`, `tests/test_nodes_module_analyzer.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 예상 계약 delta

- canonical bindings: `289 → 290`
- root/top-level residual functions: `19 → 18`
- runtime binders: `30` 유지
- runtime resolver names: `273 → 274` (`_adapter_comfy_text_encoder_names` 신규)
- shipped/runtime-closure modules: `83` 유지
- globals 26, preamble imports 6: 변화 없음
- `nodes.py` line count: `2367 → 2362`

## 금지 경계

- `_comfy_vae_names`, `_comfy_clip_loader_types` 동시 이동 금지
- infrastructure adapter signature/default/folder key `text_encoders`/fallback 순서·type·copy 정책 변경 금지
- `ANIMA_DEFAULT_CLIP_CANDIDATES`, `_folder_path_names` 이동 금지
- eager `folder_paths`/Comfy import, INPUT_TYPES/default/schema/workflow 변경 금지
- 다른 residual, Contract, Behavior 변경 결합 금지

## 검증

- focused identity/replacement/dependency-order/root behavior/INPUT_TYPES/package/analyzer/import-boundary: 11 tests 통과
- canonical `easyuse_anima/aio/resources.py` Ruff: 통과
- 독립 read-only diff review: P1-P3 발견사항 없음
- exact head `c988706`에서 `tools/check_project.ps1 -Profile full`: 통과
  - Python unittest: 914 tests 통과
  - frontend: 114 JavaScript files 통과, TypeScript 6.0.3
  - Pyright baseline ratchet 및 import-boundary gate 통과
  - 전체 Ruff 111건은 G-01 report-only 기준선입니다. 이번 Move로 root adapter alias가 문자열 resolver 전용이 되며 예상 F401 1건이 추가됐고, canonical 변경 모듈은 Ruff clean입니다.
- Live ComfyUI/browser smoke: private resource-name Move 범위에서는 수행하지 않음

## 상태

- Ready for review
- exact-head full 및 독립 diff review 완료
