### PR TITLE
refactor: move VAE name wrapper

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `82247d9b31cd477a3649c22c994fafe25c1fbd40`
+- Integrated `dev` snapshot commit: `3d7e5d21561d9f4501d2b454df4fe8a6ef4cdd3f`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c17 / `82247d9`; B-11c18 text-encoder name wrapper Move in PR #312 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c18 / `3d7e5d2`; B-11c19 VAE name wrapper Move in PR #313 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,9 +42,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,367
-  lines after B-11c17.
-- The mechanical extraction has removed 10,296
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,362
+  lines after B-11c18.
+- The mechanical extraction has removed 10,301
   lines, approximately 81.3% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
@@ -77,8 +77,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   Detailer enabled-target predicate in PR #308 / `5a86162`. B-11c15 moved only
   final-fit size planning in PR #309 / `05beee1`. B-11c16 moved only final-fit
   application in PR #310 / `f4ab6eb`. B-11c17 moved only the diffusion-model
-  name wrapper in PR #311 / `82247d9`. B-11c18 moves only the text-encoder name
-  wrapper in PR #312.
+  name wrapper in PR #311 / `82247d9`. B-11c18 moved only the text-encoder name
+  wrapper in PR #312 / `3d7e5d2`. B-11c19 moves only the VAE name wrapper in PR
+  #313.
 
 ### Current quality baseline
 
@@ -320,7 +321,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 text-encoder name wrapper Move PR #312 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 VAE name wrapper Move PR #313 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -912,6 +913,10 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
   - B-11c18 moves only `_comfy_text_encoder_names` to the existing AiO resource
     owner in PR #312. The default-candidate tuple, folder lookup, and domain-
     neutral adapter remain call-time root seams; the other resource-name
+    wrappers remain separate.
+  - B-11c19 moves only `_comfy_vae_names` to the existing AiO resource owner in
+    PR #313. The default-candidate tuple, node-class finder, folder lookup, and
+    domain-neutral adapter remain call-time root seams; the other resource-name
     wrappers remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,15 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `82247d9b31cd477a3649c22c994fafe25c1fbd40`
+  `3d7e5d21561d9f4501d2b454df4fe8a6ef4cdd3f`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c17 are integrated through PR #311. B-11c is
+- Current state: B-11a through B-11c18 are integrated through PR #312. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c18 text-encoder name wrapper Move is tracked by PR
-  #312.
+  the final root shim; B-11c19 VAE name wrapper Move is tracked by PR #313.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -76,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 290 in B-11c18
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 291 in B-11c19
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -85,10 +84,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 18 functions, 0 classes, and 26 assigned
-  globals in B-11c18 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 17 functions, 0 classes, and 26 assigned
+  globals in B-11c19 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 274, including
+- root names reached by those canonical runtime resolvers: 275, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -434,6 +433,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - PR #312 does not move or change the infrastructure adapter, constants, folder
   lookup, other resource-name wrappers, INPUT_TYPES, schema, defaults, or
   workflow behavior.
+
+### B-11c19 VAE name wrapper alias
+
+- Canonical owner: `easyuse_anima.aio.resources` for `_comfy_vae_names`.
+- The private root wrapper remains a transitional direct alias in relative
+  package and flat import modes. `EasyUseAnimaInput.INPUT_TYPES` continues to
+  resolve that root name at call time.
+- The existing resource binder resolves `_adapter_comfy_vae_names`,
+  `ANIMA_DEFAULT_VAE_CANDIDATES`, `_find_comfy_node_class`, and
+  `_folder_path_names` at use time. VAELoader-first discovery, exception
+  fallback, candidate order/copy policy, folder key, and adapter result are
+  unchanged.
+- PR #313 does not move or change the infrastructure adapter, constants,
+  node-class finder, folder lookup, other resource-name wrappers, INPUT_TYPES,
+  schema, defaults, or workflow behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/resources.py
+++ b/easyuse_anima/aio/resources.py
@@ -72,6 +72,14 @@ def _comfy_text_encoder_names() -> list[str]:
     )
 
 
+def _comfy_vae_names() -> list[str]:
+    return _runtime_helper("_adapter_comfy_vae_names")(
+        _runtime_helper("ANIMA_DEFAULT_VAE_CANDIDATES"),
+        _runtime_helper("_find_comfy_node_class"),
+        _runtime_helper("_folder_path_names"),
+    )
+
+
 def _preferred_name_default(names: list[str], candidates: tuple[str, ...]) -> str:
     if not names:
         return candidates[0] if candidates else ""

--- a/nodes.py
+++ b/nodes.py
@@ -117,6 +117,7 @@ try:
         _bind_aio_resource_runtime as _bind_aio_resource_runtime,
         _comfy_diffusion_model_names as _comfy_diffusion_model_names,
         _comfy_text_encoder_names as _comfy_text_encoder_names,
+        _comfy_vae_names as _comfy_vae_names,
         _load_aio_resources_from_input_context as _load_aio_resources_from_input_context,
         _load_aio_sam3_context as _load_aio_sam3_context,
         _load_checkpoint_with_comfy as _load_checkpoint_with_comfy,
@@ -668,6 +669,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _bind_aio_resource_runtime as _bind_aio_resource_runtime,
         _comfy_diffusion_model_names as _comfy_diffusion_model_names,
         _comfy_text_encoder_names as _comfy_text_encoder_names,
+        _comfy_vae_names as _comfy_vae_names,
         _load_aio_resources_from_input_context as _load_aio_resources_from_input_context,
         _load_aio_sam3_context as _load_aio_sam3_context,
         _load_checkpoint_with_comfy as _load_checkpoint_with_comfy,
@@ -1610,14 +1612,6 @@ def _comfy_max_resolution() -> int:
     except Exception:
         comfy_nodes = None
     return _adapter_comfy_max_resolution(comfy_nodes)
-
-
-def _comfy_vae_names() -> list[str]:
-    return _adapter_comfy_vae_names(
-        ANIMA_DEFAULT_VAE_CANDIDATES,
-        _find_comfy_node_class,
-        _folder_path_names,
-    )
 
 
 def _comfy_clip_loader_types() -> list[str]:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6783,7 +6783,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 182,
+            "line": 190,
             "type_checking": false
           },
           {
@@ -6791,7 +6791,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 183
+            "line": 191
           }
         ],
         "classification": "external",
@@ -6799,7 +6799,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 184,
+        "line": 192,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -16996,6 +16996,37 @@
         "target": "easyuse_anima/aio/resources.py"
       },
       {
+        "alias": "_comfy_vae_names",
+        "bound_name": "_comfy_vae_names",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_comfy_vae_names",
+          "target": "easyuse_anima/aio/resources.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
+        "kind": "static_from",
+        "line": 116,
+        "name": "_comfy_vae_names",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.resources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
         "alias": "_load_aio_resources_from_input_context",
         "bound_name": "_load_aio_resources_from_input_context",
         "branch_context": [
@@ -17358,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 132,
+        "line": 133,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 132,
+        "line": 133,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 132,
+        "line": 133,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 144,
+        "line": 145,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 165,
+        "line": 166,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 183,
+        "line": 184,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 219,
+        "line": 220,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 247,
+        "line": 248,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 247,
+        "line": 248,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 247,
+        "line": 248,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 247,
+        "line": 248,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 247,
+        "line": 248,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 247,
+        "line": 248,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 247,
+        "line": 248,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 247,
+        "line": 248,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 247,
+        "line": 248,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 263,
+        "line": 264,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 343,
+        "line": 344,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 343,
+        "line": 344,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 343,
+        "line": 344,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 343,
+        "line": 344,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 349,
+        "line": 350,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 349,
+        "line": 350,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 349,
+        "line": 350,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 354,
+        "line": 355,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 354,
+        "line": 355,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 354,
+        "line": 355,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 380,
+        "line": 381,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 380,
+        "line": 381,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 380,
+        "line": 381,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 380,
+        "line": 381,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 393,
+        "line": 394,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 393,
+        "line": 394,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 412,
+        "line": 413,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 412,
+        "line": 413,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 412,
+        "line": 413,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 412,
+        "line": 413,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 418,
+        "line": 419,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 418,
+        "line": 419,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 418,
+        "line": 419,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 418,
+        "line": 419,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 418,
+        "line": 419,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 426,
+        "line": 427,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 426,
+        "line": 427,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 430,
+        "line": 431,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 434,
+        "line": 435,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 434,
+        "line": 435,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 434,
+        "line": 435,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 446,
+        "line": 447,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 446,
+        "line": 447,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 446,
+        "line": 447,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 451,
+        "line": 452,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 451,
+        "line": 452,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 451,
+        "line": 452,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 469,
+        "line": 470,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 492,
+        "line": 493,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 492,
+        "line": 493,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 496,
+        "line": 497,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 496,
+        "line": 497,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 518,
+        "line": 519,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 518,
+        "line": 519,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 518,
+        "line": 519,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 518,
+        "line": 519,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 518,
+        "line": 519,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 518,
+        "line": 519,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 518,
+        "line": 519,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 518,
+        "line": 519,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 528,
+        "line": 529,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 528,
+        "line": 529,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24116,7 +24147,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24147,7 +24178,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24178,7 +24209,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24197,7 +24228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24212,7 +24243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24231,7 +24262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24246,7 +24277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24265,7 +24296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24280,7 +24311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24299,7 +24330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24314,7 +24345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24333,7 +24364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24348,7 +24379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24367,7 +24398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24382,7 +24413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24401,7 +24432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24416,7 +24447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24435,7 +24466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24450,7 +24481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24469,7 +24500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24484,7 +24515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24503,7 +24534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24518,7 +24549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24537,7 +24568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24552,7 +24583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24571,7 +24602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24586,7 +24617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24605,7 +24636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24620,7 +24651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24639,7 +24670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24654,7 +24685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24673,7 +24704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24688,7 +24719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24707,7 +24738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24722,7 +24753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24741,7 +24772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24756,7 +24787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24775,7 +24806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24790,7 +24821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24809,7 +24840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24824,7 +24855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24843,7 +24874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24858,7 +24889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24877,7 +24908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24892,7 +24923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24911,7 +24942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24926,7 +24957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24945,7 +24976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24960,7 +24991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24979,7 +25010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -24994,7 +25025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25013,7 +25044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25028,7 +25059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25047,7 +25078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25062,7 +25093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25081,7 +25112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25096,7 +25127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25115,7 +25146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25130,7 +25161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25149,7 +25180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25164,7 +25195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25183,7 +25214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25198,7 +25229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25217,7 +25248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25232,7 +25263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 603,
+        "line": 604,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25251,7 +25282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25266,7 +25297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 603,
+        "line": 604,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25285,7 +25316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25300,7 +25331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 603,
+        "line": 604,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25319,7 +25350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25334,7 +25365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 608,
+        "line": 609,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25353,7 +25384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25368,7 +25399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 608,
+        "line": 609,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25387,7 +25418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25402,7 +25433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 608,
+        "line": 609,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25421,7 +25452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25436,7 +25467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 608,
+        "line": 609,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25455,7 +25486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25470,7 +25501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25489,7 +25520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25504,7 +25535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25523,7 +25554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25538,7 +25569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25557,7 +25588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25572,7 +25603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25591,7 +25622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25606,7 +25637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25625,7 +25656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25640,7 +25671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25659,7 +25690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25674,7 +25705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25693,7 +25724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25708,7 +25739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25727,7 +25758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25742,7 +25773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25761,7 +25792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25776,7 +25807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25795,7 +25826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25810,7 +25841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25829,7 +25860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25844,7 +25875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25863,7 +25894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25878,7 +25909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25897,7 +25928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25912,7 +25943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25931,7 +25962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25946,7 +25977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25965,7 +25996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -25980,7 +26011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25999,7 +26030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26014,7 +26045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26033,7 +26064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26048,7 +26079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26067,7 +26098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26082,7 +26113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26101,7 +26132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26116,7 +26147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26135,7 +26166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26150,7 +26181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26169,7 +26200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26184,7 +26215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26203,7 +26234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26218,7 +26249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26237,7 +26268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26252,7 +26283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26271,7 +26302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26286,7 +26317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26305,7 +26336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26320,7 +26351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26339,7 +26370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26354,7 +26385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26373,7 +26404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26388,7 +26419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26407,7 +26438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26422,7 +26453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26441,7 +26472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26456,7 +26487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26475,7 +26506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26490,7 +26521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26509,7 +26540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26524,7 +26555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26543,7 +26574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26558,7 +26589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26577,7 +26608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26592,7 +26623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26611,7 +26642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26626,7 +26657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26645,7 +26676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26660,7 +26691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26679,7 +26710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26694,7 +26725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26713,7 +26744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26728,7 +26759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26747,7 +26778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26762,7 +26793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26781,7 +26812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26796,7 +26827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26815,7 +26846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26830,7 +26861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26849,7 +26880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26864,7 +26895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26883,7 +26914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26898,7 +26929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26917,7 +26948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26932,7 +26963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26951,7 +26982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -26966,7 +26997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26985,7 +27016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27000,7 +27031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27019,7 +27050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27034,7 +27065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27053,7 +27084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27068,8 +27099,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_comfy_text_encoder_names",
+        "optional": false,
+        "requested": "easyuse_anima.aio.resources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": "_comfy_vae_names",
+        "bound_name": "_comfy_vae_names",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 562,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_comfy_vae_names",
+          "target": "easyuse_anima/aio/resources.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
+        "kind": "static_from",
+        "line": 668,
+        "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
         "role": "compatibility_fallback",
@@ -27087,7 +27152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27102,7 +27167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27121,7 +27186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27136,7 +27201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27155,7 +27220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27170,7 +27235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27189,7 +27254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27204,7 +27269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27223,7 +27288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27238,7 +27303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27257,7 +27322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27272,7 +27337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27291,7 +27356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27306,7 +27371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27325,7 +27390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27340,7 +27405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27359,7 +27424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27374,7 +27439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27393,7 +27458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27408,7 +27473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27427,7 +27492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27442,7 +27507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27461,7 +27526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27476,7 +27541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27495,7 +27560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27510,7 +27575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27529,7 +27594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27544,7 +27609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27563,7 +27628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27578,7 +27643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 688,
+        "line": 690,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27597,7 +27662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27612,7 +27677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 688,
+        "line": 690,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27631,7 +27696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27646,7 +27711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 688,
+        "line": 690,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27665,7 +27730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27680,7 +27745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 688,
+        "line": 690,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27699,7 +27764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27714,7 +27779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 688,
+        "line": 690,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27733,7 +27798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27748,7 +27813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -27767,7 +27832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27782,7 +27847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27801,7 +27866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27816,7 +27881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27835,7 +27900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27850,7 +27915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27869,7 +27934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27884,7 +27949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27903,7 +27968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27918,7 +27983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27937,7 +28002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27952,7 +28017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -27971,7 +28036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -27986,7 +28051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28005,7 +28070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28020,7 +28085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28039,7 +28104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28054,7 +28119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28073,7 +28138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28088,7 +28153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28107,7 +28172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28122,7 +28187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28141,7 +28206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28156,7 +28221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28175,7 +28240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28190,7 +28255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28209,7 +28274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28224,7 +28289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28243,7 +28308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28258,7 +28323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28277,7 +28342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28292,7 +28357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28311,7 +28376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28326,7 +28391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28345,7 +28410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28360,7 +28425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28379,7 +28444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28394,7 +28459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28413,7 +28478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28428,7 +28493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28447,7 +28512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28462,7 +28527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28481,7 +28546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28496,7 +28561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28515,7 +28580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28530,7 +28595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28549,7 +28614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28564,7 +28629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28583,7 +28648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28598,7 +28663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28617,7 +28682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28632,7 +28697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28651,7 +28716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28666,7 +28731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28685,7 +28750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28700,7 +28765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28719,7 +28784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28734,7 +28799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28753,7 +28818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28768,7 +28833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28787,7 +28852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28802,7 +28867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28821,7 +28886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28836,7 +28901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28855,7 +28920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28870,7 +28935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28889,7 +28954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28904,7 +28969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28923,7 +28988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28938,7 +29003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28957,7 +29022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -28972,7 +29037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28991,7 +29056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29006,7 +29071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29025,7 +29090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29040,7 +29105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29059,7 +29124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29074,7 +29139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29093,7 +29158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29108,7 +29173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29127,7 +29192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29142,7 +29207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29161,7 +29226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29176,7 +29241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29195,7 +29260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29210,7 +29275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29229,7 +29294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29244,7 +29309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29263,7 +29328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29278,7 +29343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29297,7 +29362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29312,7 +29377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29331,7 +29396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29346,7 +29411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29365,7 +29430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29380,7 +29445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29399,7 +29464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29414,7 +29479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29433,7 +29498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29448,7 +29513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29467,7 +29532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29482,7 +29547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29501,7 +29566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29516,7 +29581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29535,7 +29600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29550,7 +29615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29569,7 +29634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29584,7 +29649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29603,7 +29668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29618,7 +29683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29637,7 +29702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29652,7 +29717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29671,7 +29736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29686,7 +29751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29705,7 +29770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29720,7 +29785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29739,7 +29804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29754,7 +29819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29773,7 +29838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29788,7 +29853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29807,7 +29872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29822,7 +29887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29841,7 +29906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29856,7 +29921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29875,7 +29940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29890,7 +29955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29909,7 +29974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29924,7 +29989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29943,7 +30008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29958,7 +30023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29977,7 +30042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -29992,7 +30057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30011,7 +30076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30026,7 +30091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30045,7 +30110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30060,7 +30125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30079,7 +30144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30094,7 +30159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30113,7 +30178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30128,7 +30193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30147,7 +30212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30162,7 +30227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30181,7 +30246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30196,7 +30261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30215,7 +30280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30230,7 +30295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30249,7 +30314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30264,7 +30329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30283,7 +30348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30298,7 +30363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30317,7 +30382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30332,7 +30397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30351,7 +30416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30366,7 +30431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30385,7 +30450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30400,7 +30465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30419,7 +30484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30434,7 +30499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30453,7 +30518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30468,7 +30533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30487,7 +30552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30502,7 +30567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30521,7 +30586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30536,7 +30601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30555,7 +30620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30570,7 +30635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30589,7 +30654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30604,7 +30669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30623,7 +30688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30638,7 +30703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30657,7 +30722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30672,7 +30737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30691,7 +30756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30706,7 +30771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30725,7 +30790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30740,7 +30805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30759,7 +30824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30774,7 +30839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30793,7 +30858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30808,7 +30873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30827,7 +30892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30842,7 +30907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30861,7 +30926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30876,7 +30941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30895,7 +30960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30910,7 +30975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30929,7 +30994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30944,7 +31009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30963,7 +31028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -30978,7 +31043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30997,7 +31062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31012,7 +31077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31031,7 +31096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31046,7 +31111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31065,7 +31130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31080,7 +31145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31099,7 +31164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31114,7 +31179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31133,7 +31198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31148,7 +31213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31167,7 +31232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31182,7 +31247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31201,7 +31266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31216,7 +31281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31235,7 +31300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31250,7 +31315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31269,7 +31334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31284,7 +31349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31303,7 +31368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31318,7 +31383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31337,7 +31402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31352,7 +31417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31371,7 +31436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31386,7 +31451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31405,7 +31470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31420,7 +31485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31439,7 +31504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31454,7 +31519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31473,7 +31538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31488,7 +31553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31507,7 +31572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31522,7 +31587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31541,7 +31606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31556,7 +31621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31575,7 +31640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31590,7 +31655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31609,7 +31674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31624,7 +31689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31643,7 +31708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31658,7 +31723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31677,7 +31742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31692,7 +31757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 944,
+        "line": 946,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31711,7 +31776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31726,7 +31791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 944,
+        "line": 946,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31745,7 +31810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31760,7 +31825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31779,7 +31844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31794,7 +31859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31813,7 +31878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31828,7 +31893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31847,7 +31912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31862,7 +31927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31881,7 +31946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31896,7 +31961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31915,7 +31980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31930,7 +31995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31949,7 +32014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31964,7 +32029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31983,7 +32048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -31998,7 +32063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32017,7 +32082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32032,7 +32097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32051,7 +32116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32066,7 +32131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32085,7 +32150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32100,7 +32165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32119,7 +32184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32134,7 +32199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32153,7 +32218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32168,7 +32233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32187,7 +32252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32202,7 +32267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32221,7 +32286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32236,7 +32301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32255,7 +32320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32270,7 +32335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32289,7 +32354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32304,7 +32369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32323,7 +32388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32338,7 +32403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32357,7 +32422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32372,7 +32437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32391,7 +32456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32406,7 +32471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32425,7 +32490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32440,7 +32505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32459,7 +32524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32474,7 +32539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32493,7 +32558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32508,7 +32573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32527,7 +32592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32542,7 +32607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32561,7 +32626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32576,7 +32641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32595,7 +32660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32610,7 +32675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32629,7 +32694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32644,7 +32709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32663,7 +32728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32678,7 +32743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32697,7 +32762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32712,7 +32777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32731,7 +32796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32746,7 +32811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32765,7 +32830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32780,7 +32845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32799,7 +32864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32814,7 +32879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32833,7 +32898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32848,7 +32913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32867,7 +32932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32882,7 +32947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32901,7 +32966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32916,7 +32981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32935,7 +33000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32950,7 +33015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -32969,7 +33034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -32984,7 +33049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33003,7 +33068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33018,7 +33083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33037,7 +33102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33052,7 +33117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33071,7 +33136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33086,7 +33151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1045,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33105,7 +33170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33120,7 +33185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1045,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33139,7 +33204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33154,7 +33219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1049,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33173,7 +33238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33188,7 +33253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1049,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33207,7 +33272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33222,7 +33287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33241,7 +33306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33256,7 +33321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33275,7 +33340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33290,7 +33355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33309,7 +33374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33324,7 +33389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33343,7 +33408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33358,7 +33423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33377,7 +33442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33392,7 +33457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33411,7 +33476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33426,7 +33491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33445,7 +33510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33460,7 +33525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33479,7 +33544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33494,7 +33559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33513,7 +33578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33528,7 +33593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33547,7 +33612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33562,7 +33627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33581,7 +33646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33596,7 +33661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33615,7 +33680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33630,7 +33695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33649,7 +33714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33664,7 +33729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33683,7 +33748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33698,7 +33763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33717,7 +33782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33732,7 +33797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33751,7 +33816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33766,7 +33831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33785,7 +33850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33800,7 +33865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33819,7 +33884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33834,7 +33899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33853,7 +33918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33868,7 +33933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33887,7 +33952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33902,7 +33967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33921,7 +33986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33936,7 +34001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33955,7 +34020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -33970,7 +34035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33989,7 +34054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34004,7 +34069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34023,7 +34088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34038,7 +34103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34057,7 +34122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34072,7 +34137,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34091,7 +34156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34106,7 +34171,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34125,7 +34190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34140,7 +34205,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1086,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34159,7 +34224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34174,7 +34239,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34193,7 +34258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34208,7 +34273,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34227,7 +34292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34242,7 +34307,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34261,7 +34326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34276,7 +34341,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1092,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34295,7 +34360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34310,7 +34375,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1092,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34329,7 +34394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34344,7 +34409,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34363,7 +34428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34378,7 +34443,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34397,7 +34462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34412,7 +34477,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34431,7 +34496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34446,7 +34511,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34465,7 +34530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34480,7 +34545,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34499,7 +34564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34514,7 +34579,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34533,7 +34598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34548,7 +34613,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34567,7 +34632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34582,7 +34647,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34601,7 +34666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34616,7 +34681,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34635,7 +34700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34650,7 +34715,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34669,7 +34734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34684,7 +34749,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34703,7 +34768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34718,7 +34783,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34737,7 +34802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34752,7 +34817,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34771,7 +34836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34786,7 +34851,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34805,7 +34870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34820,7 +34885,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34839,7 +34904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34854,7 +34919,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34873,7 +34938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34888,7 +34953,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34907,7 +34972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34922,7 +34987,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34941,7 +35006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -34956,7 +35021,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34974,7 +35039,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1608
+            "line": 1610
           }
         ],
         "classification": "external",
@@ -34982,7 +35047,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1609,
+        "line": 1611,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -34999,7 +35064,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1631
+            "line": 1625
           }
         ],
         "classification": "external",
@@ -35007,7 +35072,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1632,
+        "line": 1626,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35024,7 +35089,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1639
+            "line": 1633
           }
         ],
         "classification": "external",
@@ -35032,7 +35097,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1640,
+        "line": 1634,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -38076,13 +38141,13 @@
       },
       {
         "is_package": false,
-        "loc": 265,
+        "loc": 273,
         "module": "easyuse_anima.aio.resources",
-        "normalized_git_blob_sha1": "9b047ddabdb1268bb435ae533158f5cfbb30c971",
+        "normalized_git_blob_sha1": "3ea1a6836f341f3efe5c5874b009bf399714ac53",
         "path": "easyuse_anima/aio/resources.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 15,
+          "function_count": 16,
           "global_count": 3
         }
       },
@@ -38664,13 +38729,13 @@
       },
       {
         "is_package": false,
-        "loc": 2362,
+        "loc": 2356,
         "module": "nodes",
-        "normalized_git_blob_sha1": "7154f6a98467511193e1dafaf6832882be3c23ce",
+        "normalized_git_blob_sha1": "ff00e2019657d732f8eab20990604bb96ffa833d",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 18,
+          "function_count": 17,
           "global_count": 26
         }
       },
@@ -40030,7 +40095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40039,7 +40104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40053,7 +40118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40062,7 +40127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40076,7 +40141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40085,7 +40150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40099,7 +40164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40108,7 +40173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40122,7 +40187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40131,7 +40196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40145,7 +40210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40154,7 +40219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40168,7 +40233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40177,7 +40242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40191,7 +40256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40200,7 +40265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 562,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40214,7 +40279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40223,7 +40288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40237,7 +40302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40246,7 +40311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 573,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40260,7 +40325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40269,7 +40334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40283,7 +40348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40292,7 +40357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40306,7 +40371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40315,7 +40380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40329,7 +40394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40338,7 +40403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40352,7 +40417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40361,7 +40426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40375,7 +40440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40384,7 +40449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40398,7 +40463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40407,7 +40472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40421,7 +40486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40430,7 +40495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40444,7 +40509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40453,7 +40518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40467,7 +40532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40476,7 +40541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40490,7 +40555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40499,7 +40564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40513,7 +40578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40522,7 +40587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40536,7 +40601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40545,7 +40610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40559,7 +40624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40568,7 +40633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40582,7 +40647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40591,7 +40656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40605,7 +40670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40614,7 +40679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40628,7 +40693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40637,7 +40702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40651,7 +40716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40660,7 +40725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40674,7 +40739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40683,7 +40748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40697,7 +40762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40706,7 +40771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40720,7 +40785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40729,7 +40794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 603,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40743,7 +40808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40752,7 +40817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 603,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40766,7 +40831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40775,7 +40840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 603,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40789,7 +40854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40798,7 +40863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 608,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40812,7 +40877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40821,7 +40886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 608,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40835,7 +40900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40844,7 +40909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 608,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40858,7 +40923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40867,7 +40932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 608,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40881,7 +40946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40890,7 +40955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40904,7 +40969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40913,7 +40978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40927,7 +40992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40936,7 +41001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40950,7 +41015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40959,7 +41024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40973,7 +41038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -40982,7 +41047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40996,7 +41061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41005,7 +41070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41019,7 +41084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41028,7 +41093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41042,7 +41107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41051,7 +41116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41065,7 +41130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41074,7 +41139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41088,7 +41153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41097,7 +41162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41111,7 +41176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41120,7 +41185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41134,7 +41199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41143,7 +41208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41157,7 +41222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41166,7 +41231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41180,7 +41245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41189,7 +41254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41203,7 +41268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41212,7 +41277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41226,7 +41291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41235,7 +41300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41249,7 +41314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41258,7 +41323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41272,7 +41337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41281,7 +41346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41295,7 +41360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41304,7 +41369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41318,7 +41383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41327,7 +41392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41341,7 +41406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41350,7 +41415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41364,7 +41429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41373,7 +41438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41387,7 +41452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41396,7 +41461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41410,7 +41475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41419,7 +41484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41433,7 +41498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41442,7 +41507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 629,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41456,7 +41521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41465,7 +41530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41479,7 +41544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41488,7 +41553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41502,7 +41567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41511,7 +41576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41525,7 +41590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41534,7 +41599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41548,7 +41613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41557,7 +41622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41571,7 +41636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41580,7 +41645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41594,7 +41659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41603,7 +41668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41617,7 +41682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41626,7 +41691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41640,7 +41705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41649,7 +41714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41663,7 +41728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41672,7 +41737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 643,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41686,7 +41751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41695,7 +41760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41709,7 +41774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41718,7 +41783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41732,7 +41797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41741,7 +41806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41755,7 +41820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41764,7 +41829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41778,7 +41843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41787,7 +41852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41801,7 +41866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41810,7 +41875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41824,7 +41889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41833,7 +41898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41847,7 +41912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41856,7 +41921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41870,7 +41935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41879,7 +41944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41893,7 +41958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41902,7 +41967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 655,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41916,7 +41981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41925,7 +41990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41939,7 +42004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41948,7 +42013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41962,7 +42027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41971,7 +42036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41985,7 +42050,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
+        "kind": "static_from",
+        "line": 668,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -41994,7 +42082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42008,7 +42096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42017,7 +42105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42031,7 +42119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42040,7 +42128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42054,7 +42142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42063,7 +42151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42077,7 +42165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42086,7 +42174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42100,7 +42188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42109,7 +42197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42123,7 +42211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42132,7 +42220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42146,7 +42234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42155,7 +42243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42169,7 +42257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42178,7 +42266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42192,7 +42280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42201,7 +42289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42215,7 +42303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42224,7 +42312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 667,
+        "line": 668,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42238,7 +42326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42247,7 +42335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42261,7 +42349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42270,7 +42358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42284,7 +42372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42293,7 +42381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42307,7 +42395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42316,7 +42404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 688,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42330,7 +42418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42339,7 +42427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 688,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42353,7 +42441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42362,7 +42450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 688,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42376,7 +42464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42385,7 +42473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 688,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42399,7 +42487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42408,7 +42496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 688,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42422,7 +42510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42431,7 +42519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42445,7 +42533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42454,7 +42542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42468,7 +42556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42477,7 +42565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42491,7 +42579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42500,7 +42588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42514,7 +42602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42523,7 +42611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42537,7 +42625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42546,7 +42634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42560,7 +42648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42569,7 +42657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42583,7 +42671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42592,7 +42680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42606,7 +42694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42615,7 +42703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42629,7 +42717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42638,7 +42726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42652,7 +42740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42661,7 +42749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42675,7 +42763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42684,7 +42772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42698,7 +42786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42707,7 +42795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42721,7 +42809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42730,7 +42818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42744,7 +42832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42753,7 +42841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42767,7 +42855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42776,7 +42864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42790,7 +42878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42799,7 +42887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42813,7 +42901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42822,7 +42910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42836,7 +42924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42845,7 +42933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42859,7 +42947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42868,7 +42956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42882,7 +42970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42891,7 +42979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42905,7 +42993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42914,7 +43002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42928,7 +43016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42937,7 +43025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42951,7 +43039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42960,7 +43048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42974,7 +43062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -42983,7 +43071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42997,7 +43085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43006,7 +43094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43020,7 +43108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43029,7 +43117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43043,7 +43131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43052,7 +43140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43066,7 +43154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43075,7 +43163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43089,7 +43177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43098,7 +43186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43112,7 +43200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43121,7 +43209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43135,7 +43223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43144,7 +43232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43158,7 +43246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43167,7 +43255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43181,7 +43269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43190,7 +43278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43204,7 +43292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43213,7 +43301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43227,7 +43315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43236,7 +43324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43250,7 +43338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43259,7 +43347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43273,7 +43361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43282,7 +43370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43296,7 +43384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43305,7 +43393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43319,7 +43407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43328,7 +43416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43342,7 +43430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43351,7 +43439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43365,7 +43453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43374,7 +43462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43388,7 +43476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43397,7 +43485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43411,7 +43499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43420,7 +43508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43434,7 +43522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43443,7 +43531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43457,7 +43545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43466,7 +43554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43480,7 +43568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43489,7 +43577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43503,7 +43591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43512,7 +43600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43526,7 +43614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43535,7 +43623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43549,7 +43637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43558,7 +43646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43572,7 +43660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43581,7 +43669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43595,7 +43683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43604,7 +43692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43618,7 +43706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43627,7 +43715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43641,7 +43729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43650,7 +43738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43664,7 +43752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43673,7 +43761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43687,7 +43775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43696,7 +43784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43710,7 +43798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43719,7 +43807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43733,7 +43821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43742,7 +43830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 770,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43756,7 +43844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43765,7 +43853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43779,7 +43867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43788,7 +43876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43802,7 +43890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43811,7 +43899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43825,7 +43913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43834,7 +43922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43848,7 +43936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43857,7 +43945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43871,7 +43959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43880,7 +43968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43894,7 +43982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43903,7 +43991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43917,7 +44005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43926,7 +44014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43940,7 +44028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43949,7 +44037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 798,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43963,7 +44051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43972,7 +44060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43986,7 +44074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -43995,7 +44083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44009,7 +44097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44018,7 +44106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44032,7 +44120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44041,7 +44129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44055,7 +44143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44064,7 +44152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44078,7 +44166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44087,7 +44175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44101,7 +44189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44110,7 +44198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44124,7 +44212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44133,7 +44221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44147,7 +44235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44156,7 +44244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44170,7 +44258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44179,7 +44267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44193,7 +44281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44202,7 +44290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44216,7 +44304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44225,7 +44313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44239,7 +44327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44248,7 +44336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44262,7 +44350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44271,7 +44359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44285,7 +44373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44294,7 +44382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44308,7 +44396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44317,7 +44405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44331,7 +44419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44340,7 +44428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44354,7 +44442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44363,7 +44451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44377,7 +44465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44386,7 +44474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44400,7 +44488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44409,7 +44497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44423,7 +44511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44432,7 +44520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44446,7 +44534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44455,7 +44543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44469,7 +44557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44478,7 +44566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44492,7 +44580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44501,7 +44589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44515,7 +44603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44524,7 +44612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44538,7 +44626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44547,7 +44635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44561,7 +44649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44570,7 +44658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44584,7 +44672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44593,7 +44681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44607,7 +44695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44616,7 +44704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 894,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44630,7 +44718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44639,7 +44727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44653,7 +44741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44662,7 +44750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44676,7 +44764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44685,7 +44773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44699,7 +44787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44708,7 +44796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44722,7 +44810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44731,7 +44819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44745,7 +44833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44754,7 +44842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 905,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44768,7 +44856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44777,7 +44865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44791,7 +44879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44800,7 +44888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44814,7 +44902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44823,7 +44911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44837,7 +44925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44846,7 +44934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44860,7 +44948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44869,7 +44957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44883,7 +44971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44892,7 +44980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44906,7 +44994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44915,7 +45003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44929,7 +45017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44938,7 +45026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44952,7 +45040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44961,7 +45049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44975,7 +45063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -44984,7 +45072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 920,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44998,7 +45086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45007,7 +45095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45021,7 +45109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45030,7 +45118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45044,7 +45132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45053,7 +45141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45067,7 +45155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45076,7 +45164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 931,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45090,7 +45178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45099,7 +45187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 944,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45113,7 +45201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45122,7 +45210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 944,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45136,7 +45224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45145,7 +45233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45159,7 +45247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45168,7 +45256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45182,7 +45270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45191,7 +45279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45205,7 +45293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45214,7 +45302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45228,7 +45316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45237,7 +45325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45251,7 +45339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45260,7 +45348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45274,7 +45362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45283,7 +45371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45297,7 +45385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45306,7 +45394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45320,7 +45408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45329,7 +45417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45343,7 +45431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45352,7 +45440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45366,7 +45454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45375,7 +45463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45389,7 +45477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45398,7 +45486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 963,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45412,7 +45500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45421,7 +45509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45435,7 +45523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45444,7 +45532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45458,7 +45546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45467,7 +45555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45481,7 +45569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45490,7 +45578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45504,7 +45592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45513,7 +45601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45527,7 +45615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45536,7 +45624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45550,7 +45638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45559,7 +45647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45573,7 +45661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45582,7 +45670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45596,7 +45684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45605,7 +45693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45619,7 +45707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45628,7 +45716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45642,7 +45730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45651,7 +45739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45665,7 +45753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45674,7 +45762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45688,7 +45776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45697,7 +45785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45711,7 +45799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45720,7 +45808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45734,7 +45822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45743,7 +45831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45757,7 +45845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45766,7 +45854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 990,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45780,7 +45868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45789,7 +45877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45803,7 +45891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45812,7 +45900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45826,7 +45914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45835,7 +45923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45849,7 +45937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45858,7 +45946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45872,7 +45960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45881,7 +45969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45895,7 +45983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45904,7 +45992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45918,7 +46006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45927,7 +46015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45941,7 +46029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45950,7 +46038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45964,7 +46052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45973,7 +46061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45987,7 +46075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -45996,7 +46084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46010,7 +46098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46019,7 +46107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46033,7 +46121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46042,7 +46130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46056,7 +46144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46065,7 +46153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46079,7 +46167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46088,7 +46176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1049,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46102,7 +46190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46111,7 +46199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1049,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46125,7 +46213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46134,7 +46222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46148,7 +46236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46157,7 +46245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46171,7 +46259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46180,7 +46268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46194,7 +46282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46203,7 +46291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46217,7 +46305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46226,7 +46314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46240,7 +46328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46249,7 +46337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46263,7 +46351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46272,7 +46360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46286,7 +46374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46295,7 +46383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46309,7 +46397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46318,7 +46406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46332,7 +46420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46341,7 +46429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46355,7 +46443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46364,7 +46452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46378,7 +46466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46387,7 +46475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46401,7 +46489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46410,7 +46498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46424,7 +46512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46433,7 +46521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46447,7 +46535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46456,7 +46544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1052,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46470,7 +46558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46479,7 +46567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46493,7 +46581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46502,7 +46590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46516,7 +46604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46525,7 +46613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46539,7 +46627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46548,7 +46636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46562,7 +46650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46571,7 +46659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46585,7 +46673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46594,7 +46682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46608,7 +46696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46617,7 +46705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46631,7 +46719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46640,7 +46728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46654,7 +46742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46663,7 +46751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46677,7 +46765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46686,7 +46774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46700,7 +46788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46709,7 +46797,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46723,7 +46811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46732,7 +46820,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46746,7 +46834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46755,7 +46843,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46769,7 +46857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46778,7 +46866,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46792,7 +46880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46801,7 +46889,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46815,7 +46903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46824,7 +46912,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46838,7 +46926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46847,7 +46935,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46861,7 +46949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46870,7 +46958,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46884,7 +46972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46893,7 +46981,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46907,7 +46995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46916,7 +47004,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46930,7 +47018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46939,7 +47027,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46953,7 +47041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46962,7 +47050,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46976,7 +47064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -46985,7 +47073,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46999,7 +47087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47008,7 +47096,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47022,7 +47110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47031,7 +47119,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47045,7 +47133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47054,7 +47142,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47068,7 +47156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47077,7 +47165,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47091,7 +47179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47100,7 +47188,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47114,7 +47202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47123,7 +47211,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47137,7 +47225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47146,7 +47234,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47160,7 +47248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47169,7 +47257,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47183,7 +47271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47192,7 +47280,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47206,7 +47294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47215,7 +47303,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47229,7 +47317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47238,7 +47326,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47252,7 +47340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47261,7 +47349,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47275,7 +47363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47284,7 +47372,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47298,7 +47386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 562,
             "kind": "try",
             "line": 10
           }
@@ -47307,7 +47395,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49162,7 +49250,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 182,
+            "line": 190,
             "type_checking": false
           },
           {
@@ -49170,14 +49258,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 183
+            "line": 191
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 184,
+        "line": 192,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -51134,14 +51222,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1608
+            "line": 1610
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1609,
+        "line": 1611,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51153,14 +51241,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1631
+            "line": 1625
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1632,
+        "line": 1626,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51172,14 +51260,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1639
+            "line": 1633
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1640,
+        "line": 1634,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51957,7 +52045,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 182,
+            "line": 190,
             "type_checking": false
           },
           {
@@ -51965,14 +52053,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 183
+            "line": 191
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 184,
+        "line": 192,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -52554,14 +52642,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1608
+            "line": 1610
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1609,
+        "line": 1611,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52573,14 +52661,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1631
+            "line": 1625
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1632,
+        "line": 1626,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52592,14 +52680,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1639
+            "line": 1633
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1640,
+        "line": 1634,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54060,7 +54148,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1113,
+        "line": 1115,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54069,7 +54157,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2258,
+        "line": 2252,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54078,7 +54166,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2261,
+        "line": 2255,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54087,7 +54175,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2264,
+        "line": 2258,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54096,7 +54184,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2267,
+        "line": 2261,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54105,7 +54193,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2270,
+        "line": 2264,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54114,7 +54202,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2273,
+        "line": 2267,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54123,7 +54211,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2276,
+        "line": 2270,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54132,7 +54220,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2279,
+        "line": 2273,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54141,7 +54229,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2282,
+        "line": 2276,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54150,7 +54238,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2285,
+        "line": 2279,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54159,7 +54247,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2288,
+        "line": 2282,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54168,7 +54256,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2291,
+        "line": 2285,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54177,7 +54265,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2294,
+        "line": 2288,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54186,7 +54274,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2297,
+        "line": 2291,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54195,7 +54283,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2300,
+        "line": 2294,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54204,7 +54292,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2303,
+        "line": 2297,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54213,7 +54301,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2307,
+        "line": 2301,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54222,7 +54310,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2310,
+        "line": 2304,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54231,7 +54319,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2314,
+        "line": 2308,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54240,7 +54328,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2317,
+        "line": 2311,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54249,7 +54337,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2321,
+        "line": 2315,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54258,7 +54346,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2324,
+        "line": 2318,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54267,7 +54355,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2327,
+        "line": 2321,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54276,7 +54364,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2330,
+        "line": 2324,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54285,7 +54373,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2333,
+        "line": 2327,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54294,7 +54382,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2336,
+        "line": 2330,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54303,7 +54391,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2343,
+        "line": 2337,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54312,7 +54400,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2349,
+        "line": 2343,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54321,7 +54409,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2354,
+        "line": 2348,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54330,7 +54418,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2358,
+        "line": 2352,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54844,13 +54932,13 @@
       },
       {
         "kind": "dict",
-        "line": 1175,
+        "line": 1177,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1164,
+        "line": 1166,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "82247d9b31cd477a3649c22c994fafe25c1fbd40",
+    "base_commit": "3d7e5d21561d9f4501d2b454df4fe8a6ef4cdd3f",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -48,7 +48,8 @@
       "B-11c15",
       "B-11c16",
       "B-11c17",
-      "B-11c18"
+      "B-11c18",
+      "B-11c19"
     ]
   },
   "enums": {
@@ -83,11 +84,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 290,
+    "nodes_canonical_bindings": 291,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 18,
+    "root_residual_functions": 17,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -235,6 +236,7 @@
       "easyuse_anima.nodes.aio_nodes"
     ],
     "ANIMA_DEFAULT_VAE_CANDIDATES": [
+      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE": [
@@ -349,6 +351,9 @@
       "easyuse_anima.aio.resources"
     ],
     "_adapter_comfy_text_encoder_names": [
+      "easyuse_anima.aio.resources"
+    ],
+    "_adapter_comfy_vae_names": [
       "easyuse_anima.aio.resources"
     ],
     "_advanced_artist_field_prompt": [
@@ -2270,6 +2275,7 @@
         "_bind_aio_resource_runtime": "_bind_aio_resource_runtime",
         "_comfy_diffusion_model_names": "_comfy_diffusion_model_names",
         "_comfy_text_encoder_names": "_comfy_text_encoder_names",
+        "_comfy_vae_names": "_comfy_vae_names",
         "_load_aio_resources_from_input_context": "_load_aio_resources_from_input_context",
         "_load_aio_sam3_context": "_load_aio_sam3_context",
         "_load_checkpoint_with_comfy": "_load_checkpoint_with_comfy",
@@ -4139,7 +4145,6 @@
       "symbols": {
         "_comfy_clip_loader_types": "_comfy_clip_loader_types",
         "_comfy_max_resolution": "_comfy_max_resolution",
-        "_comfy_vae_names": "_comfy_vae_names",
         "_consume_reserved_wildcard_next_seed": "_consume_reserved_wildcard_next_seed",
         "_encode_with_comfy_clip": "_encode_with_comfy_clip",
         "_find_comfy_node_class": "_find_comfy_node_class",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1438,6 +1438,74 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
             ]
             self._assert_text_encoder_contract(package_nodes, package_resources)
 
+    def _assert_vae_contract(self, root_module, canonical_module):
+        self.assertIs(
+            root_module._comfy_vae_names,
+            canonical_module._comfy_vae_names,
+        )
+
+        candidates = ("preferred.vae", "fallback.vae")
+        returned = ["runtime.vae"]
+        events = []
+
+        def find_node_class(_node_id):
+            return None
+
+        def folder_names(_folder, _fallback):
+            return ["runtime.vae"]
+
+        def adapter(candidate_values, node_finder, folder_lookup):
+            events.append(
+                ("adapter_call", candidate_values, node_finder, folder_lookup)
+            )
+            return returned
+
+        def resolver(name):
+            events.append(name)
+            return getattr(root_module, name)
+
+        with (
+            patch.object(root_module, "ANIMA_DEFAULT_VAE_CANDIDATES", candidates),
+            patch.object(root_module, "_adapter_comfy_vae_names", adapter),
+            patch.object(root_module, "_find_comfy_node_class", find_node_class),
+            patch.object(root_module, "_folder_path_names", folder_names),
+        ):
+            canonical_module._bind_aio_resource_runtime(resolve_helper=resolver)
+            try:
+                result = canonical_module._comfy_vae_names()
+            finally:
+                canonical_module._bind_aio_resource_runtime(
+                    resolve_helper=lambda name: getattr(root_module, name)
+                )
+
+        self.assertIs(result, returned)
+        self.assertEqual(
+            events,
+            [
+                "_adapter_comfy_vae_names",
+                "ANIMA_DEFAULT_VAE_CANDIDATES",
+                "_find_comfy_node_class",
+                "_folder_path_names",
+                (
+                    "adapter_call",
+                    candidates,
+                    find_node_class,
+                    folder_names,
+                ),
+            ],
+        )
+
+    def test_vae_root_alias_and_call_time_dependencies(self):
+        self._assert_vae_contract(nodes, aio_resources)
+
+    def test_vae_package_alias_and_call_time_dependencies(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_resources = sys.modules[
+                f"{package_name}.easyuse_anima.aio.resources"
+            ]
+            self._assert_vae_contract(package_nodes, package_resources)
+
 
 class AioSeedNormalizationMoveContractTests(unittest.TestCase):
     CONSTANT_NAMES = (

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "7154f6a98467511193e1dafaf6832882be3c23ce")
-        # Issue #184 B-11c18 moves only the text-encoder name wrapper to
+        self.assertEqual(report["git_blob_sha1"], "ff00e2019657d732f8eab20990604bb96ffa833d")
+        # Issue #184 B-11c19 moves only the VAE name wrapper to
         # the canonical AiO resource owner.
-        self.assertEqual(report["top_level"]["function_count"], 18)
+        self.assertEqual(report["top_level"]["function_count"], 17)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_362)
+        self.assertEqual(report["line_count"], 2_356)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "82247d9b31cd477a3649c22c994fafe25c1fbd40"
+BASE_COMMIT = "3d7e5d21561d9f4501d2b454df4fe8a6ef4cdd3f"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1321,6 +1321,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c16",
                 "B-11c17",
                 "B-11c18",
+                "B-11c19",
             ],
         },
         "enums": {
@@ -1333,11 +1334,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 290,
+            "nodes_canonical_bindings": 291,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 18,
+            "root_residual_functions": 17,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c19 단일 Move로 root `_comfy_vae_names` wrapper만 기존 canonical owner `easyuse_anima.aio.resources`로 이동합니다.
- root `nodes.py`에는 relative/flat direct identity alias를 유지하고 기존 resource binder로 네 dependency를 사용 시점에 resolve합니다.

## 작업 전 inventory

### Symbol / caller

- `_comfy_vae_names`
  - 현재 surface: `nodes.py` private root definition
  - production consumer: `easyuse_anima.nodes.aio_nodes.EasyUseAnimaInput.INPUT_TYPES`가 매 호출 `_runtime_helper("_comfy_vae_names")()`로 root seam 조회
  - direct root production caller: 없음
  - root/package behavior와 INPUT_TYPES 계약 테스트가 직접 소비
- `_adapter_comfy_vae_names`
  - `easyuse_anima.infrastructure.comfy.resources._comfy_vae_names`의 별도 direct alias
  - 후보 tuple, node-class finder, folder lookup을 받는 domain-neutral 3-argument adapter이며 이동 대상 wrapper와 identity/signature가 다름
  - 이번 PR에서는 이동·변경하지 않습니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical wrapper identity를 유지합니다.
- 기존 `_bind_aio_resource_runtime` 하나를 재사용합니다. 새 binder/global/module은 추가하지 않습니다.
- 사용 시점 root seam과 정확한 resolve 순서:
  1. `_adapter_comfy_vae_names`
  2. `ANIMA_DEFAULT_VAE_CANDIDATES`
  3. `_find_comfy_node_class`
  4. `_folder_path_names`
  5. adapter 호출
- wrapper 자체의 cache, mutation, I/O, mutable global은 없습니다.

### 보존할 adapter 동작

- `find_node_class("VAELoader")`를 먼저 조회합니다.
- loader의 `INPUT_TYPES()["required"]["vae_name"]`에서 non-empty 목록을 얻으면 즉시 반환합니다.
- loader 조회/계약 예외는 기존 broad exception 경계 안에서 folder fallback으로 전환합니다.
- fallback folder key는 정확히 `vae`이며 후보는 `list(candidates)` 복사본입니다.
- 후보 순서, loader 성공 시 folder 미호출, adapter 반환 object identity를 보존합니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/resources.py`, `nodes.py`
- contract/analyzer: `tests/test_node_contracts.py`, `tests/test_python_compatibility_surface.py`, `tests/test_nodes_module_analyzer.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 예상 계약 delta

- base: `dev` / `3d7e5d21561d9f4501d2b454df4fe8a6ef4cdd3f`
- canonical bindings: `290 → 291`
- root/top-level residual functions: `18 → 17`
- runtime binders: `30` 유지
- runtime resolver names: `274 → 275` (`_adapter_comfy_vae_names` 신규)
- shipped/runtime-closure modules: `83` 유지
- globals 26, preamble imports 6: 변화 없음
- `nodes.py` line count: `2362 → 2356`

## 금지 경계

- `_comfy_clip_loader_types`, `_find_comfy_node_class` 동시 이동 금지
- infrastructure adapter signature, VAELoader 탐색, 예외, folder fallback, candidate-copy 동작 변경 금지
- `ANIMA_DEFAULT_VAE_CANDIDATES`, `_folder_path_names` 이동 금지
- adapter/helper 정적 import로 root monkeypatch seam 우회 금지
- `aio_nodes.py`, INPUT_TYPES, schema/default/workflow 변경 금지
- 다른 residual, Contract, Behavior 변경 결합 금지

## 검증

- focused identity/replacement/dependency-order/VAE adapter/INPUT_TYPES/package/analyzer/import-boundary: 14 tests 통과
- canonical `easyuse_anima/aio/resources.py` Ruff: 통과
- 독립 read-only diff review: P1-P3 발견사항 없음
- exact head `5eb9aec`에서 `tools/check_project.ps1 -Profile full`: 통과
  - Python unittest: 916 tests 통과
  - frontend: 114 JavaScript files 통과, TypeScript 6.0.3
  - Pyright baseline ratchet 및 import-boundary gate 통과
  - 전체 Ruff 112건은 G-01 report-only 기준선입니다. 이번 Move로 root adapter alias가 문자열 resolver 전용이 되며 예상 F401 1건이 추가됐고, canonical 변경 모듈은 Ruff clean입니다.
- Live ComfyUI/browser smoke: private resource-name Move 범위에서는 수행하지 않음

## 상태

- Ready for review
- exact-head full 및 독립 diff review 완료
