### PR TITLE
refactor: move CLIP loader type wrapper

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `3d7e5d21561d9f4501d2b454df4fe8a6ef4cdd3f`
+- Integrated `dev` snapshot commit: `de57090f20aefe00663b7630ba87055333ddf107`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c18 / `3d7e5d2`; B-11c19 VAE name wrapper Move in PR #313 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c19 / `de57090`; B-11c20 CLIP loader-type wrapper Move in PR #314 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,362
-  lines after B-11c18.
-- The mechanical extraction has removed 10,301
-  lines, approximately 81.3% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,356
+  lines after B-11c19.
+- The mechanical extraction has removed 10,307
+  lines, approximately 81.4% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -78,8 +78,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   final-fit size planning in PR #309 / `05beee1`. B-11c16 moved only final-fit
   application in PR #310 / `f4ab6eb`. B-11c17 moved only the diffusion-model
   name wrapper in PR #311 / `82247d9`. B-11c18 moved only the text-encoder name
-  wrapper in PR #312 / `3d7e5d2`. B-11c19 moves only the VAE name wrapper in PR
-  #313.
+  wrapper in PR #312 / `3d7e5d2`. B-11c19 moved only the VAE name wrapper in PR
+  #313 / `de57090`. B-11c20 moves only the CLIP loader-type wrapper in PR #314.
 
 ### Current quality baseline
 
@@ -321,7 +321,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 VAE name wrapper Move PR #313 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 CLIP loader-type wrapper Move PR #314 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -918,6 +918,10 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     PR #313. The default-candidate tuple, node-class finder, folder lookup, and
     domain-neutral adapter remain call-time root seams; the other resource-name
     wrappers remain separate.
+  - B-11c20 moves only `_comfy_clip_loader_types` to the existing AiO resource
+    owner in PR #314. The allowed-type tuple, node-class finder, and domain-
+    neutral adapter remain call-time root seams; the other capability wrappers
+    remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,15 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `3d7e5d21561d9f4501d2b454df4fe8a6ef4cdd3f`
+  `de57090f20aefe00663b7630ba87055333ddf107`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c18 are integrated through PR #312. B-11c is
+- Current state: B-11a through B-11c19 are integrated through PR #313. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c19 VAE name wrapper Move is tracked by PR #313.
+  the final root shim; B-11c20 CLIP loader-type wrapper Move is tracked by PR
+  #314.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,7 +76,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 291 in B-11c19
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 292 in B-11c20
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -84,10 +85,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 17 functions, 0 classes, and 26 assigned
-  globals in B-11c19 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 16 functions, 0 classes, and 26 assigned
+  globals in B-11c20 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 275, including
+- root names reached by those canonical runtime resolvers: 277, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -448,6 +449,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - PR #313 does not move or change the infrastructure adapter, constants,
   node-class finder, folder lookup, other resource-name wrappers, INPUT_TYPES,
   schema, defaults, or workflow behavior.
+
+### B-11c20 CLIP loader-type wrapper alias
+
+- Canonical owner: `easyuse_anima.aio.resources` for
+  `_comfy_clip_loader_types`.
+- The private root wrapper remains a transitional direct alias in relative
+  package and flat import modes. `EasyUseAnimaInput.INPUT_TYPES` continues to
+  resolve that root name at call time.
+- The existing resource binder resolves `_adapter_comfy_clip_loader_types`,
+  `ANIMA_CLIP_TYPES`, and `_find_comfy_node_class` at use time. CLIPLoader-first
+  discovery, finder exception propagation, loader-processing exception
+  fallback, allowed-type order/copy policy, and adapter result are unchanged.
+- PR #314 does not move or change the infrastructure adapter, constants,
+  node-class finder, other resource-name wrappers, INPUT_TYPES, schema,
+  defaults, or workflow behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/resources.py
+++ b/easyuse_anima/aio/resources.py
@@ -80,6 +80,13 @@ def _comfy_vae_names() -> list[str]:
     )
 
 
+def _comfy_clip_loader_types() -> list[str]:
+    return _runtime_helper("_adapter_comfy_clip_loader_types")(
+        _runtime_helper("ANIMA_CLIP_TYPES"),
+        _runtime_helper("_find_comfy_node_class"),
+    )
+
+
 def _preferred_name_default(names: list[str], candidates: tuple[str, ...]) -> str:
     if not names:
         return candidates[0] if candidates else ""

--- a/nodes.py
+++ b/nodes.py
@@ -115,6 +115,7 @@ try:
     )
     from .easyuse_anima.aio.resources import (
         _bind_aio_resource_runtime as _bind_aio_resource_runtime,
+        _comfy_clip_loader_types as _comfy_clip_loader_types,
         _comfy_diffusion_model_names as _comfy_diffusion_model_names,
         _comfy_text_encoder_names as _comfy_text_encoder_names,
         _comfy_vae_names as _comfy_vae_names,
@@ -667,6 +668,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     )
     from easyuse_anima.aio.resources import (
         _bind_aio_resource_runtime as _bind_aio_resource_runtime,
+        _comfy_clip_loader_types as _comfy_clip_loader_types,
         _comfy_diffusion_model_names as _comfy_diffusion_model_names,
         _comfy_text_encoder_names as _comfy_text_encoder_names,
         _comfy_vae_names as _comfy_vae_names,
@@ -1612,13 +1614,6 @@ def _comfy_max_resolution() -> int:
     except Exception:
         comfy_nodes = None
     return _adapter_comfy_max_resolution(comfy_nodes)
-
-
-def _comfy_clip_loader_types() -> list[str]:
-    return _adapter_comfy_clip_loader_types(
-        ANIMA_CLIP_TYPES,
-        _find_comfy_node_class,
-    )
 
 
 def _find_comfy_node_class(node_id: str):

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6783,7 +6783,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 190,
+            "line": 197,
             "type_checking": false
           },
           {
@@ -6791,7 +6791,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 191
+            "line": 198
           }
         ],
         "classification": "external",
@@ -6799,7 +6799,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 192,
+        "line": 199,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -16934,6 +16934,37 @@
         "target": "easyuse_anima/aio/resources.py"
       },
       {
+        "alias": "_comfy_clip_loader_types",
+        "bound_name": "_comfy_clip_loader_types",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_comfy_clip_loader_types",
+          "target": "easyuse_anima/aio/resources.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
+        "kind": "static_from",
+        "line": 116,
+        "name": "_comfy_clip_loader_types",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.resources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
         "alias": "_comfy_diffusion_model_names",
         "bound_name": "_comfy_diffusion_model_names",
         "branch_context": [
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 146,
+        "line": 147,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 146,
+        "line": 147,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 146,
+        "line": 147,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 146,
+        "line": 147,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 166,
+        "line": 167,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 166,
+        "line": 167,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 166,
+        "line": 167,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 166,
+        "line": 167,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 166,
+        "line": 167,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 166,
+        "line": 167,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 166,
+        "line": 167,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 184,
+        "line": 185,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 220,
+        "line": 221,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 248,
+        "line": 249,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 248,
+        "line": 249,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 248,
+        "line": 249,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 248,
+        "line": 249,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 248,
+        "line": 249,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 248,
+        "line": 249,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 248,
+        "line": 249,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 248,
+        "line": 249,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 248,
+        "line": 249,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 264,
+        "line": 265,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 344,
+        "line": 345,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 344,
+        "line": 345,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 344,
+        "line": 345,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 344,
+        "line": 345,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 350,
+        "line": 351,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 350,
+        "line": 351,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 350,
+        "line": 351,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 355,
+        "line": 356,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 355,
+        "line": 356,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 355,
+        "line": 356,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 361,
+        "line": 362,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 361,
+        "line": 362,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 361,
+        "line": 362,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 361,
+        "line": 362,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 361,
+        "line": 362,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 361,
+        "line": 362,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 361,
+        "line": 362,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 370,
+        "line": 371,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 370,
+        "line": 371,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 370,
+        "line": 371,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 381,
+        "line": 382,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 381,
+        "line": 382,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 381,
+        "line": 382,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 381,
+        "line": 382,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 413,
+        "line": 414,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 413,
+        "line": 414,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 413,
+        "line": 414,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 413,
+        "line": 414,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 419,
+        "line": 420,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 419,
+        "line": 420,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 419,
+        "line": 420,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 419,
+        "line": 420,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 419,
+        "line": 420,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 427,
+        "line": 428,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 427,
+        "line": 428,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 431,
+        "line": 432,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 435,
+        "line": 436,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 435,
+        "line": 436,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 435,
+        "line": 436,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 452,
+        "line": 453,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 452,
+        "line": 453,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 452,
+        "line": 453,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 470,
+        "line": 471,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 493,
+        "line": 494,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 493,
+        "line": 494,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 497,
+        "line": 498,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 497,
+        "line": 498,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 519,
+        "line": 520,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 519,
+        "line": 520,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 519,
+        "line": 520,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 519,
+        "line": 520,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 519,
+        "line": 520,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 519,
+        "line": 520,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 519,
+        "line": 520,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 519,
+        "line": 520,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 529,
+        "line": 530,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 529,
+        "line": 530,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 535,
+        "line": 536,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 535,
+        "line": 536,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 535,
+        "line": 536,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24116,7 +24147,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24147,7 +24178,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24178,7 +24209,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24209,7 +24240,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24228,7 +24259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24243,7 +24274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24262,7 +24293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24277,7 +24308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24296,7 +24327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24311,7 +24342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24330,7 +24361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24345,7 +24376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24364,7 +24395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24379,7 +24410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24398,7 +24429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24413,7 +24444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24432,7 +24463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24447,7 +24478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24466,7 +24497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24481,7 +24512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24500,7 +24531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24515,7 +24546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24534,7 +24565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24549,7 +24580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24568,7 +24599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24583,7 +24614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24602,7 +24633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24617,7 +24648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24636,7 +24667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24651,7 +24682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24670,7 +24701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24685,7 +24716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24704,7 +24735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24719,7 +24750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24738,7 +24769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24753,7 +24784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24772,7 +24803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24787,7 +24818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24806,7 +24837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24821,7 +24852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24840,7 +24871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24855,7 +24886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24874,7 +24905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24889,7 +24920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24908,7 +24939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24923,7 +24954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24942,7 +24973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24957,7 +24988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24976,7 +25007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -24991,7 +25022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25010,7 +25041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25025,7 +25056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25044,7 +25075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25059,7 +25090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25078,7 +25109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25093,7 +25124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25112,7 +25143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25127,7 +25158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 596,
+        "line": 597,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25146,7 +25177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25161,7 +25192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 599,
+        "line": 600,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25180,7 +25211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25195,7 +25226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 599,
+        "line": 600,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25214,7 +25245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25229,7 +25260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 599,
+        "line": 600,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25248,7 +25279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25263,7 +25294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 604,
+        "line": 605,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25282,7 +25313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25297,7 +25328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 604,
+        "line": 605,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25316,7 +25347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25331,7 +25362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 604,
+        "line": 605,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25350,7 +25381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25365,7 +25396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25384,7 +25415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25399,7 +25430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25418,7 +25449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25433,7 +25464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25452,7 +25483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25467,7 +25498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25486,7 +25517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25501,7 +25532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25520,7 +25551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25535,7 +25566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25554,7 +25585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25569,7 +25600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25588,7 +25619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25603,7 +25634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25622,7 +25653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25637,7 +25668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25656,7 +25687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25671,7 +25702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25690,7 +25721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25705,7 +25736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25724,7 +25755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25739,7 +25770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25758,7 +25789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25773,7 +25804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25792,7 +25823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25807,7 +25838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25826,7 +25857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25841,7 +25872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25860,7 +25891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25875,7 +25906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25894,7 +25925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25909,7 +25940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25928,7 +25959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25943,7 +25974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25962,7 +25993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -25977,7 +26008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25996,7 +26027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26011,7 +26042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26030,7 +26061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26045,7 +26076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26064,7 +26095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26079,7 +26110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26098,7 +26129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26113,7 +26144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26132,7 +26163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26147,7 +26178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26166,7 +26197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26181,7 +26212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26200,7 +26231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26215,7 +26246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26234,7 +26265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26249,7 +26280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26268,7 +26299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26283,7 +26314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26302,7 +26333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26317,7 +26348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26336,7 +26367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26351,7 +26382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26370,7 +26401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26385,7 +26416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26404,7 +26435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26419,7 +26450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26438,7 +26469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26453,7 +26484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26472,7 +26503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26487,7 +26518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26506,7 +26537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26521,7 +26552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26540,7 +26571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26555,7 +26586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26574,7 +26605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26589,7 +26620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26608,7 +26639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26623,7 +26654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26642,7 +26673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26657,7 +26688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26676,7 +26707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26691,7 +26722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26710,7 +26741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26725,7 +26756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26744,7 +26775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26759,7 +26790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26778,7 +26809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26793,7 +26824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26812,7 +26843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26827,7 +26858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26846,7 +26877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26861,7 +26892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26880,7 +26911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26895,7 +26926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26914,7 +26945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26929,7 +26960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26948,7 +26979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26963,7 +26994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26982,7 +27013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -26997,7 +27028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27016,7 +27047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27031,8 +27062,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_bind_aio_resource_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.aio.resources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": "_comfy_clip_loader_types",
+        "bound_name": "_comfy_clip_loader_types",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 563,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_comfy_clip_loader_types",
+          "target": "easyuse_anima/aio/resources.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
+        "kind": "static_from",
+        "line": 669,
+        "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
         "role": "compatibility_fallback",
@@ -27050,7 +27115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27065,7 +27130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27084,7 +27149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27099,7 +27164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27118,7 +27183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27133,7 +27198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27152,7 +27217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27167,7 +27232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27186,7 +27251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27201,7 +27266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27220,7 +27285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27235,7 +27300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27254,7 +27319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27269,7 +27334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27288,7 +27353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27303,7 +27368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27322,7 +27387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27337,7 +27402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27356,7 +27421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27371,7 +27436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27390,7 +27455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27405,7 +27470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27424,7 +27489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27439,7 +27504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27458,7 +27523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27473,7 +27538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27492,7 +27557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27507,7 +27572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27526,7 +27591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27541,7 +27606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 685,
+        "line": 687,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27560,7 +27625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27575,7 +27640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 685,
+        "line": 687,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27594,7 +27659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27609,7 +27674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 685,
+        "line": 687,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27628,7 +27693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27643,7 +27708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27662,7 +27727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27677,7 +27742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27696,7 +27761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27711,7 +27776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27730,7 +27795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27745,7 +27810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27764,7 +27829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27779,7 +27844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27798,7 +27863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27813,7 +27878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -27832,7 +27897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27847,7 +27912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27866,7 +27931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27881,7 +27946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27900,7 +27965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27915,7 +27980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27934,7 +27999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27949,7 +28014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27968,7 +28033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -27983,7 +28048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28002,7 +28067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28017,7 +28082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28036,7 +28101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28051,7 +28116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28070,7 +28135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28085,7 +28150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28104,7 +28169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28119,7 +28184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28138,7 +28203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28153,7 +28218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28172,7 +28237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28187,7 +28252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28206,7 +28271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28221,7 +28286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28240,7 +28305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28255,7 +28320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28274,7 +28339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28289,7 +28354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28308,7 +28373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28323,7 +28388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28342,7 +28407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28357,7 +28422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28376,7 +28441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28391,7 +28456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28410,7 +28475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28425,7 +28490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28444,7 +28509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28459,7 +28524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28478,7 +28543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28493,7 +28558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28512,7 +28577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28527,7 +28592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28546,7 +28611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28561,7 +28626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28580,7 +28645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28595,7 +28660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28614,7 +28679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28629,7 +28694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28648,7 +28713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28663,7 +28728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28682,7 +28747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28697,7 +28762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28716,7 +28781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28731,7 +28796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28750,7 +28815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28765,7 +28830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28784,7 +28849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28799,7 +28864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28818,7 +28883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28833,7 +28898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28852,7 +28917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28867,7 +28932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28886,7 +28951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28901,7 +28966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28920,7 +28985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28935,7 +29000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28954,7 +29019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -28969,7 +29034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28988,7 +29053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29003,7 +29068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29022,7 +29087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29037,7 +29102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29056,7 +29121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29071,7 +29136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29090,7 +29155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29105,7 +29170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29124,7 +29189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29139,7 +29204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29158,7 +29223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29173,7 +29238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29192,7 +29257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29207,7 +29272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29226,7 +29291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29241,7 +29306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29260,7 +29325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29275,7 +29340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29294,7 +29359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29309,7 +29374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29328,7 +29393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29343,7 +29408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29362,7 +29427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29377,7 +29442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29396,7 +29461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29411,7 +29476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29430,7 +29495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29445,7 +29510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29464,7 +29529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29479,7 +29544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29498,7 +29563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29513,7 +29578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29532,7 +29597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29547,7 +29612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29566,7 +29631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29581,7 +29646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29600,7 +29665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29615,7 +29680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29634,7 +29699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29649,7 +29714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29668,7 +29733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29683,7 +29748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29702,7 +29767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29717,7 +29782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29736,7 +29801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29751,7 +29816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29770,7 +29835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29785,7 +29850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29804,7 +29869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29819,7 +29884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29838,7 +29903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29853,7 +29918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29872,7 +29937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29887,7 +29952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29906,7 +29971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29921,7 +29986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29940,7 +30005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29955,7 +30020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29974,7 +30039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -29989,7 +30054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30008,7 +30073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30023,7 +30088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30042,7 +30107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30057,7 +30122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30076,7 +30141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30091,7 +30156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30110,7 +30175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30125,7 +30190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30144,7 +30209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30159,7 +30224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30178,7 +30243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30193,7 +30258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30212,7 +30277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30227,7 +30292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30246,7 +30311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30261,7 +30326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30280,7 +30345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30295,7 +30360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30314,7 +30379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30329,7 +30394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30348,7 +30413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30363,7 +30428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30382,7 +30447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30397,7 +30462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30416,7 +30481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30431,7 +30496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30450,7 +30515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30465,7 +30530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30484,7 +30549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30499,7 +30564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30518,7 +30583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30533,7 +30598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30552,7 +30617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30567,7 +30632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30586,7 +30651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30601,7 +30666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30620,7 +30685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30635,7 +30700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30654,7 +30719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30669,7 +30734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30688,7 +30753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30703,7 +30768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30722,7 +30787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30737,7 +30802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30756,7 +30821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30771,7 +30836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30790,7 +30855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30805,7 +30870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30824,7 +30889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30839,7 +30904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30858,7 +30923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30873,7 +30938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30892,7 +30957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30907,7 +30972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30926,7 +30991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30941,7 +31006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30960,7 +31025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -30975,7 +31040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -30994,7 +31059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31009,7 +31074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31028,7 +31093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31043,7 +31108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31062,7 +31127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31077,7 +31142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31096,7 +31161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31111,7 +31176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31130,7 +31195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31145,7 +31210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31164,7 +31229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31179,7 +31244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31198,7 +31263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31213,7 +31278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31232,7 +31297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31247,7 +31312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31266,7 +31331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31281,7 +31346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31300,7 +31365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31315,7 +31380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31334,7 +31399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31349,7 +31414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31368,7 +31433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31383,7 +31448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31402,7 +31467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31417,7 +31482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31436,7 +31501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31451,7 +31516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31470,7 +31535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31485,7 +31550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31504,7 +31569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31519,7 +31584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31538,7 +31603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31553,7 +31618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31572,7 +31637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31587,7 +31652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31606,7 +31671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31621,7 +31686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31640,7 +31705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31655,7 +31720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31674,7 +31739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31689,7 +31754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31708,7 +31773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31723,7 +31788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31742,7 +31807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31757,7 +31822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31776,7 +31841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31791,7 +31856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31810,7 +31875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31825,7 +31890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31844,7 +31909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31859,7 +31924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31878,7 +31943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31893,7 +31958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31912,7 +31977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31927,7 +31992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31946,7 +32011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31961,7 +32026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31980,7 +32045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -31995,7 +32060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32014,7 +32079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32029,7 +32094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32048,7 +32113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32063,7 +32128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32082,7 +32147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32097,7 +32162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32116,7 +32181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32131,7 +32196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32150,7 +32215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32165,7 +32230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32184,7 +32249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32199,7 +32264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32218,7 +32283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32233,7 +32298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32252,7 +32317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32267,7 +32332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32286,7 +32351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32301,7 +32366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32320,7 +32385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32335,7 +32400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32354,7 +32419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32369,7 +32434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32388,7 +32453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32403,7 +32468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32422,7 +32487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32437,7 +32502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32456,7 +32521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32471,7 +32536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32490,7 +32555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32505,7 +32570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32524,7 +32589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32539,7 +32604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32558,7 +32623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32573,7 +32638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32592,7 +32657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32607,7 +32672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 992,
+        "line": 994,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32626,7 +32691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32641,7 +32706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 992,
+        "line": 994,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32660,7 +32725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32675,7 +32740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 992,
+        "line": 994,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32694,7 +32759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32709,7 +32774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 992,
+        "line": 994,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32728,7 +32793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32743,7 +32808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 992,
+        "line": 994,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32762,7 +32827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32777,7 +32842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32796,7 +32861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32811,7 +32876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32830,7 +32895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32845,7 +32910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32864,7 +32929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32879,7 +32944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32898,7 +32963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32913,7 +32978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32932,7 +32997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32947,7 +33012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32966,7 +33031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -32981,7 +33046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33000,7 +33065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33015,7 +33080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33034,7 +33099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33049,7 +33114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33068,7 +33133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33083,7 +33148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33102,7 +33167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33117,7 +33182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33136,7 +33201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33151,7 +33216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1047,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33170,7 +33235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33185,7 +33250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1047,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33204,7 +33269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33219,7 +33284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1049,
+        "line": 1051,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33238,7 +33303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33253,7 +33318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1049,
+        "line": 1051,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33272,7 +33337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33287,7 +33352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33306,7 +33371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33321,7 +33386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33340,7 +33405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33355,7 +33420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33374,7 +33439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33389,7 +33454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33408,7 +33473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33423,7 +33488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33442,7 +33507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33457,7 +33522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33476,7 +33541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33491,7 +33556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33510,7 +33575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33525,7 +33590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33544,7 +33609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33559,7 +33624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33578,7 +33643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33593,7 +33658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33612,7 +33677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33627,7 +33692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33646,7 +33711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33661,7 +33726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33680,7 +33745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33695,7 +33760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33714,7 +33779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33729,7 +33794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33748,7 +33813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33763,7 +33828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33782,7 +33847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33797,7 +33862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33816,7 +33881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33831,7 +33896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33850,7 +33915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33865,7 +33930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33884,7 +33949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33899,7 +33964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33918,7 +33983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33933,7 +33998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33952,7 +34017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -33967,7 +34032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33986,7 +34051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34001,7 +34066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34020,7 +34085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34035,7 +34100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34054,7 +34119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34069,7 +34134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34088,7 +34153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34103,7 +34168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34122,7 +34187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34137,7 +34202,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34156,7 +34221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34171,7 +34236,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34190,7 +34255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34205,7 +34270,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1088,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34224,7 +34289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34239,7 +34304,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34258,7 +34323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34273,7 +34338,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34292,7 +34357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34307,7 +34372,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34326,7 +34391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34341,7 +34406,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1094,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34360,7 +34425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34375,7 +34440,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1094,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34394,7 +34459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34409,7 +34474,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34428,7 +34493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34443,7 +34508,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34462,7 +34527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34477,7 +34542,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34496,7 +34561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34511,7 +34576,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34530,7 +34595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34545,7 +34610,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34564,7 +34629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34579,7 +34644,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34598,7 +34663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34613,7 +34678,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34632,7 +34697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34647,7 +34712,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34666,7 +34731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34681,7 +34746,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34700,7 +34765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34715,7 +34780,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34734,7 +34799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34749,7 +34814,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34768,7 +34833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34783,7 +34848,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34802,7 +34867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34817,7 +34882,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34836,7 +34901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34851,7 +34916,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34870,7 +34935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34885,7 +34950,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34904,7 +34969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34919,7 +34984,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34938,7 +35003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34953,7 +35018,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34972,7 +35037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -34987,7 +35052,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35006,7 +35071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -35021,7 +35086,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35039,7 +35104,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1610
+            "line": 1612
           }
         ],
         "classification": "external",
@@ -35047,7 +35112,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1611,
+        "line": 1613,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35064,7 +35129,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1625
+            "line": 1620
           }
         ],
         "classification": "external",
@@ -35072,7 +35137,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1626,
+        "line": 1621,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35089,7 +35154,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1633
+            "line": 1628
           }
         ],
         "classification": "external",
@@ -35097,7 +35162,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1634,
+        "line": 1629,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -38141,13 +38206,13 @@
       },
       {
         "is_package": false,
-        "loc": 273,
+        "loc": 280,
         "module": "easyuse_anima.aio.resources",
-        "normalized_git_blob_sha1": "3ea1a6836f341f3efe5c5874b009bf399714ac53",
+        "normalized_git_blob_sha1": "0ae47ad33deedf52edc9a65a2cab3b044ab8aa26",
         "path": "easyuse_anima/aio/resources.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 16,
+          "function_count": 17,
           "global_count": 3
         }
       },
@@ -38729,13 +38794,13 @@
       },
       {
         "is_package": false,
-        "loc": 2356,
+        "loc": 2351,
         "module": "nodes",
-        "normalized_git_blob_sha1": "ff00e2019657d732f8eab20990604bb96ffa833d",
+        "normalized_git_blob_sha1": "3b6b059398d98188f2271d08044230487e5559cf",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 17,
+          "function_count": 16,
           "global_count": 26
         }
       },
@@ -40095,7 +40160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40104,7 +40169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40118,7 +40183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40127,7 +40192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40141,7 +40206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40150,7 +40215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40164,7 +40229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40173,7 +40238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40187,7 +40252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40196,7 +40261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40210,7 +40275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40219,7 +40284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40233,7 +40298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40242,7 +40307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40256,7 +40321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40265,7 +40330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 563,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40279,7 +40344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40288,7 +40353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40302,7 +40367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40311,7 +40376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 574,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40325,7 +40390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40334,7 +40399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40348,7 +40413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40357,7 +40422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40371,7 +40436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40380,7 +40445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40394,7 +40459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40403,7 +40468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40417,7 +40482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40426,7 +40491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40440,7 +40505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40449,7 +40514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40463,7 +40528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40472,7 +40537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40486,7 +40551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40495,7 +40560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40509,7 +40574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40518,7 +40583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40532,7 +40597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40541,7 +40606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40555,7 +40620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40564,7 +40629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40578,7 +40643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40587,7 +40652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40601,7 +40666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40610,7 +40675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40624,7 +40689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40633,7 +40698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40647,7 +40712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40656,7 +40721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40670,7 +40735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40679,7 +40744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40693,7 +40758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40702,7 +40767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 596,
+        "line": 597,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40716,7 +40781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40725,7 +40790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 599,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40739,7 +40804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40748,7 +40813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 599,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40762,7 +40827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40771,7 +40836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 599,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40785,7 +40850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40794,7 +40859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 604,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40808,7 +40873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40817,7 +40882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 604,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40831,7 +40896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40840,7 +40905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 604,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40854,7 +40919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40863,7 +40928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40877,7 +40942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40886,7 +40951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40900,7 +40965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40909,7 +40974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40923,7 +40988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40932,7 +40997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40946,7 +41011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40955,7 +41020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40969,7 +41034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -40978,7 +41043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40992,7 +41057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41001,7 +41066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41015,7 +41080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41024,7 +41089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41038,7 +41103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41047,7 +41112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41061,7 +41126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41070,7 +41135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41084,7 +41149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41093,7 +41158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41107,7 +41172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41116,7 +41181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41130,7 +41195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41139,7 +41204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41153,7 +41218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41162,7 +41227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41176,7 +41241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41185,7 +41250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41199,7 +41264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41208,7 +41273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41222,7 +41287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41231,7 +41296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 615,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41245,7 +41310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41254,7 +41319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41268,7 +41333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41277,7 +41342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41291,7 +41356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41300,7 +41365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41314,7 +41379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41323,7 +41388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41337,7 +41402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41346,7 +41411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41360,7 +41425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41369,7 +41434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41383,7 +41448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41392,7 +41457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41406,7 +41471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41415,7 +41480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41429,7 +41494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41438,7 +41503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41452,7 +41517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41461,7 +41526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41475,7 +41540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41484,7 +41549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41498,7 +41563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41507,7 +41572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41521,7 +41586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41530,7 +41595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41544,7 +41609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41553,7 +41618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41567,7 +41632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41576,7 +41641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41590,7 +41655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41599,7 +41664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41613,7 +41678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41622,7 +41687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41636,7 +41701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41645,7 +41710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41659,7 +41724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41668,7 +41733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41682,7 +41747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41691,7 +41756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41705,7 +41770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41714,7 +41779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41728,7 +41793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41737,7 +41802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 644,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41751,7 +41816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41760,7 +41825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41774,7 +41839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41783,7 +41848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41797,7 +41862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41806,7 +41871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41820,7 +41885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41829,7 +41894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41843,7 +41908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41852,7 +41917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41866,7 +41931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41875,7 +41940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41889,7 +41954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41898,7 +41963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41912,7 +41977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41921,7 +41986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41935,7 +42000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41944,7 +42009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41958,7 +42023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41967,7 +42032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 656,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41981,7 +42046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -41990,7 +42055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42004,7 +42069,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
+        "kind": "static_from",
+        "line": 669,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42013,7 +42101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42027,7 +42115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42036,7 +42124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42050,7 +42138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42059,7 +42147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42073,7 +42161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42082,7 +42170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42096,7 +42184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42105,7 +42193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42119,7 +42207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42128,7 +42216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42142,7 +42230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42151,7 +42239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42165,7 +42253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42174,7 +42262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42188,7 +42276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42197,7 +42285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42211,7 +42299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42220,7 +42308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42234,7 +42322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42243,7 +42331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42257,7 +42345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42266,7 +42354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42280,7 +42368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42289,7 +42377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42303,7 +42391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42312,7 +42400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 668,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42326,7 +42414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42335,7 +42423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 685,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42349,7 +42437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42358,7 +42446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 685,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42372,7 +42460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42381,7 +42469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 685,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42395,7 +42483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42404,7 +42492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42418,7 +42506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42427,7 +42515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42441,7 +42529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42450,7 +42538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42464,7 +42552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42473,7 +42561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42487,7 +42575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42496,7 +42584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 690,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42510,7 +42598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42519,7 +42607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42533,7 +42621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42542,7 +42630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42556,7 +42644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42565,7 +42653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42579,7 +42667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42588,7 +42676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42602,7 +42690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42611,7 +42699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42625,7 +42713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42634,7 +42722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42648,7 +42736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42657,7 +42745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42671,7 +42759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42680,7 +42768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42694,7 +42782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42703,7 +42791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42717,7 +42805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42726,7 +42814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42740,7 +42828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42749,7 +42837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42763,7 +42851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42772,7 +42860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42786,7 +42874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42795,7 +42883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42809,7 +42897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42818,7 +42906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42832,7 +42920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42841,7 +42929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42855,7 +42943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42864,7 +42952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42878,7 +42966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42887,7 +42975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42901,7 +42989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42910,7 +42998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42924,7 +43012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42933,7 +43021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42947,7 +43035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42956,7 +43044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42970,7 +43058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -42979,7 +43067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42993,7 +43081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43002,7 +43090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43016,7 +43104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43025,7 +43113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43039,7 +43127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43048,7 +43136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43062,7 +43150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43071,7 +43159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43085,7 +43173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43094,7 +43182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43108,7 +43196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43117,7 +43205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43131,7 +43219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43140,7 +43228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43154,7 +43242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43163,7 +43251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43177,7 +43265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43186,7 +43274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43200,7 +43288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43209,7 +43297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43223,7 +43311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43232,7 +43320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43246,7 +43334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43255,7 +43343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43269,7 +43357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43278,7 +43366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43292,7 +43380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43301,7 +43389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43315,7 +43403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43324,7 +43412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43338,7 +43426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43347,7 +43435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43361,7 +43449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43370,7 +43458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43384,7 +43472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43393,7 +43481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43407,7 +43495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43416,7 +43504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43430,7 +43518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43439,7 +43527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43453,7 +43541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43462,7 +43550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43476,7 +43564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43485,7 +43573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43499,7 +43587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43508,7 +43596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43522,7 +43610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43531,7 +43619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43545,7 +43633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43554,7 +43642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43568,7 +43656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43577,7 +43665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43591,7 +43679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43600,7 +43688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43614,7 +43702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43623,7 +43711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43637,7 +43725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43646,7 +43734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43660,7 +43748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43669,7 +43757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43683,7 +43771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43692,7 +43780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43706,7 +43794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43715,7 +43803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43729,7 +43817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43738,7 +43826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43752,7 +43840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43761,7 +43849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43775,7 +43863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43784,7 +43872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43798,7 +43886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43807,7 +43895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43821,7 +43909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43830,7 +43918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 772,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43844,7 +43932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43853,7 +43941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43867,7 +43955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43876,7 +43964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43890,7 +43978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43899,7 +43987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43913,7 +44001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43922,7 +44010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43936,7 +44024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43945,7 +44033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43959,7 +44047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43968,7 +44056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43982,7 +44070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -43991,7 +44079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44005,7 +44093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44014,7 +44102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44028,7 +44116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44037,7 +44125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 800,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44051,7 +44139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44060,7 +44148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44074,7 +44162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44083,7 +44171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44097,7 +44185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44106,7 +44194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44120,7 +44208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44129,7 +44217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44143,7 +44231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44152,7 +44240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44166,7 +44254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44175,7 +44263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44189,7 +44277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44198,7 +44286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44212,7 +44300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44221,7 +44309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44235,7 +44323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44244,7 +44332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44258,7 +44346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44267,7 +44355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44281,7 +44369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44290,7 +44378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44304,7 +44392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44313,7 +44401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44327,7 +44415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44336,7 +44424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44350,7 +44438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44359,7 +44447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44373,7 +44461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44382,7 +44470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44396,7 +44484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44405,7 +44493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44419,7 +44507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44428,7 +44516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44442,7 +44530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44451,7 +44539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44465,7 +44553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44474,7 +44562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44488,7 +44576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44497,7 +44585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44511,7 +44599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44520,7 +44608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44534,7 +44622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44543,7 +44631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44557,7 +44645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44566,7 +44654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44580,7 +44668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44589,7 +44677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44603,7 +44691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44612,7 +44700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44626,7 +44714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44635,7 +44723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44649,7 +44737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44658,7 +44746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44672,7 +44760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44681,7 +44769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44695,7 +44783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44704,7 +44792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 896,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44718,7 +44806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44727,7 +44815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44741,7 +44829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44750,7 +44838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44764,7 +44852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44773,7 +44861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44787,7 +44875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44796,7 +44884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44810,7 +44898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44819,7 +44907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44833,7 +44921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44842,7 +44930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 907,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44856,7 +44944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44865,7 +44953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44879,7 +44967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44888,7 +44976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44902,7 +44990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44911,7 +44999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44925,7 +45013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44934,7 +45022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44948,7 +45036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44957,7 +45045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44971,7 +45059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -44980,7 +45068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44994,7 +45082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45003,7 +45091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45017,7 +45105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45026,7 +45114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45040,7 +45128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45049,7 +45137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45063,7 +45151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45072,7 +45160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 922,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45086,7 +45174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45095,7 +45183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45109,7 +45197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45118,7 +45206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45132,7 +45220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45141,7 +45229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45155,7 +45243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45164,7 +45252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 933,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45178,7 +45266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45187,7 +45275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45201,7 +45289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45210,7 +45298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 946,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45224,7 +45312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45233,7 +45321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45247,7 +45335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45256,7 +45344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45270,7 +45358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45279,7 +45367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45293,7 +45381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45302,7 +45390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45316,7 +45404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45325,7 +45413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45339,7 +45427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45348,7 +45436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45362,7 +45450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45371,7 +45459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45385,7 +45473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45394,7 +45482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45408,7 +45496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45417,7 +45505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45431,7 +45519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45440,7 +45528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45454,7 +45542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45463,7 +45551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45477,7 +45565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45486,7 +45574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 965,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45500,7 +45588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45509,7 +45597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45523,7 +45611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45532,7 +45620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45546,7 +45634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45555,7 +45643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45569,7 +45657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45578,7 +45666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45592,7 +45680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45601,7 +45689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45615,7 +45703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45624,7 +45712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45638,7 +45726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45647,7 +45735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45661,7 +45749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45670,7 +45758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45684,7 +45772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45693,7 +45781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45707,7 +45795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45716,7 +45804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45730,7 +45818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45739,7 +45827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45753,7 +45841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45762,7 +45850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 992,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45776,7 +45864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45785,7 +45873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 992,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45799,7 +45887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45808,7 +45896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 992,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45822,7 +45910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45831,7 +45919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 992,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45845,7 +45933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45854,7 +45942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 992,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45868,7 +45956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45877,7 +45965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45891,7 +45979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45900,7 +45988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45914,7 +46002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45923,7 +46011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45937,7 +46025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45946,7 +46034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45960,7 +46048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45969,7 +46057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45983,7 +46071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -45992,7 +46080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46006,7 +46094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46015,7 +46103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46029,7 +46117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46038,7 +46126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46052,7 +46140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46061,7 +46149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46075,7 +46163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46084,7 +46172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46098,7 +46186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46107,7 +46195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1024,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46121,7 +46209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46130,7 +46218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1047,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46144,7 +46232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46153,7 +46241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1047,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46167,7 +46255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46176,7 +46264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1049,
+        "line": 1051,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46190,7 +46278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46199,7 +46287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1049,
+        "line": 1051,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46213,7 +46301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46222,7 +46310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46236,7 +46324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46245,7 +46333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46259,7 +46347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46268,7 +46356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46282,7 +46370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46291,7 +46379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46305,7 +46393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46314,7 +46402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46328,7 +46416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46337,7 +46425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46351,7 +46439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46360,7 +46448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46374,7 +46462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46383,7 +46471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46397,7 +46485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46406,7 +46494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46420,7 +46508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46429,7 +46517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46443,7 +46531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46452,7 +46540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46466,7 +46554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46475,7 +46563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46489,7 +46577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46498,7 +46586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46512,7 +46600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46521,7 +46609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46535,7 +46623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46544,7 +46632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46558,7 +46646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46567,7 +46655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46581,7 +46669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46590,7 +46678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46604,7 +46692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46613,7 +46701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46627,7 +46715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46636,7 +46724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46650,7 +46738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46659,7 +46747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46673,7 +46761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46682,7 +46770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46696,7 +46784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46705,7 +46793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46719,7 +46807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46728,7 +46816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46742,7 +46830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46751,7 +46839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46765,7 +46853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46774,7 +46862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46788,7 +46876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46797,7 +46885,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46811,7 +46899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46820,7 +46908,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46834,7 +46922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46843,7 +46931,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1088,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46857,7 +46945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46866,7 +46954,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46880,7 +46968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46889,7 +46977,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46903,7 +46991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46912,7 +47000,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46926,7 +47014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46935,7 +47023,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46949,7 +47037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46958,7 +47046,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46972,7 +47060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -46981,7 +47069,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46995,7 +47083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47004,7 +47092,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47018,7 +47106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47027,7 +47115,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47041,7 +47129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47050,7 +47138,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47064,7 +47152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47073,7 +47161,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47087,7 +47175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47096,7 +47184,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47110,7 +47198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47119,7 +47207,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47133,7 +47221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47142,7 +47230,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47156,7 +47244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47165,7 +47253,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47179,7 +47267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47188,7 +47276,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47202,7 +47290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47211,7 +47299,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47225,7 +47313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47234,7 +47322,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47248,7 +47336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47257,7 +47345,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47271,7 +47359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47280,7 +47368,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47294,7 +47382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47303,7 +47391,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47317,7 +47405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47326,7 +47414,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47340,7 +47428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47349,7 +47437,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47363,7 +47451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47372,7 +47460,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47386,7 +47474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 562,
+            "handler_line": 563,
             "kind": "try",
             "line": 10
           }
@@ -47395,7 +47483,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49250,7 +49338,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 190,
+            "line": 197,
             "type_checking": false
           },
           {
@@ -49258,14 +49346,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 191
+            "line": 198
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 192,
+        "line": 199,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -51222,14 +51310,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1610
+            "line": 1612
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1611,
+        "line": 1613,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51241,14 +51329,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1625
+            "line": 1620
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1626,
+        "line": 1621,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51260,14 +51348,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1633
+            "line": 1628
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1634,
+        "line": 1629,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52045,7 +52133,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 190,
+            "line": 197,
             "type_checking": false
           },
           {
@@ -52053,14 +52141,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 191
+            "line": 198
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 192,
+        "line": 199,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -52642,14 +52730,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1610
+            "line": 1612
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1611,
+        "line": 1613,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52661,14 +52749,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1625
+            "line": 1620
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1626,
+        "line": 1621,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52680,14 +52768,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1633
+            "line": 1628
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1634,
+        "line": 1629,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54148,7 +54236,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1115,
+        "line": 1117,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54157,7 +54245,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2252,
+        "line": 2247,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54166,7 +54254,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2255,
+        "line": 2250,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54175,7 +54263,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2258,
+        "line": 2253,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54184,7 +54272,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2261,
+        "line": 2256,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54193,7 +54281,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2264,
+        "line": 2259,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54202,7 +54290,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2267,
+        "line": 2262,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54211,7 +54299,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2270,
+        "line": 2265,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54220,7 +54308,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2273,
+        "line": 2268,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54229,7 +54317,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2276,
+        "line": 2271,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54238,7 +54326,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2279,
+        "line": 2274,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54247,7 +54335,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2282,
+        "line": 2277,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54256,7 +54344,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2285,
+        "line": 2280,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54265,7 +54353,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2288,
+        "line": 2283,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54274,7 +54362,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2291,
+        "line": 2286,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54283,7 +54371,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2294,
+        "line": 2289,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54292,7 +54380,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2297,
+        "line": 2292,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54301,7 +54389,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2301,
+        "line": 2296,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54310,7 +54398,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2304,
+        "line": 2299,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54319,7 +54407,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2308,
+        "line": 2303,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54328,7 +54416,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2311,
+        "line": 2306,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54337,7 +54425,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2315,
+        "line": 2310,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54346,7 +54434,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2318,
+        "line": 2313,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54355,7 +54443,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2321,
+        "line": 2316,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54364,7 +54452,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2324,
+        "line": 2319,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54373,7 +54461,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2327,
+        "line": 2322,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54382,7 +54470,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2330,
+        "line": 2325,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54391,7 +54479,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2337,
+        "line": 2332,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54400,7 +54488,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2343,
+        "line": 2338,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54409,7 +54497,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2348,
+        "line": 2343,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54418,7 +54506,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2352,
+        "line": 2347,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54932,13 +55020,13 @@
       },
       {
         "kind": "dict",
-        "line": 1177,
+        "line": 1179,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1166,
+        "line": 1168,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "3d7e5d21561d9f4501d2b454df4fe8a6ef4cdd3f",
+    "base_commit": "de57090f20aefe00663b7630ba87055333ddf107",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -49,7 +49,8 @@
       "B-11c16",
       "B-11c17",
       "B-11c18",
-      "B-11c19"
+      "B-11c19",
+      "B-11c20"
     ]
   },
   "enums": {
@@ -84,11 +85,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 291,
+    "nodes_canonical_bindings": 292,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 17,
+    "root_residual_functions": 16,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -227,6 +228,9 @@
     "ANIMA_CLIP_DEVICES": [
       "easyuse_anima.aio.resources"
     ],
+    "ANIMA_CLIP_TYPES": [
+      "easyuse_anima.aio.resources"
+    ],
     "ANIMA_DEFAULT_CLIP_CANDIDATES": [
       "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
@@ -346,6 +350,9 @@
     ],
     "_WEIGHTED_TOKEN_RE": [
       "easyuse_anima.prompt.fields"
+    ],
+    "_adapter_comfy_clip_loader_types": [
+      "easyuse_anima.aio.resources"
     ],
     "_adapter_comfy_diffusion_model_names": [
       "easyuse_anima.aio.resources"
@@ -2273,6 +2280,7 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_bind_aio_resource_runtime": "_bind_aio_resource_runtime",
+        "_comfy_clip_loader_types": "_comfy_clip_loader_types",
         "_comfy_diffusion_model_names": "_comfy_diffusion_model_names",
         "_comfy_text_encoder_names": "_comfy_text_encoder_names",
         "_comfy_vae_names": "_comfy_vae_names",
@@ -2709,11 +2717,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.resources"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.resources string runtime lookup"
       ],
       "removal_gates": [
@@ -4143,7 +4149,6 @@
       "surface": "nodes_root_residuals",
       "kind": "functions",
       "symbols": {
-        "_comfy_clip_loader_types": "_comfy_clip_loader_types",
         "_comfy_max_resolution": "_comfy_max_resolution",
         "_consume_reserved_wildcard_next_seed": "_consume_reserved_wildcard_next_seed",
         "_encode_with_comfy_clip": "_encode_with_comfy_clip",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1506,6 +1506,66 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
             ]
             self._assert_vae_contract(package_nodes, package_resources)
 
+    def _assert_clip_loader_type_contract(self, root_module, canonical_module):
+        self.assertIs(
+            root_module._comfy_clip_loader_types,
+            canonical_module._comfy_clip_loader_types,
+        )
+
+        candidates = ("qwen_image", "stable_diffusion")
+        returned = ["runtime_clip_type"]
+        events = []
+
+        def find_node_class(_node_id):
+            return None
+
+        def adapter(candidate_values, node_finder):
+            events.append(("adapter_call", candidate_values, node_finder))
+            return returned
+
+        def resolver(name):
+            events.append(name)
+            return getattr(root_module, name)
+
+        with (
+            patch.object(root_module, "ANIMA_CLIP_TYPES", candidates),
+            patch.object(
+                root_module,
+                "_adapter_comfy_clip_loader_types",
+                adapter,
+            ),
+            patch.object(root_module, "_find_comfy_node_class", find_node_class),
+        ):
+            canonical_module._bind_aio_resource_runtime(resolve_helper=resolver)
+            try:
+                result = canonical_module._comfy_clip_loader_types()
+            finally:
+                canonical_module._bind_aio_resource_runtime(
+                    resolve_helper=lambda name: getattr(root_module, name)
+                )
+
+        self.assertIs(result, returned)
+        self.assertEqual(
+            events,
+            [
+                "_adapter_comfy_clip_loader_types",
+                "ANIMA_CLIP_TYPES",
+                "_find_comfy_node_class",
+                ("adapter_call", candidates, find_node_class),
+            ],
+        )
+
+    def test_clip_loader_type_root_alias_and_call_time_dependencies(self):
+        self._assert_clip_loader_type_contract(nodes, aio_resources)
+
+    def test_clip_loader_type_package_alias_and_call_time_dependencies(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_resources = sys.modules[
+                f"{package_name}.easyuse_anima.aio.resources"
+            ]
+            self._assert_clip_loader_type_contract(package_nodes, package_resources)
+
 
 class AioSeedNormalizationMoveContractTests(unittest.TestCase):
     CONSTANT_NAMES = (

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "ff00e2019657d732f8eab20990604bb96ffa833d")
-        # Issue #184 B-11c19 moves only the VAE name wrapper to
+        self.assertEqual(report["git_blob_sha1"], "3b6b059398d98188f2271d08044230487e5559cf")
+        # Issue #184 B-11c20 moves only the CLIP loader-type wrapper to
         # the canonical AiO resource owner.
-        self.assertEqual(report["top_level"]["function_count"], 17)
+        self.assertEqual(report["top_level"]["function_count"], 16)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_356)
+        self.assertEqual(report["line_count"], 2_351)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "3d7e5d21561d9f4501d2b454df4fe8a6ef4cdd3f"
+BASE_COMMIT = "de57090f20aefe00663b7630ba87055333ddf107"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1322,6 +1322,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c17",
                 "B-11c18",
                 "B-11c19",
+                "B-11c20",
             ],
         },
         "enums": {
@@ -1334,11 +1335,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 291,
+            "nodes_canonical_bindings": 292,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 17,
+            "root_residual_functions": 16,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c20 단일 Move로 root `_comfy_clip_loader_types` wrapper만 기존 canonical owner `easyuse_anima.aio.resources`로 이동합니다.
- root `nodes.py`에는 relative/flat direct identity alias를 유지하고 기존 resource binder로 세 dependency를 사용 시점에 resolve합니다.

## 작업 전 inventory

### Symbol / caller

- `_comfy_clip_loader_types`
  - 현재 surface: `nodes.py` private root definition
  - production consumer: `easyuse_anima.nodes.aio_nodes.EasyUseAnimaInput.INPUT_TYPES`가 매 호출 `_runtime_helper("_comfy_clip_loader_types")()`로 root seam 조회
  - direct root production caller: 없음
  - root/package behavior와 INPUT_TYPES 계약 테스트가 직접 소비
- `_adapter_comfy_clip_loader_types`
  - `easyuse_anima.infrastructure.comfy.resources._comfy_clip_loader_types`의 별도 direct alias
  - 후보 tuple과 node-class finder를 받는 domain-neutral 2-argument adapter이며 이동 대상 wrapper와 identity/signature가 다름
  - 이번 PR에서는 이동·변경하지 않습니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical wrapper identity를 유지합니다.
- 기존 `_bind_aio_resource_runtime` 하나를 재사용합니다. 새 binder/global/module은 추가하지 않습니다.
- 사용 시점 root seam과 정확한 resolve 순서:
  1. `_adapter_comfy_clip_loader_types`
  2. `ANIMA_CLIP_TYPES`
  3. `_find_comfy_node_class`
  4. adapter 호출
- wrapper 자체의 cache, mutation, I/O, mutable global은 없습니다.

### 보존할 adapter 동작

- `find_node_class("CLIPLoader")`를 먼저 조회하며 finder 자체 예외는 그대로 전파합니다.
- loader의 `INPUT_TYPES()["required"]["type"]` 값을 `str`로 변환한 non-empty 목록이면 즉시 반환합니다.
- loader schema/호출 처리 예외는 기존 broad exception 경계 안에서 fallback으로 전환합니다.
- loader 부재·empty 목록·처리 예외 시 `list(ANIMA_CLIP_TYPES)` 새 복사본을 반환합니다.
- fallback 순서, adapter 반환 object identity를 보존하며 folder lookup을 추가하지 않습니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/resources.py`, `nodes.py`
- contract/analyzer: `tests/test_node_contracts.py`, `tests/test_python_compatibility_surface.py`, `tests/test_nodes_module_analyzer.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 예상 계약 delta

- base: `dev` / `de57090f20aefe00663b7630ba87055333ddf107`
- canonical bindings: `291 → 292`
- root/top-level residual functions: `17 → 16`
- runtime binders: `30` 유지
- runtime resolver names: `275 → 277` (`ANIMA_CLIP_TYPES`, `_adapter_comfy_clip_loader_types` 신규)
- shipped/runtime-closure modules: `83` 유지
- globals 26, preamble imports 6: 변화 없음
- `nodes.py` line count: `2356 → 2351`

## 금지 경계

- `_find_comfy_node_class` 또는 다른 resource-name wrapper 동시 이동 금지
- infrastructure adapter signature, finder 예외, loader broad-exception, fallback copy/order 동작 변경 금지
- `ANIMA_CLIP_TYPES` 이동 및 folder lookup 추가 금지
- adapter/helper 정적 import로 root monkeypatch seam 우회 금지
- `aio_nodes.py`, INPUT_TYPES, schema/default/workflow 변경 금지
- 다른 residual, Contract, Behavior 변경 결합 금지

## 검증

- focused identity/replacement/dependency-order/CLIP adapter/INPUT_TYPES/package/analyzer/import-boundary: 16 tests 통과
- canonical `easyuse_anima/aio/resources.py` Ruff: 통과
- 독립 read-only diff review: P1-P3 발견사항 없음
- exact head `01bfc67`에서 `tools/check_project.ps1 -Profile full`: 통과
  - Python unittest: 918 tests 통과
  - frontend: 114 JavaScript files 통과, TypeScript 6.0.3
  - Pyright baseline ratchet 및 import-boundary gate 통과
  - 전체 Ruff 113건은 G-01 report-only 기준선입니다. 이번 Move로 root adapter alias가 문자열 resolver 전용이 되며 예상 F401 1건이 추가됐고, canonical 변경 모듈은 Ruff clean입니다.
- Live ComfyUI/browser smoke: private resource-type Move 범위에서는 수행하지 않음

## 상태

- Ready for review
- exact-head full 및 독립 diff review 완료
