### PR TITLE
refactor: move AiO postprocess stage

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `de57090f20aefe00663b7630ba87055333ddf107`
+- Integrated `dev` snapshot commit: `43c30568731e95f2a5d4bf2603678d72ae3a3fda`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c19 / `de57090`; B-11c20 CLIP loader-type wrapper Move in PR #314 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c20 / `43c3056`; B-11c21 AiO postprocess stage Move in PR #315 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,9 +42,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,356
-  lines after B-11c19.
-- The mechanical extraction has removed 10,307
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,351
+  lines after B-11c20.
+- The mechanical extraction has removed 10,312
   lines, approximately 81.4% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
@@ -79,7 +79,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   application in PR #310 / `f4ab6eb`. B-11c17 moved only the diffusion-model
   name wrapper in PR #311 / `82247d9`. B-11c18 moved only the text-encoder name
   wrapper in PR #312 / `3d7e5d2`. B-11c19 moved only the VAE name wrapper in PR
-  #313 / `de57090`. B-11c20 moves only the CLIP loader-type wrapper in PR #314.
+  #313 / `de57090`. B-11c20 moved only the CLIP loader-type wrapper in PR #314 /
+  `43c3056`. B-11c21 moves only the AiO postprocess stage in PR #315.
 
 ### Current quality baseline
 
@@ -321,7 +322,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 CLIP loader-type wrapper Move PR #314 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 AiO postprocess stage Move PR #315 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -922,6 +923,11 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     owner in PR #314. The allowed-type tuple, node-class finder, and domain-
     neutral adapter remain call-time root seams; the other capability wrappers
     remain separate.
+  - B-11c21 moves only `_run_aio_postprocess_stage` to the existing AiO
+    postprocess owner in PR #315. Coercion, image-size, final-fit, and logger
+    dependencies remain call-time root seams. `_comfy_max_resolution` remains
+    deferred until a host-provider contract can preserve its zero-argument root
+    wrapper without importing root `nodes` from canonical code.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,15 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `de57090f20aefe00663b7630ba87055333ddf107`
+  `43c30568731e95f2a5d4bf2603678d72ae3a3fda`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c19 are integrated through PR #313. B-11c is
+- Current state: B-11a through B-11c20 are integrated through PR #314. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c20 CLIP loader-type wrapper Move is tracked by PR
-  #314.
+  the final root shim; B-11c21 AiO postprocess stage Move is tracked by PR #315.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -76,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 292 in B-11c20
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 293 in B-11c21
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -85,10 +84,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 16 functions, 0 classes, and 26 assigned
-  globals in B-11c20 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 15 functions, 0 classes, and 26 assigned
+  globals in B-11c21 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 277, including
+- root names reached by those canonical runtime resolvers: 278, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -464,6 +463,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - PR #314 does not move or change the infrastructure adapter, constants,
   node-class finder, other resource-name wrappers, INPUT_TYPES, schema,
   defaults, or workflow behavior.
+
+### B-11c21 AiO postprocess stage alias
+
+- Canonical owner: `easyuse_anima.aio.postprocess` for
+  `_run_aio_postprocess_stage`.
+- The private root stage remains a transitional direct alias in relative
+  package and flat import modes. `easyuse_anima.aio.legacy_generation`
+  continues to resolve that root name at call time.
+- The existing postprocess binder resolves `_as_bool`, `_image_tensor_size`,
+  `_apply_aio_final_fit`, and `logger` at use time. Disabled short-circuit,
+  final-fit metadata identity, dimension fallback, limit formatting, logging,
+  and return metadata order are unchanged.
+- PR #315 does not move or change the host-provider contract for
+  `_comfy_max_resolution`, final-fit/resize helpers, legacy-generation caller,
+  postprocess schema, defaults, or workflow behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/postprocess.py
+++ b/easyuse_anima/aio/postprocess.py
@@ -124,4 +124,51 @@ def _apply_aio_final_fit(
     return output, metadata
 
 
+def _run_aio_postprocess_stage(
+    image,
+    postprocess_settings: dict[str, Any],
+) -> tuple[Any, dict[str, Any]]:
+    if not _runtime_helper("_as_bool")(
+        postprocess_settings.get("enabled"),
+        False,
+    ):
+        width, height = _runtime_helper("_image_tensor_size")(image, 0, 0)
+        return image, {
+            "enabled": False,
+            "width": int(width),
+            "height": int(height),
+        }
+    output, fit_metadata = _runtime_helper("_apply_aio_final_fit")(
+        image,
+        postprocess_settings,
+    )
+    width, height = _runtime_helper("_image_tensor_size")(
+        output,
+        fit_metadata.get("target_width", 0),
+        fit_metadata.get("target_height", 0),
+    )
+    limit = (
+        f"{fit_metadata.get('max_megapixels')}MP"
+        if fit_metadata.get("mode") == "megapixels"
+        else f"{fit_metadata.get('max_long_edge')}px"
+    )
+    _runtime_helper("logger").info(
+        "[EasyUseAnima][AiO] Postprocess final fit: input=%sx%s mode=%s limit=%s method=%s applied=%s output=%sx%s",
+        fit_metadata.get("width"),
+        fit_metadata.get("height"),
+        fit_metadata.get("mode"),
+        limit,
+        fit_metadata.get("method"),
+        bool(fit_metadata.get("applied")),
+        width,
+        height,
+    )
+    return output, {
+        "enabled": True,
+        "width": int(width),
+        "height": int(height),
+        "fit": fit_metadata,
+    }
+
+
 __all__ = ()

--- a/nodes.py
+++ b/nodes.py
@@ -53,6 +53,7 @@ try:
         _apply_aio_final_fit as _apply_aio_final_fit,
         _aio_final_fit_size as _aio_final_fit_size,
         _bind_aio_postprocess_runtime as _bind_aio_postprocess_runtime,
+        _run_aio_postprocess_stage as _run_aio_postprocess_stage,
     )
     from .easyuse_anima.aio.conditioning import (
         _aio_prompt_data_fields_for_usdu as _aio_prompt_data_fields_for_usdu,
@@ -606,6 +607,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _apply_aio_final_fit as _apply_aio_final_fit,
         _aio_final_fit_size as _aio_final_fit_size,
         _bind_aio_postprocess_runtime as _bind_aio_postprocess_runtime,
+        _run_aio_postprocess_stage as _run_aio_postprocess_stage,
     )
     from easyuse_anima.aio.conditioning import (
         _aio_prompt_data_fields_for_usdu as _aio_prompt_data_fields_for_usdu,
@@ -1749,40 +1751,6 @@ def _run_aio_highres_stage(
         "height": int(height),
         "applied_scale": float(applied_scale),
         "sampler": _prompt_data_json_safe(stage_sampler),
-    }
-
-
-def _run_aio_postprocess_stage(image, postprocess_settings: dict[str, Any]) -> tuple[Any, dict[str, Any]]:
-    if not _as_bool(postprocess_settings.get("enabled"), False):
-        width, height = _image_tensor_size(image, 0, 0)
-        return image, {
-            "enabled": False,
-            "width": int(width),
-            "height": int(height),
-        }
-    output, fit_metadata = _apply_aio_final_fit(image, postprocess_settings)
-    width, height = _image_tensor_size(output, fit_metadata.get("target_width", 0), fit_metadata.get("target_height", 0))
-    limit = (
-        f"{fit_metadata.get('max_megapixels')}MP"
-        if fit_metadata.get("mode") == "megapixels"
-        else f"{fit_metadata.get('max_long_edge')}px"
-    )
-    logger.info(
-        "[EasyUseAnima][AiO] Postprocess final fit: input=%sx%s mode=%s limit=%s method=%s applied=%s output=%sx%s",
-        fit_metadata.get("width"),
-        fit_metadata.get("height"),
-        fit_metadata.get("mode"),
-        limit,
-        fit_metadata.get("method"),
-        bool(fit_metadata.get("applied")),
-        width,
-        height,
-    )
-    return output, {
-        "enabled": True,
-        "width": int(width),
-        "height": int(height),
-        "fit": fit_metadata,
     }
 
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -15384,6 +15384,37 @@
         "target": "easyuse_anima/aio/postprocess.py"
       },
       {
+        "alias": "_run_aio_postprocess_stage",
+        "bound_name": "_run_aio_postprocess_stage",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_postprocess_stage",
+          "target": "easyuse_anima/aio/postprocess.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
+        "kind": "static_from",
+        "line": 52,
+        "name": "_run_aio_postprocess_stage",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.postprocess",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
         "alias": "_aio_prompt_data_fields_for_usdu",
         "bound_name": "_aio_prompt_data_fields_for_usdu",
         "branch_context": [
@@ -15405,7 +15436,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15436,7 +15467,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15467,7 +15498,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15498,7 +15529,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15529,7 +15560,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15560,7 +15591,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15591,7 +15622,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15622,7 +15653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15653,7 +15684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15684,7 +15715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15715,7 +15746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15746,7 +15777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15777,7 +15808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15808,7 +15839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15839,7 +15870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15870,7 +15901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15901,7 +15932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15932,7 +15963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 78,
+        "line": 79,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15963,7 +15994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 78,
+        "line": 79,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15994,7 +16025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 78,
+        "line": 79,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16025,7 +16056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 78,
+        "line": 79,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16056,7 +16087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 78,
+        "line": 79,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16087,7 +16118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 78,
+        "line": 79,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16118,7 +16149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 78,
+        "line": 79,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16149,7 +16180,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 78,
+        "line": 79,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16180,7 +16211,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 78,
+        "line": 79,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16211,7 +16242,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 78,
+        "line": 79,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16242,7 +16273,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 78,
+        "line": 79,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16273,7 +16304,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 78,
+        "line": 79,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16304,7 +16335,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16335,7 +16366,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16366,7 +16397,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16397,7 +16428,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16428,7 +16459,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16459,7 +16490,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16490,7 +16521,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16521,7 +16552,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16552,7 +16583,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16583,7 +16614,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 92,
+        "line": 93,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16614,7 +16645,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16645,7 +16676,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16676,7 +16707,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16707,7 +16738,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16738,7 +16769,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16769,7 +16800,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16800,7 +16831,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16831,7 +16862,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16862,7 +16893,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16893,7 +16924,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 104,
+        "line": 105,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16924,7 +16955,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16955,7 +16986,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16986,7 +17017,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17017,7 +17048,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17048,7 +17079,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17079,7 +17110,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17110,7 +17141,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17141,7 +17172,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17172,7 +17203,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17203,7 +17234,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17234,7 +17265,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17265,7 +17296,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17296,7 +17327,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17327,7 +17358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17358,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 134,
+        "line": 135,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 134,
+        "line": 135,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 134,
+        "line": 135,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 146,
+        "line": 147,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 147,
+        "line": 148,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 147,
+        "line": 148,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 147,
+        "line": 148,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 147,
+        "line": 148,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 167,
+        "line": 168,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 167,
+        "line": 168,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 167,
+        "line": 168,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 167,
+        "line": 168,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 167,
+        "line": 168,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 167,
+        "line": 168,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 167,
+        "line": 168,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 185,
+        "line": 186,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 221,
+        "line": 222,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 249,
+        "line": 250,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 249,
+        "line": 250,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 249,
+        "line": 250,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 249,
+        "line": 250,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 249,
+        "line": 250,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 249,
+        "line": 250,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 249,
+        "line": 250,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 249,
+        "line": 250,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 249,
+        "line": 250,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 265,
+        "line": 266,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 345,
+        "line": 346,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 345,
+        "line": 346,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 345,
+        "line": 346,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 345,
+        "line": 346,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 356,
+        "line": 357,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 356,
+        "line": 357,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 356,
+        "line": 357,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 371,
+        "line": 372,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 371,
+        "line": 372,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 371,
+        "line": 372,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 382,
+        "line": 383,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 382,
+        "line": 383,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 382,
+        "line": 383,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 382,
+        "line": 383,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 395,
+        "line": 396,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 395,
+        "line": 396,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 403,
+        "line": 404,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 403,
+        "line": 404,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 403,
+        "line": 404,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 403,
+        "line": 404,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 403,
+        "line": 404,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 403,
+        "line": 404,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 403,
+        "line": 404,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 403,
+        "line": 404,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 414,
+        "line": 415,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 414,
+        "line": 415,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 414,
+        "line": 415,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 414,
+        "line": 415,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 428,
+        "line": 429,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 428,
+        "line": 429,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 432,
+        "line": 433,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 436,
+        "line": 437,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 436,
+        "line": 437,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 436,
+        "line": 437,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 448,
+        "line": 449,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 448,
+        "line": 449,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 448,
+        "line": 449,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 453,
+        "line": 454,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 453,
+        "line": 454,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 453,
+        "line": 454,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 471,
+        "line": 472,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 494,
+        "line": 495,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 494,
+        "line": 495,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 520,
+        "line": 521,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 520,
+        "line": 521,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 520,
+        "line": 521,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 520,
+        "line": 521,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 520,
+        "line": 521,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 520,
+        "line": 521,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 520,
+        "line": 521,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 520,
+        "line": 521,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 530,
+        "line": 531,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 535,
+        "line": 536,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 536,
+        "line": 537,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 536,
+        "line": 537,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 536,
+        "line": 537,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24116,7 +24147,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24147,7 +24178,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24178,7 +24209,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24209,7 +24240,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24240,7 +24271,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24259,7 +24290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24274,7 +24305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24293,7 +24324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24308,7 +24339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24327,7 +24358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24342,7 +24373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24361,7 +24392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24376,7 +24407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24395,7 +24426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24410,7 +24441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24429,7 +24460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24444,7 +24475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24463,7 +24494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24478,7 +24509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24497,7 +24528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24512,7 +24543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24531,7 +24562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24546,7 +24577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24565,7 +24596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24580,7 +24611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24599,7 +24630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24614,7 +24645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24633,7 +24664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24648,7 +24679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24667,7 +24698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24682,7 +24713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24701,7 +24732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24716,7 +24747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24735,7 +24766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24750,7 +24781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24769,7 +24800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24784,7 +24815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24803,7 +24834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24818,7 +24849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24837,7 +24868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24852,7 +24883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24871,7 +24902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24886,7 +24917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24905,7 +24936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24920,7 +24951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24939,7 +24970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24954,7 +24985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24973,7 +25004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -24988,7 +25019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25007,7 +25038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25022,7 +25053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25041,7 +25072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25056,7 +25087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25075,7 +25106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25090,7 +25121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25109,7 +25140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25124,7 +25155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25143,7 +25174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25158,7 +25189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25177,7 +25208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25192,7 +25223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 600,
+        "line": 601,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25211,7 +25242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25226,7 +25257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 600,
+        "line": 601,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25245,7 +25276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25260,7 +25291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 600,
+        "line": 601,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25279,7 +25310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25294,7 +25325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 605,
+        "line": 606,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25313,7 +25344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25328,7 +25359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 605,
+        "line": 606,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25347,7 +25378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25362,8 +25393,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 605,
+        "line": 606,
         "name": "_bind_aio_postprocess_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.aio.postprocess",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "alias": "_run_aio_postprocess_stage",
+        "bound_name": "_run_aio_postprocess_stage",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 564,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_postprocess_stage",
+          "target": "easyuse_anima/aio/postprocess.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
+        "kind": "static_from",
+        "line": 606,
+        "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
         "role": "compatibility_fallback",
@@ -25381,7 +25446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25396,7 +25461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25415,7 +25480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25430,7 +25495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25449,7 +25514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25464,7 +25529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25483,7 +25548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25498,7 +25563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25517,7 +25582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25532,7 +25597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25551,7 +25616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25566,7 +25631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25585,7 +25650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25600,7 +25665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25619,7 +25684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25634,7 +25699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25653,7 +25718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25668,7 +25733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25687,7 +25752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25702,7 +25767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25721,7 +25786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25736,7 +25801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25755,7 +25820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25770,7 +25835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25789,7 +25854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25804,7 +25869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25823,7 +25888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25838,7 +25903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25857,7 +25922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25872,7 +25937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25891,7 +25956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25906,7 +25971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25925,7 +25990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25940,7 +26005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25959,7 +26024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -25974,7 +26039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -25993,7 +26058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26008,7 +26073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26027,7 +26092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26042,7 +26107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26061,7 +26126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26076,7 +26141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26095,7 +26160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26110,7 +26175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26129,7 +26194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26144,7 +26209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26163,7 +26228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26178,7 +26243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26197,7 +26262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26212,7 +26277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26231,7 +26296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26246,7 +26311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26265,7 +26330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26280,7 +26345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26299,7 +26364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26314,7 +26379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26333,7 +26398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26348,7 +26413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26367,7 +26432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26382,7 +26447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26401,7 +26466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26416,7 +26481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26435,7 +26500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26450,7 +26515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26469,7 +26534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26484,7 +26549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26503,7 +26568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26518,7 +26583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26537,7 +26602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26552,7 +26617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26571,7 +26636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26586,7 +26651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26605,7 +26670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26620,7 +26685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26639,7 +26704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26654,7 +26719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26673,7 +26738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26688,7 +26753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26707,7 +26772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26722,7 +26787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26741,7 +26806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26756,7 +26821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26775,7 +26840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26790,7 +26855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26809,7 +26874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26824,7 +26889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26843,7 +26908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26858,7 +26923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26877,7 +26942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26892,7 +26957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26911,7 +26976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26926,7 +26991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26945,7 +27010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26960,7 +27025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26979,7 +27044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -26994,7 +27059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27013,7 +27078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27028,7 +27093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27047,7 +27112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27062,7 +27127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27081,7 +27146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27096,7 +27161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27115,7 +27180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27130,7 +27195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27149,7 +27214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27164,7 +27229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27183,7 +27248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27198,7 +27263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27217,7 +27282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27232,7 +27297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27251,7 +27316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27266,7 +27331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27285,7 +27350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27300,7 +27365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27319,7 +27384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27334,7 +27399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27353,7 +27418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27368,7 +27433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27387,7 +27452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27402,7 +27467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27421,7 +27486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27436,7 +27501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27455,7 +27520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27470,7 +27535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27489,7 +27554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27504,7 +27569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27523,7 +27588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27538,7 +27603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27557,7 +27622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27572,7 +27637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27591,7 +27656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27606,7 +27671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 687,
+        "line": 689,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27625,7 +27690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27640,7 +27705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 687,
+        "line": 689,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27659,7 +27724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27674,7 +27739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 687,
+        "line": 689,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27693,7 +27758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27708,7 +27773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27727,7 +27792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27742,7 +27807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27761,7 +27826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27776,7 +27841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27795,7 +27860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27810,7 +27875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27829,7 +27894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27844,7 +27909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27863,7 +27928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27878,7 +27943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 699,
+        "line": 701,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -27897,7 +27962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27912,7 +27977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27931,7 +27996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27946,7 +28011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27965,7 +28030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -27980,7 +28045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27999,7 +28064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28014,7 +28079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28033,7 +28098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28048,7 +28113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28067,7 +28132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28082,7 +28147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28101,7 +28166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28116,7 +28181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28135,7 +28200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28150,7 +28215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28169,7 +28234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28184,7 +28249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28203,7 +28268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28218,7 +28283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28237,7 +28302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28252,7 +28317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28271,7 +28336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28286,7 +28351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28305,7 +28370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28320,7 +28385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28339,7 +28404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28354,7 +28419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28373,7 +28438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28388,7 +28453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28407,7 +28472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28422,7 +28487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28441,7 +28506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28456,7 +28521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28475,7 +28540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28490,7 +28555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28509,7 +28574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28524,7 +28589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28543,7 +28608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28558,7 +28623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28577,7 +28642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28592,7 +28657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28611,7 +28676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28626,7 +28691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28645,7 +28710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28660,7 +28725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28679,7 +28744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28694,7 +28759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28713,7 +28778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28728,7 +28793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28747,7 +28812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28762,7 +28827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28781,7 +28846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28796,7 +28861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28815,7 +28880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28830,7 +28895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28849,7 +28914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28864,7 +28929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28883,7 +28948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28898,7 +28963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28917,7 +28982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28932,7 +28997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28951,7 +29016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -28966,7 +29031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28985,7 +29050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29000,7 +29065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29019,7 +29084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29034,7 +29099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29053,7 +29118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29068,7 +29133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29087,7 +29152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29102,7 +29167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29121,7 +29186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29136,7 +29201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29155,7 +29220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29170,7 +29235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29189,7 +29254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29204,7 +29269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29223,7 +29288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29238,7 +29303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29257,7 +29322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29272,7 +29337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29291,7 +29356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29306,7 +29371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29325,7 +29390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29340,7 +29405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29359,7 +29424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29374,7 +29439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29393,7 +29458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29408,7 +29473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29427,7 +29492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29442,7 +29507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29461,7 +29526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29476,7 +29541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29495,7 +29560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29510,7 +29575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29529,7 +29594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29544,7 +29609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29563,7 +29628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29578,7 +29643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29597,7 +29662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29612,7 +29677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29631,7 +29696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29646,7 +29711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29665,7 +29730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29680,7 +29745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29699,7 +29764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29714,7 +29779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29733,7 +29798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29748,7 +29813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29767,7 +29832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29782,7 +29847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29801,7 +29866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29816,7 +29881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29835,7 +29900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29850,7 +29915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29869,7 +29934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29884,7 +29949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29903,7 +29968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29918,7 +29983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29937,7 +30002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29952,7 +30017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29971,7 +30036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -29986,7 +30051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30005,7 +30070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30020,7 +30085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30039,7 +30104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30054,7 +30119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30073,7 +30138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30088,7 +30153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30107,7 +30172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30122,7 +30187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30141,7 +30206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30156,7 +30221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30175,7 +30240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30190,7 +30255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30209,7 +30274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30224,7 +30289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30243,7 +30308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30258,7 +30323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30277,7 +30342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30292,7 +30357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30311,7 +30376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30326,7 +30391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30345,7 +30410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30360,7 +30425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30379,7 +30444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30394,7 +30459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30413,7 +30478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30428,7 +30493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30447,7 +30512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30462,7 +30527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30481,7 +30546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30496,7 +30561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30515,7 +30580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30530,7 +30595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30549,7 +30614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30564,7 +30629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30583,7 +30648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30598,7 +30663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30617,7 +30682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30632,7 +30697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30651,7 +30716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30666,7 +30731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30685,7 +30750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30700,7 +30765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30719,7 +30784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30734,7 +30799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30753,7 +30818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30768,7 +30833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30787,7 +30852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30802,7 +30867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30821,7 +30886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30836,7 +30901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30855,7 +30920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30870,7 +30935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30889,7 +30954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30904,7 +30969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30923,7 +30988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30938,7 +31003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30957,7 +31022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -30972,7 +31037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30991,7 +31056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31006,7 +31071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31025,7 +31090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31040,7 +31105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31059,7 +31124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31074,7 +31139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31093,7 +31158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31108,7 +31173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31127,7 +31192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31142,7 +31207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31161,7 +31226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31176,7 +31241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31195,7 +31260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31210,7 +31275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31229,7 +31294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31244,7 +31309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31263,7 +31328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31278,7 +31343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31297,7 +31362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31312,7 +31377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31331,7 +31396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31346,7 +31411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31365,7 +31430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31380,7 +31445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31399,7 +31464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31414,7 +31479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31433,7 +31498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31448,7 +31513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31467,7 +31532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31482,7 +31547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31501,7 +31566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31516,7 +31581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31535,7 +31600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31550,7 +31615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31569,7 +31634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31584,7 +31649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31603,7 +31668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31618,7 +31683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31637,7 +31702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31652,7 +31717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31671,7 +31736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31686,7 +31751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 935,
+        "line": 937,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31705,7 +31770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31720,7 +31785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 935,
+        "line": 937,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31739,7 +31804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31754,7 +31819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 935,
+        "line": 937,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31773,7 +31838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31788,7 +31853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 935,
+        "line": 937,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31807,7 +31872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31822,7 +31887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31841,7 +31906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31856,7 +31921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31875,7 +31940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31890,7 +31955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31909,7 +31974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31924,7 +31989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31943,7 +32008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31958,7 +32023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31977,7 +32042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -31992,7 +32057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32011,7 +32076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32026,7 +32091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32045,7 +32110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32060,7 +32125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32079,7 +32144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32094,7 +32159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32113,7 +32178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32128,7 +32193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32147,7 +32212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32162,7 +32227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32181,7 +32246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32196,7 +32261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32215,7 +32280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32230,7 +32295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32249,7 +32314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32264,7 +32329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32283,7 +32348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32298,7 +32363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32317,7 +32382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32332,7 +32397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32351,7 +32416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32366,7 +32431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32385,7 +32450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32400,7 +32465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32419,7 +32484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32434,7 +32499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32453,7 +32518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32468,7 +32533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32487,7 +32552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32502,7 +32567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32521,7 +32586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32536,7 +32601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32555,7 +32620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32570,7 +32635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32589,7 +32654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32604,7 +32669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32623,7 +32688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32638,7 +32703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32657,7 +32722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32672,7 +32737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 994,
+        "line": 996,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32691,7 +32756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32706,7 +32771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 994,
+        "line": 996,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32725,7 +32790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32740,7 +32805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 994,
+        "line": 996,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32759,7 +32824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32774,7 +32839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 994,
+        "line": 996,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32793,7 +32858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32808,7 +32873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 994,
+        "line": 996,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32827,7 +32892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32842,7 +32907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1003,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32861,7 +32926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32876,7 +32941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1003,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32895,7 +32960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32910,7 +32975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1003,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32929,7 +32994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32944,7 +33009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32963,7 +33028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -32978,7 +33043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -32997,7 +33062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33012,7 +33077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33031,7 +33096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33046,7 +33111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33065,7 +33130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33080,7 +33145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33099,7 +33164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33114,7 +33179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33133,7 +33198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33148,7 +33213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33167,7 +33232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33182,7 +33247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33201,7 +33266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33216,7 +33281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1049,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33235,7 +33300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33250,7 +33315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1049,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33269,7 +33334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33284,7 +33349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1051,
+        "line": 1053,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33303,7 +33368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33318,7 +33383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1051,
+        "line": 1053,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33337,7 +33402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33352,7 +33417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33371,7 +33436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33386,7 +33451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33405,7 +33470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33420,7 +33485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33439,7 +33504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33454,7 +33519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33473,7 +33538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33488,7 +33553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33507,7 +33572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33522,7 +33587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33541,7 +33606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33556,7 +33621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33575,7 +33640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33590,7 +33655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33609,7 +33674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33624,7 +33689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33643,7 +33708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33658,7 +33723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33677,7 +33742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33692,7 +33757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33711,7 +33776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33726,7 +33791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33745,7 +33810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33760,7 +33825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33779,7 +33844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33794,7 +33859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33813,7 +33878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33828,7 +33893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33847,7 +33912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33862,7 +33927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33881,7 +33946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33896,7 +33961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33915,7 +33980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33930,7 +33995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33949,7 +34014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33964,7 +34029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33983,7 +34048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -33998,7 +34063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34017,7 +34082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34032,7 +34097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34051,7 +34116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34066,7 +34131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34085,7 +34150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34100,7 +34165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34119,7 +34184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34134,7 +34199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34153,7 +34218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34168,7 +34233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34187,7 +34252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34202,7 +34267,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34221,7 +34286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34236,7 +34301,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34255,7 +34320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34270,7 +34335,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1090,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34289,7 +34354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34304,7 +34369,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34323,7 +34388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34338,7 +34403,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34357,7 +34422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34372,7 +34437,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34391,7 +34456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34406,7 +34471,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1096,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34425,7 +34490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34440,7 +34505,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1096,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34459,7 +34524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34474,7 +34539,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34493,7 +34558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34508,7 +34573,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34527,7 +34592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34542,7 +34607,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34561,7 +34626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34576,7 +34641,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34595,7 +34660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34610,7 +34675,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34629,7 +34694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34644,7 +34709,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34663,7 +34728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34678,7 +34743,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34697,7 +34762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34712,7 +34777,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34731,7 +34796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34746,7 +34811,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34765,7 +34830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34780,7 +34845,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34799,7 +34864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34814,7 +34879,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34833,7 +34898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34848,7 +34913,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34867,7 +34932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34882,7 +34947,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34901,7 +34966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34916,7 +34981,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34935,7 +35000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34950,7 +35015,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34969,7 +35034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -34984,7 +35049,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35003,7 +35068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -35018,7 +35083,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35037,7 +35102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -35052,7 +35117,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35071,7 +35136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -35086,7 +35151,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35104,7 +35169,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1612
+            "line": 1614
           }
         ],
         "classification": "external",
@@ -35112,7 +35177,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1613,
+        "line": 1615,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35129,7 +35194,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1620
+            "line": 1622
           }
         ],
         "classification": "external",
@@ -35137,7 +35202,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1621,
+        "line": 1623,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35154,7 +35219,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1628
+            "line": 1630
           }
         ],
         "classification": "external",
@@ -35162,7 +35227,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1629,
+        "line": 1631,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -38182,13 +38247,13 @@
       },
       {
         "is_package": false,
-        "loc": 127,
+        "loc": 174,
         "module": "easyuse_anima.aio.postprocess",
-        "normalized_git_blob_sha1": "e2b8d08cee93c99986abb88b06c9ec6252b93936",
+        "normalized_git_blob_sha1": "85fa7f041636614cce3c1c17cb3c2d1087fed44a",
         "path": "easyuse_anima/aio/postprocess.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 4,
+          "function_count": 5,
           "global_count": 3
         }
       },
@@ -38794,13 +38859,13 @@
       },
       {
         "is_package": false,
-        "loc": 2351,
+        "loc": 2319,
         "module": "nodes",
-        "normalized_git_blob_sha1": "3b6b059398d98188f2271d08044230487e5559cf",
+        "normalized_git_blob_sha1": "c0f1454971e614e93b1357313b29371794587041",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 16,
+          "function_count": 15,
           "global_count": 26
         }
       },
@@ -40160,7 +40225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40169,7 +40234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40183,7 +40248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40192,7 +40257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40206,7 +40271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40215,7 +40280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40229,7 +40294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40238,7 +40303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40252,7 +40317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40261,7 +40326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40275,7 +40340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40284,7 +40349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40298,7 +40363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40307,7 +40372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40321,7 +40386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40330,7 +40395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 564,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40344,7 +40409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40353,7 +40418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40367,7 +40432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40376,7 +40441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 575,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40390,7 +40455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40399,7 +40464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40413,7 +40478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40422,7 +40487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40436,7 +40501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40445,7 +40510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40459,7 +40524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40468,7 +40533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40482,7 +40547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40491,7 +40556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40505,7 +40570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40514,7 +40579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40528,7 +40593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40537,7 +40602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40551,7 +40616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40560,7 +40625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40574,7 +40639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40583,7 +40648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40597,7 +40662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40606,7 +40671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40620,7 +40685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40629,7 +40694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40643,7 +40708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40652,7 +40717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40666,7 +40731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40675,7 +40740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40689,7 +40754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40698,7 +40763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40712,7 +40777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40721,7 +40786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40735,7 +40800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40744,7 +40809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40758,7 +40823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40767,7 +40832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 597,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40781,7 +40846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40790,7 +40855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 600,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40804,7 +40869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40813,7 +40878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 600,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40827,7 +40892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40836,7 +40901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 600,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40850,7 +40915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40859,7 +40924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 605,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40873,7 +40938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40882,7 +40947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 605,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40896,7 +40961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40905,7 +40970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 605,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40919,7 +40984,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
+        "kind": "static_from",
+        "line": 606,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40928,7 +41016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40942,7 +41030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40951,7 +41039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40965,7 +41053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40974,7 +41062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40988,7 +41076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -40997,7 +41085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41011,7 +41099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41020,7 +41108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41034,7 +41122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41043,7 +41131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41057,7 +41145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41066,7 +41154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41080,7 +41168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41089,7 +41177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41103,7 +41191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41112,7 +41200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41126,7 +41214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41135,7 +41223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41149,7 +41237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41158,7 +41246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41172,7 +41260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41181,7 +41269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41195,7 +41283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41204,7 +41292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41218,7 +41306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41227,7 +41315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41241,7 +41329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41250,7 +41338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41264,7 +41352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41273,7 +41361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41287,7 +41375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41296,7 +41384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41310,7 +41398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41319,7 +41407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41333,7 +41421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41342,7 +41430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41356,7 +41444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41365,7 +41453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41379,7 +41467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41388,7 +41476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41402,7 +41490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41411,7 +41499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41425,7 +41513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41434,7 +41522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41448,7 +41536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41457,7 +41545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41471,7 +41559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41480,7 +41568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41494,7 +41582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41503,7 +41591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41517,7 +41605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41526,7 +41614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41540,7 +41628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41549,7 +41637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41563,7 +41651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41572,7 +41660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 631,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41586,7 +41674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41595,7 +41683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41609,7 +41697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41618,7 +41706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41632,7 +41720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41641,7 +41729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41655,7 +41743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41664,7 +41752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41678,7 +41766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41687,7 +41775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41701,7 +41789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41710,7 +41798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41724,7 +41812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41733,7 +41821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41747,7 +41835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41756,7 +41844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41770,7 +41858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41779,7 +41867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41793,7 +41881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41802,7 +41890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41816,7 +41904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41825,7 +41913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41839,7 +41927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41848,7 +41936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41862,7 +41950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41871,7 +41959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41885,7 +41973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41894,7 +41982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41908,7 +41996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41917,7 +42005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41931,7 +42019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41940,7 +42028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41954,7 +42042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41963,7 +42051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41977,7 +42065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -41986,7 +42074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42000,7 +42088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42009,7 +42097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42023,7 +42111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42032,7 +42120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42046,7 +42134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42055,7 +42143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42069,7 +42157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42078,7 +42166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42092,7 +42180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42101,7 +42189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42115,7 +42203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42124,7 +42212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42138,7 +42226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42147,7 +42235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42161,7 +42249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42170,7 +42258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42184,7 +42272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42193,7 +42281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42207,7 +42295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42216,7 +42304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42230,7 +42318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42239,7 +42327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42253,7 +42341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42262,7 +42350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42276,7 +42364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42285,7 +42373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42299,7 +42387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42308,7 +42396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42322,7 +42410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42331,7 +42419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42345,7 +42433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42354,7 +42442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42368,7 +42456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42377,7 +42465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42391,7 +42479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42400,7 +42488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42414,7 +42502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42423,7 +42511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 687,
+        "line": 689,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42437,7 +42525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42446,7 +42534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 687,
+        "line": 689,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42460,7 +42548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42469,7 +42557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 687,
+        "line": 689,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42483,7 +42571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42492,7 +42580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42506,7 +42594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42515,7 +42603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42529,7 +42617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42538,7 +42626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42552,7 +42640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42561,7 +42649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42575,7 +42663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42584,7 +42672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 692,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42598,7 +42686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42607,7 +42695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 699,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42621,7 +42709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42630,7 +42718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42644,7 +42732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42653,7 +42741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42667,7 +42755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42676,7 +42764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42690,7 +42778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42699,7 +42787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42713,7 +42801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42722,7 +42810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42736,7 +42824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42745,7 +42833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42759,7 +42847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42768,7 +42856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42782,7 +42870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42791,7 +42879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42805,7 +42893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42814,7 +42902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42828,7 +42916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42837,7 +42925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42851,7 +42939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42860,7 +42948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42874,7 +42962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42883,7 +42971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42897,7 +42985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42906,7 +42994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42920,7 +43008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42929,7 +43017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42943,7 +43031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42952,7 +43040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42966,7 +43054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42975,7 +43063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42989,7 +43077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -42998,7 +43086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43012,7 +43100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43021,7 +43109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43035,7 +43123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43044,7 +43132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43058,7 +43146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43067,7 +43155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43081,7 +43169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43090,7 +43178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43104,7 +43192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43113,7 +43201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43127,7 +43215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43136,7 +43224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43150,7 +43238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43159,7 +43247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43173,7 +43261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43182,7 +43270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43196,7 +43284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43205,7 +43293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43219,7 +43307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43228,7 +43316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43242,7 +43330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43251,7 +43339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43265,7 +43353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43274,7 +43362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43288,7 +43376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43297,7 +43385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43311,7 +43399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43320,7 +43408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43334,7 +43422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43343,7 +43431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43357,7 +43445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43366,7 +43454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43380,7 +43468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43389,7 +43477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43403,7 +43491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43412,7 +43500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43426,7 +43514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43435,7 +43523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43449,7 +43537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43458,7 +43546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43472,7 +43560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43481,7 +43569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43495,7 +43583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43504,7 +43592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43518,7 +43606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43527,7 +43615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43541,7 +43629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43550,7 +43638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43564,7 +43652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43573,7 +43661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43587,7 +43675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43596,7 +43684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 738,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43610,7 +43698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43619,7 +43707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43633,7 +43721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43642,7 +43730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43656,7 +43744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43665,7 +43753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43679,7 +43767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43688,7 +43776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43702,7 +43790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43711,7 +43799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43725,7 +43813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43734,7 +43822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43748,7 +43836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43757,7 +43845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43771,7 +43859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43780,7 +43868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43794,7 +43882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43803,7 +43891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43817,7 +43905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43826,7 +43914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43840,7 +43928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43849,7 +43937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43863,7 +43951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43872,7 +43960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43886,7 +43974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43895,7 +43983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43909,7 +43997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43918,7 +44006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 774,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43932,7 +44020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43941,7 +44029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43955,7 +44043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43964,7 +44052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43978,7 +44066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -43987,7 +44075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44001,7 +44089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44010,7 +44098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44024,7 +44112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44033,7 +44121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44047,7 +44135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44056,7 +44144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44070,7 +44158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44079,7 +44167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44093,7 +44181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44102,7 +44190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44116,7 +44204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44125,7 +44213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 802,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44139,7 +44227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44148,7 +44236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44162,7 +44250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44171,7 +44259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44185,7 +44273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44194,7 +44282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44208,7 +44296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44217,7 +44305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44231,7 +44319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44240,7 +44328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44254,7 +44342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44263,7 +44351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44277,7 +44365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44286,7 +44374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44300,7 +44388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44309,7 +44397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44323,7 +44411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44332,7 +44420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44346,7 +44434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44355,7 +44443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44369,7 +44457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44378,7 +44466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44392,7 +44480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44401,7 +44489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44415,7 +44503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44424,7 +44512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44438,7 +44526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44447,7 +44535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44461,7 +44549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44470,7 +44558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44484,7 +44572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44493,7 +44581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44507,7 +44595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44516,7 +44604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44530,7 +44618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44539,7 +44627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44553,7 +44641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44562,7 +44650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44576,7 +44664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44585,7 +44673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44599,7 +44687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44608,7 +44696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44622,7 +44710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44631,7 +44719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44645,7 +44733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44654,7 +44742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44668,7 +44756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44677,7 +44765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44691,7 +44779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44700,7 +44788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 818,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44714,7 +44802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44723,7 +44811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44737,7 +44825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44746,7 +44834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44760,7 +44848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44769,7 +44857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44783,7 +44871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44792,7 +44880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 898,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44806,7 +44894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44815,7 +44903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44829,7 +44917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44838,7 +44926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44852,7 +44940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44861,7 +44949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44875,7 +44963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44884,7 +44972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44898,7 +44986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44907,7 +44995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44921,7 +45009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44930,7 +45018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 909,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44944,7 +45032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44953,7 +45041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44967,7 +45055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44976,7 +45064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44990,7 +45078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -44999,7 +45087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45013,7 +45101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45022,7 +45110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45036,7 +45124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45045,7 +45133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45059,7 +45147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45068,7 +45156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45082,7 +45170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45091,7 +45179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45105,7 +45193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45114,7 +45202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45128,7 +45216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45137,7 +45225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45151,7 +45239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45160,7 +45248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 924,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45174,7 +45262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45183,7 +45271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 935,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45197,7 +45285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45206,7 +45294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 935,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45220,7 +45308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45229,7 +45317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 935,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45243,7 +45331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45252,7 +45340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 935,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45266,7 +45354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45275,7 +45363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45289,7 +45377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45298,7 +45386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 948,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45312,7 +45400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45321,7 +45409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45335,7 +45423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45344,7 +45432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45358,7 +45446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45367,7 +45455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45381,7 +45469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45390,7 +45478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45404,7 +45492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45413,7 +45501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45427,7 +45515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45436,7 +45524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45450,7 +45538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45459,7 +45547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45473,7 +45561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45482,7 +45570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45496,7 +45584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45505,7 +45593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45519,7 +45607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45528,7 +45616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45542,7 +45630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45551,7 +45639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45565,7 +45653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45574,7 +45662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 967,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45588,7 +45676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45597,7 +45685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45611,7 +45699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45620,7 +45708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45634,7 +45722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45643,7 +45731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45657,7 +45745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45666,7 +45754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45680,7 +45768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45689,7 +45777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45703,7 +45791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45712,7 +45800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45726,7 +45814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45735,7 +45823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45749,7 +45837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45758,7 +45846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45772,7 +45860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45781,7 +45869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45795,7 +45883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45804,7 +45892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45818,7 +45906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45827,7 +45915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45841,7 +45929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45850,7 +45938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 994,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45864,7 +45952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45873,7 +45961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 994,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45887,7 +45975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45896,7 +45984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 994,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45910,7 +45998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45919,7 +46007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 994,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45933,7 +46021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45942,7 +46030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 994,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45956,7 +46044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45965,7 +46053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45979,7 +46067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -45988,7 +46076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46002,7 +46090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46011,7 +46099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46025,7 +46113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46034,7 +46122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46048,7 +46136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46057,7 +46145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46071,7 +46159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46080,7 +46168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46094,7 +46182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46103,7 +46191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46117,7 +46205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46126,7 +46214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46140,7 +46228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46149,7 +46237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46163,7 +46251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46172,7 +46260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46186,7 +46274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46195,7 +46283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1024,
+        "line": 1026,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46209,7 +46297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46218,7 +46306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1049,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46232,7 +46320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46241,7 +46329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1049,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46255,7 +46343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46264,7 +46352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1051,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46278,7 +46366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46287,7 +46375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1051,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46301,7 +46389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46310,7 +46398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46324,7 +46412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46333,7 +46421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46347,7 +46435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46356,7 +46444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46370,7 +46458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46379,7 +46467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46393,7 +46481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46402,7 +46490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46416,7 +46504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46425,7 +46513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46439,7 +46527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46448,7 +46536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46462,7 +46550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46471,7 +46559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46485,7 +46573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46494,7 +46582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46508,7 +46596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46517,7 +46605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46531,7 +46619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46540,7 +46628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46554,7 +46642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46563,7 +46651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46577,7 +46665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46586,7 +46674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46600,7 +46688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46609,7 +46697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46623,7 +46711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46632,7 +46720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46646,7 +46734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46655,7 +46743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46669,7 +46757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46678,7 +46766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46692,7 +46780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46701,7 +46789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46715,7 +46803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46724,7 +46812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46738,7 +46826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46747,7 +46835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46761,7 +46849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46770,7 +46858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46784,7 +46872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46793,7 +46881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46807,7 +46895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46816,7 +46904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46830,7 +46918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46839,7 +46927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46853,7 +46941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46862,7 +46950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46876,7 +46964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46885,7 +46973,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46899,7 +46987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46908,7 +46996,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46922,7 +47010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46931,7 +47019,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1090,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46945,7 +47033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46954,7 +47042,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46968,7 +47056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -46977,7 +47065,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46991,7 +47079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47000,7 +47088,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47014,7 +47102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47023,7 +47111,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47037,7 +47125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47046,7 +47134,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47060,7 +47148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47069,7 +47157,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47083,7 +47171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47092,7 +47180,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47106,7 +47194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47115,7 +47203,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47129,7 +47217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47138,7 +47226,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47152,7 +47240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47161,7 +47249,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47175,7 +47263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47184,7 +47272,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47198,7 +47286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47207,7 +47295,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47221,7 +47309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47230,7 +47318,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47244,7 +47332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47253,7 +47341,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47267,7 +47355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47276,7 +47364,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47290,7 +47378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47299,7 +47387,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47313,7 +47401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47322,7 +47410,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47336,7 +47424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47345,7 +47433,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47359,7 +47447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47368,7 +47456,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47382,7 +47470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47391,7 +47479,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47405,7 +47493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47414,7 +47502,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47428,7 +47516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47437,7 +47525,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47451,7 +47539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47460,7 +47548,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47474,7 +47562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 564,
             "kind": "try",
             "line": 10
           }
@@ -47483,7 +47571,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51310,14 +51398,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1612
+            "line": 1614
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1613,
+        "line": 1615,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51329,14 +51417,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1620
+            "line": 1622
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1621,
+        "line": 1623,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51348,14 +51436,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1628
+            "line": 1630
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1629,
+        "line": 1631,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52730,14 +52818,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1612
+            "line": 1614
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1613,
+        "line": 1615,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52749,14 +52837,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1620
+            "line": 1622
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1621,
+        "line": 1623,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52768,14 +52856,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1628
+            "line": 1630
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1629,
+        "line": 1631,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54236,7 +54324,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1117,
+        "line": 1119,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54245,7 +54333,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2247,
+        "line": 2215,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54254,7 +54342,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2250,
+        "line": 2218,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54263,7 +54351,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2253,
+        "line": 2221,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54272,7 +54360,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2256,
+        "line": 2224,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54281,7 +54369,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2259,
+        "line": 2227,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54290,7 +54378,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2262,
+        "line": 2230,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54299,7 +54387,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2265,
+        "line": 2233,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54308,7 +54396,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2268,
+        "line": 2236,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54317,7 +54405,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2271,
+        "line": 2239,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54326,7 +54414,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2274,
+        "line": 2242,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54335,7 +54423,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2277,
+        "line": 2245,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54344,7 +54432,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2280,
+        "line": 2248,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54353,7 +54441,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2283,
+        "line": 2251,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54362,7 +54450,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2286,
+        "line": 2254,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54371,7 +54459,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2289,
+        "line": 2257,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54380,7 +54468,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2292,
+        "line": 2260,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54389,7 +54477,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2296,
+        "line": 2264,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54398,7 +54486,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2299,
+        "line": 2267,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54407,7 +54495,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2303,
+        "line": 2271,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54416,7 +54504,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2306,
+        "line": 2274,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54425,7 +54513,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2310,
+        "line": 2278,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54434,7 +54522,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2313,
+        "line": 2281,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54443,7 +54531,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2316,
+        "line": 2284,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54452,7 +54540,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2319,
+        "line": 2287,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54461,7 +54549,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2322,
+        "line": 2290,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54470,7 +54558,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2325,
+        "line": 2293,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54479,7 +54567,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2332,
+        "line": 2300,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54488,7 +54576,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2338,
+        "line": 2306,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54497,7 +54585,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2343,
+        "line": 2311,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54506,7 +54594,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2347,
+        "line": 2315,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55020,13 +55108,13 @@
       },
       {
         "kind": "dict",
-        "line": 1179,
+        "line": 1181,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1168,
+        "line": 1170,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "de57090f20aefe00663b7630ba87055333ddf107",
+    "base_commit": "43c30568731e95f2a5d4bf2603678d72ae3a3fda",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -50,7 +50,8 @@
       "B-11c17",
       "B-11c18",
       "B-11c19",
-      "B-11c20"
+      "B-11c20",
+      "B-11c21"
     ]
   },
   "enums": {
@@ -85,11 +86,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 292,
+    "nodes_canonical_bindings": 293,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 16,
+    "root_residual_functions": 15,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -473,6 +474,9 @@
     ],
     "_apply_aio_anima_dave_patch": [
       "easyuse_anima.aio.model_preparation"
+    ],
+    "_apply_aio_final_fit": [
+      "easyuse_anima.aio.postprocess"
     ],
     "_apply_aio_kj_model_patches": [
       "easyuse_anima.aio.model_preparation"
@@ -1112,6 +1116,7 @@
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.output",
+      "easyuse_anima.aio.postprocess",
       "easyuse_anima.aio.preview"
     ],
     "next_seed": [
@@ -2208,7 +2213,8 @@
       "symbols": {
         "_aio_final_fit_size": "_aio_final_fit_size",
         "_apply_aio_final_fit": "_apply_aio_final_fit",
-        "_bind_aio_postprocess_runtime": "_bind_aio_postprocess_runtime"
+        "_bind_aio_postprocess_runtime": "_bind_aio_postprocess_runtime",
+        "_run_aio_postprocess_stage": "_run_aio_postprocess_stage"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -2221,10 +2227,12 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.postprocess"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.postprocess string runtime lookup"
       ],
       "removal_gates": [
@@ -4161,7 +4169,6 @@
         "_run_aio_detailer_stage": "_run_aio_detailer_stage",
         "_run_aio_detailer_target": "_run_aio_detailer_target",
         "_run_aio_highres_stage": "_run_aio_highres_stage",
-        "_run_aio_postprocess_stage": "_run_aio_postprocess_stage",
         "_run_aio_resshift_upscale_stage": "_run_aio_resshift_upscale_stage",
         "_run_aio_upscale_stage": "_run_aio_upscale_stage",
         "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage"

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1071,7 +1071,157 @@ class AioFinalFitPlanningMoveContractTests(unittest.TestCase):
         "_apply_aio_final_fit",
         "_aio_final_fit_size",
         "_bind_aio_postprocess_runtime",
+        "_run_aio_postprocess_stage",
     )
+
+    def _assert_stage_contract(self, root_module, canonical_module):
+        image = object()
+        events = []
+
+        class StageLogger:
+            def info(self, *args):
+                events.append(("logger.info", args))
+
+        stage_logger = StageLogger()
+
+        def resolver(name):
+            events.append(("resolve", name))
+            return getattr(root_module, name)
+
+        def disabled_as_bool(value, default):
+            events.append(("as_bool", (value, default)))
+            return False
+
+        def disabled_size(value, width, height):
+            events.append(("image_tensor_size", (value, width, height)))
+            return 640, 480
+
+        def unexpected_apply(*args):
+            raise AssertionError(f"disabled postprocess applied final fit: {args!r}")
+
+        with (
+            patch.object(root_module, "_as_bool", disabled_as_bool),
+            patch.object(root_module, "_image_tensor_size", disabled_size),
+            patch.object(root_module, "_apply_aio_final_fit", unexpected_apply),
+            patch.object(root_module, "logger", stage_logger),
+        ):
+            canonical_module._bind_aio_postprocess_runtime(resolve_helper=resolver)
+            try:
+                output, metadata = canonical_module._run_aio_postprocess_stage(
+                    image,
+                    {"enabled": "off"},
+                )
+            finally:
+                canonical_module._bind_aio_postprocess_runtime(
+                    resolve_helper=lambda name: getattr(root_module, name)
+                )
+
+        self.assertIs(output, image)
+        self.assertEqual(
+            events,
+            [
+                ("resolve", "_as_bool"),
+                ("as_bool", ("off", False)),
+                ("resolve", "_image_tensor_size"),
+                ("image_tensor_size", (image, 0, 0)),
+            ],
+        )
+        self.assertEqual(list(metadata), ["enabled", "width", "height"])
+        self.assertEqual(
+            metadata,
+            {"enabled": False, "width": 640, "height": 480},
+        )
+
+        for mode, expected_limit in (
+            ("max_long_edge", "2048px"),
+            ("megapixels", "4.5MP"),
+        ):
+            with self.subTest(mode=mode):
+                output_image = object()
+                fit_metadata = {
+                    "width": 1024,
+                    "height": 768,
+                    "mode": mode,
+                    "max_long_edge": 2048,
+                    "max_megapixels": 4.5,
+                    "method": "bicubic",
+                    "applied": 1,
+                    "target_width": 800,
+                    "target_height": 600,
+                }
+                settings = {"enabled": "on", "fit": {"mode": mode}}
+                events = []
+
+                def enabled_as_bool(value, default):
+                    events.append(("as_bool", (value, default)))
+                    return True
+
+                def apply_final_fit(value, stage_settings):
+                    events.append(("apply_final_fit", (value, stage_settings)))
+                    return output_image, fit_metadata
+
+                def enabled_size(value, width, height):
+                    events.append(("image_tensor_size", (value, width, height)))
+                    return 800, 600
+
+                with (
+                    patch.object(root_module, "_as_bool", enabled_as_bool),
+                    patch.object(
+                        root_module,
+                        "_apply_aio_final_fit",
+                        apply_final_fit,
+                    ),
+                    patch.object(root_module, "_image_tensor_size", enabled_size),
+                    patch.object(root_module, "logger", stage_logger),
+                ):
+                    canonical_module._bind_aio_postprocess_runtime(
+                        resolve_helper=resolver
+                    )
+                    try:
+                        output, metadata = canonical_module._run_aio_postprocess_stage(
+                            image,
+                            settings,
+                        )
+                    finally:
+                        canonical_module._bind_aio_postprocess_runtime(
+                            resolve_helper=lambda name: getattr(root_module, name)
+                        )
+
+                self.assertIs(output, output_image)
+                self.assertEqual(
+                    events,
+                    [
+                        ("resolve", "_as_bool"),
+                        ("as_bool", ("on", False)),
+                        ("resolve", "_apply_aio_final_fit"),
+                        ("apply_final_fit", (image, settings)),
+                        ("resolve", "_image_tensor_size"),
+                        ("image_tensor_size", (output_image, 800, 600)),
+                        ("resolve", "logger"),
+                        (
+                            "logger.info",
+                            (
+                                "[EasyUseAnima][AiO] Postprocess final fit: input=%sx%s mode=%s limit=%s method=%s applied=%s output=%sx%s",
+                                1024,
+                                768,
+                                mode,
+                                expected_limit,
+                                "bicubic",
+                                True,
+                                800,
+                                600,
+                            ),
+                        ),
+                    ],
+                )
+                self.assertEqual(
+                    list(metadata),
+                    ["enabled", "width", "height", "fit"],
+                )
+                self.assertEqual(metadata["enabled"], True)
+                self.assertEqual(metadata["width"], 800)
+                self.assertEqual(metadata["height"], 600)
+                self.assertIs(metadata["fit"], fit_metadata)
 
     def _assert_contract(self, root_module, canonical_module):
         for name in self.MOVED_NAMES:
@@ -1300,6 +1450,8 @@ class AioFinalFitPlanningMoveContractTests(unittest.TestCase):
         self.assertEqual(metadata["scale"], 0.5)
         self.assertEqual(metadata["target_width"], 320)
         self.assertEqual(metadata["target_height"], 240)
+
+        self._assert_stage_contract(root_module, canonical_module)
 
     def test_root_aliases_and_call_time_helpers(self):
         self._assert_contract(nodes, aio_postprocess)

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "3b6b059398d98188f2271d08044230487e5559cf")
-        # Issue #184 B-11c20 moves only the CLIP loader-type wrapper to
-        # the canonical AiO resource owner.
-        self.assertEqual(report["top_level"]["function_count"], 16)
+        self.assertEqual(report["git_blob_sha1"], "c0f1454971e614e93b1357313b29371794587041")
+        # Issue #184 B-11c21 moves only the AiO postprocess stage to its
+        # canonical postprocess owner.
+        self.assertEqual(report["top_level"]["function_count"], 15)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_351)
+        self.assertEqual(report["line_count"], 2_319)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "de57090f20aefe00663b7630ba87055333ddf107"
+BASE_COMMIT = "43c30568731e95f2a5d4bf2603678d72ae3a3fda"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1323,6 +1323,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c18",
                 "B-11c19",
                 "B-11c20",
+                "B-11c21",
             ],
         },
         "enums": {
@@ -1335,11 +1336,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 292,
+            "nodes_canonical_bindings": 293,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 16,
+            "root_residual_functions": 15,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c21 단일 Move로 root `_run_aio_postprocess_stage`만 기존 canonical owner `easyuse_anima.aio.postprocess`로 이동합니다.
- root `nodes.py`에는 relative/flat direct identity alias를 유지하고 기존 postprocess binder로 네 dependency를 사용 시점에 resolve합니다.

## 작업 전 inventory

### Symbol / caller

- `_run_aio_postprocess_stage`
  - 현재 surface: `nodes.py` private root definition
  - production consumer: `easyuse_anima.aio.legacy_generation`이 `_runtime_helper("_run_aio_postprocess_stage")`로 root seam 조회
  - 직접 root behavior test와 legacy orchestration contract가 소비
  - public mapping/export 없음

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical stage identity를 유지합니다.
- 기존 `_bind_aio_postprocess_runtime`을 재사용합니다. 새 binder/global/module은 추가하지 않습니다.
- call-time root dependencies: `_as_bool`, `_image_tensor_size`, `_apply_aio_final_fit`, `logger`.
- cache, provider import, mutable module state는 없고 settings/fit metadata를 새로 변경하지 않습니다.

### 보존할 평가 순서와 동작

- disabled:
  1. `_as_bool`
  2. `_image_tensor_size(image, 0, 0)`
  3. 원본 image와 `enabled,width,height` metadata 반환
  4. final-fit 및 logger 미호출
- enabled:
  1. `_as_bool`
  2. `_apply_aio_final_fit`
  3. `_image_tensor_size(output, target_width, target_height)`
  4. mode 확인 후 `megapixels`면 `max_megapixels`, 아니면 `max_long_edge` formatting
  5. root `logger.info`
  6. `enabled,width,height,fit` 순서 metadata 반환
- 로그 문자열·인자 순서, `bool(applied)`, `MP`/`px` formatting, fit object identity를 유지합니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/postprocess.py`, `nodes.py`
- contract/analyzer: `tests/test_node_contracts.py`, `tests/test_python_compatibility_surface.py`, `tests/test_nodes_module_analyzer.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 예상 계약 delta

- base: `dev` / `43c30568731e95f2a5d4bf2603678d72ae3a3fda`
- canonical bindings: `292 → 293`
- root/top-level residual functions: `16 → 15`
- runtime binders: `30` 유지
- runtime resolver names: `277 → 278` (`_apply_aio_final_fit` 신규)
- shipped/runtime-closure modules: `83` 유지
- globals 26, preamble imports 6: 변화 없음
- `nodes.py` line count: `2351 → 2319`

## 선행 blocker 기록

- `_comfy_max_resolution` pure Move는 보류합니다. zero-arg wrapper의 call-time host-provider import 계약을 canonical root-import gate 없이 표현할 seam이 없으며, 기존 same-name adapter는 인자 시그니처가 다릅니다.

## 금지 경계

- `_comfy_max_resolution` provider 계약 동시 변경 금지
- size/final-fit/resize helper 재수정 금지
- logger를 module-local logger로 대체하거나 로그 문구·인자·formatting 변경 금지
- legacy-generation caller 수정 금지
- postprocess settings, schema, defaults, workflow 변경 금지
- 새 binder/module, Comfy import, Contract/Behavior 변경 결합 금지

## 검증

- focused stage identity/dependency order/disabled short-circuit/enabled formatting/legacy caller/analyzer/import-boundary: 11 tests 통과
- canonical `easyuse_anima/aio/postprocess.py` Ruff: 통과
- 독립 read-only diff review: P1-P3 발견사항 없음
- exact head `1a2cfdd`에서 `tools/check_project.ps1 -Profile full`: 통과
  - Python unittest: 918 tests 통과
  - frontend: 114 JavaScript files 통과, TypeScript 6.0.3
  - Pyright baseline ratchet 및 import-boundary gate 통과
  - 전체 Ruff 113건은 G-01 report-only 기준선이며 이번 direct alias Move로 수가 늘지 않았습니다.
- Live ComfyUI/browser smoke: private orchestration Move 범위에서는 수행하지 않음

## 상태

- Ready for review
- exact-head full 및 독립 diff review 완료
