### PR TITLE
refactor: move AiO highres stage

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `43c30568731e95f2a5d4bf2603678d72ae3a3fda`
+- Integrated `dev` snapshot commit: `8b3ba38988407225aa53b9cd23e151db3a7d6ac8`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c20 / `43c3056`; B-11c21 AiO postprocess stage Move in PR #315 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c21 / `8b3ba38`; B-11c22 AiO highres stage Move in PR #316 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,351
-  lines after B-11c20.
-- The mechanical extraction has removed 10,312
-  lines, approximately 81.4% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,319
+  lines after B-11c21.
+- The mechanical extraction has removed 10,344
+  lines, approximately 81.7% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -80,7 +80,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   name wrapper in PR #311 / `82247d9`. B-11c18 moved only the text-encoder name
   wrapper in PR #312 / `3d7e5d2`. B-11c19 moved only the VAE name wrapper in PR
   #313 / `de57090`. B-11c20 moved only the CLIP loader-type wrapper in PR #314 /
-  `43c3056`. B-11c21 moves only the AiO postprocess stage in PR #315.
+  `43c3056`. B-11c21 moved only the AiO postprocess stage in PR #315 /
+  `8b3ba38`. B-11c22 moves only the AiO highres stage in PR #316.
 
 ### Current quality baseline
 
@@ -322,7 +323,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 AiO postprocess stage Move PR #315 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 AiO highres stage Move PR #316 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -924,10 +925,14 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     neutral adapter remain call-time root seams; the other capability wrappers
     remain separate.
   - B-11c21 moves only `_run_aio_postprocess_stage` to the existing AiO
-    postprocess owner in PR #315. Coercion, image-size, final-fit, and logger
-    dependencies remain call-time root seams. `_comfy_max_resolution` remains
+    postprocess owner in PR #315 / `8b3ba38`. Coercion, image-size, final-fit,
+    and logger dependencies remain call-time root seams. `_comfy_max_resolution` remains
     deferred until a host-provider contract can preserve its zero-argument root
     wrapper without importing root `nodes` from canonical code.
+  - B-11c22 moves only `_run_aio_highres_stage` to the existing AiO legacy-
+    generation owner in PR #316. Sampler planning, scaler construction, VAE,
+    model-patch, sampling, cleanup, resize, and metadata helpers remain call-time
+    root seams; execution order and the legacy caller lookup remain unchanged.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `43c30568731e95f2a5d4bf2603678d72ae3a3fda`
+  `8b3ba38988407225aa53b9cd23e151db3a7d6ac8`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c20 are integrated through PR #314. B-11c is
+- Current state: B-11a through B-11c21 are integrated through PR #315. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c21 AiO postprocess stage Move is tracked by PR #315.
+  the final root shim; B-11c22 AiO highres stage Move is tracked by PR #316.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 293 in B-11c21
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 294 in B-11c22
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -84,10 +84,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 15 functions, 0 classes, and 26 assigned
-  globals in B-11c21 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 14 functions, 0 classes, and 26 assigned
+  globals in B-11c22 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 278, including
+- root names reached by those canonical runtime resolvers: 280, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -478,6 +478,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - PR #315 does not move or change the host-provider contract for
   `_comfy_max_resolution`, final-fit/resize helpers, legacy-generation caller,
   postprocess schema, defaults, or workflow behavior.
+
+### B-11c22 AiO highres stage alias
+
+- Canonical owner: `easyuse_anima.aio.legacy_generation` for
+  `_run_aio_highres_stage`.
+- The private root stage remains a transitional direct alias in relative
+  package and flat import modes. The canonical legacy-generation caller keeps
+  resolving the root name at call time to preserve its monkeypatch seam.
+- The existing legacy-generation binder resolves boolean coercion, stage
+  sampler planning, scaler construction, VAE encode/decode, model patching,
+  sampling, cleanup, resize, and metadata serialization at use time. Disabled
+  short-circuit, patch-before-try, sampling-only cleanup, conditional re-encode,
+  argument order, and metadata order are unchanged.
+- PR #316 does not move or change sampling helpers, the stage protocol, schema,
+  defaults, workflow behavior, or the later #169 Contract/Behavior work.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/legacy_generation.py
+++ b/easyuse_anima/aio/legacy_generation.py
@@ -21,6 +21,89 @@ def _runtime_helper(name: str) -> Any:
     return resolver(name)
 
 
+def _run_aio_highres_stage(
+    model,
+    clip,
+    vae,
+    positive,
+    negative,
+    image,
+    base_latent,
+    base_width: int,
+    base_height: int,
+    sampler_settings: dict[str, Any],
+    highres_settings: dict[str, Any],
+    mod_guidance_settings: dict[str, Any] | None = None,
+    use_mod_guidance: bool = False,
+    quality_tags: str = "",
+    quality_neg: str = "",
+) -> tuple[Any, Any, int, int, dict[str, Any]]:
+    if not _runtime_helper("_as_bool")(
+        highres_settings.get("enabled"), False
+    ):
+        return base_latent, image, int(base_width), int(base_height), {"enabled": False}
+
+    stage_sampler = _runtime_helper("_aio_stage_sampler_settings")(
+        sampler_settings,
+        highres_settings,
+        scheduler_default="simple",
+        inherit_backend=True,
+    )
+    scaled_image, width, height, applied_scale = _runtime_helper(
+        "EasyUseAnimaImageScaleByMultiple"
+    )().upscale(
+        image,
+        highres_settings.get("scale_by", 1.25),
+        highres_settings.get("upscale_method", "bicubic"),
+        highres_settings.get("multiple", "32"),
+        highres_settings.get("max_long_edge", 2560),
+    )
+    latent_image = _runtime_helper("_encode_image_with_comfy_vae")(
+        vae, scaled_image
+    )
+    stage_model = model
+    if stage_sampler.get("backend") == "comfy_ksampler":
+        stage_model = _runtime_helper(
+            "_apply_aio_spectrum_model_patches_for_comfy_sampler"
+        )(
+            model,
+            clip,
+            positive,
+            stage_sampler,
+        )
+    try:
+        latent = _runtime_helper("_sample_latent_with_aio_backend")(
+            stage_model,
+            clip,
+            positive,
+            negative,
+            latent_image,
+            stage_sampler,
+            mod_guidance_settings or {},
+            use_mod_guidance,
+            quality_tags,
+            quality_neg,
+        )
+    finally:
+        _runtime_helper("_cleanup_aio_ephemeral_model")(stage_model, model)
+    decoded = _runtime_helper("_decode_latent_with_comfy")(vae, latent)
+    decoded, resized = _runtime_helper("_resize_image_to_size_if_needed")(
+        decoded,
+        width,
+        height,
+        highres_settings.get("upscale_method", "bicubic"),
+    )
+    if resized:
+        latent = _runtime_helper("_encode_image_with_comfy_vae")(vae, decoded)
+    return latent, decoded, int(width), int(height), {
+        "enabled": True,
+        "width": int(width),
+        "height": int(height),
+        "applied_scale": float(applied_scale),
+        "sampler": _runtime_helper("_prompt_data_json_safe")(stage_sampler),
+    }
+
+
 def _run_aio_legacy_generation(
     generator,
     easy_use_anima_input,

--- a/nodes.py
+++ b/nodes.py
@@ -21,6 +21,7 @@ try:
     )
     from .easyuse_anima.aio.legacy_generation import (
         _bind_aio_legacy_generation_runtime as _bind_aio_legacy_generation_runtime,
+        _run_aio_highres_stage as _run_aio_highres_stage,
         _run_aio_legacy_generation as _run_aio_legacy_generation,
     )
     from .easyuse_anima.aio.generation_normalization import (
@@ -575,6 +576,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     )
     from easyuse_anima.aio.legacy_generation import (
         _bind_aio_legacy_generation_runtime as _bind_aio_legacy_generation_runtime,
+        _run_aio_highres_stage as _run_aio_highres_stage,
         _run_aio_legacy_generation as _run_aio_legacy_generation,
     )
     from easyuse_anima.aio.generation_normalization import (
@@ -1677,81 +1679,6 @@ def _resize_image_to_size_if_needed(
     samples = image.movedim(-1, 1)
     resized = _common_upscale_image(samples, target_width, target_height, str(upscale_method or "bicubic"))
     return resized.movedim(1, -1), True
-
-
-def _run_aio_highres_stage(
-    model,
-    clip,
-    vae,
-    positive,
-    negative,
-    image,
-    base_latent,
-    base_width: int,
-    base_height: int,
-    sampler_settings: dict[str, Any],
-    highres_settings: dict[str, Any],
-    mod_guidance_settings: dict[str, Any] | None = None,
-    use_mod_guidance: bool = False,
-    quality_tags: str = "",
-    quality_neg: str = "",
-) -> tuple[Any, Any, int, int, dict[str, Any]]:
-    if not _as_bool(highres_settings.get("enabled"), False):
-        return base_latent, image, int(base_width), int(base_height), {"enabled": False}
-
-    stage_sampler = _aio_stage_sampler_settings(
-        sampler_settings,
-        highres_settings,
-        scheduler_default="simple",
-        inherit_backend=True,
-    )
-    scaled_image, width, height, applied_scale = EasyUseAnimaImageScaleByMultiple().upscale(
-        image,
-        highres_settings.get("scale_by", 1.25),
-        highres_settings.get("upscale_method", "bicubic"),
-        highres_settings.get("multiple", "32"),
-        highres_settings.get("max_long_edge", 2560),
-    )
-    latent_image = _encode_image_with_comfy_vae(vae, scaled_image)
-    stage_model = model
-    if stage_sampler.get("backend") == "comfy_ksampler":
-        stage_model = _apply_aio_spectrum_model_patches_for_comfy_sampler(
-            model,
-            clip,
-            positive,
-            stage_sampler,
-        )
-    try:
-        latent = _sample_latent_with_aio_backend(
-            stage_model,
-            clip,
-            positive,
-            negative,
-            latent_image,
-            stage_sampler,
-            mod_guidance_settings or {},
-            use_mod_guidance,
-            quality_tags,
-            quality_neg,
-        )
-    finally:
-        _cleanup_aio_ephemeral_model(stage_model, model)
-    decoded = _decode_latent_with_comfy(vae, latent)
-    decoded, resized = _resize_image_to_size_if_needed(
-        decoded,
-        width,
-        height,
-        highres_settings.get("upscale_method", "bicubic"),
-    )
-    if resized:
-        latent = _encode_image_with_comfy_vae(vae, decoded)
-    return latent, decoded, int(width), int(height), {
-        "enabled": True,
-        "width": int(width),
-        "height": int(height),
-        "applied_scale": float(applied_scale),
-        "sampler": _prompt_data_json_safe(stage_sampler),
-    }
 
 
 def _run_aio_usdu_upscale_stage(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14640,6 +14640,37 @@
         "target": "easyuse_anima/aio/legacy_generation.py"
       },
       {
+        "alias": "_run_aio_highres_stage",
+        "bound_name": "_run_aio_highres_stage",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_highres_stage",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_run_aio_highres_stage",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
         "alias": "_run_aio_legacy_generation",
         "bound_name": "_run_aio_legacy_generation",
         "branch_context": [
@@ -14692,7 +14723,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14723,7 +14754,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14754,7 +14785,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14785,7 +14816,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14816,7 +14847,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14847,7 +14878,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14878,7 +14909,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14909,7 +14940,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14940,7 +14971,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14971,7 +15002,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15002,7 +15033,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15033,7 +15064,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15064,7 +15095,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15095,7 +15126,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15126,7 +15157,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15157,7 +15188,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 26,
+        "line": 27,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15188,7 +15219,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 44,
+        "line": 45,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -15219,7 +15250,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 47,
+        "line": 48,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15250,7 +15281,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 47,
+        "line": 48,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15281,7 +15312,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 47,
+        "line": 48,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15312,7 +15343,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 52,
+        "line": 53,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15343,7 +15374,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 52,
+        "line": 53,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15374,7 +15405,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 52,
+        "line": 53,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15405,7 +15436,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 52,
+        "line": 53,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15436,7 +15467,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 58,
+        "line": 59,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15467,7 +15498,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 58,
+        "line": 59,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15498,7 +15529,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 58,
+        "line": 59,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15529,7 +15560,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 58,
+        "line": 59,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15560,7 +15591,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15591,7 +15622,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15622,7 +15653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15653,7 +15684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15684,7 +15715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15715,7 +15746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15746,7 +15777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15777,7 +15808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15808,7 +15839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15839,7 +15870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15870,7 +15901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15901,7 +15932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15932,7 +15963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15963,7 +15994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -15994,7 +16025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16025,7 +16056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16056,7 +16087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16087,7 +16118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16118,7 +16149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16149,7 +16180,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16180,7 +16211,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16211,7 +16242,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16242,7 +16273,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16273,7 +16304,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16304,7 +16335,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16335,7 +16366,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16366,7 +16397,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16397,7 +16428,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16428,7 +16459,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16459,7 +16490,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16490,7 +16521,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16521,7 +16552,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16552,7 +16583,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16583,7 +16614,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16614,7 +16645,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16645,7 +16676,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16676,7 +16707,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16707,7 +16738,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16738,7 +16769,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16769,7 +16800,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16800,7 +16831,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16831,7 +16862,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16862,7 +16893,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16893,7 +16924,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16924,7 +16955,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16955,7 +16986,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -16986,7 +17017,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17017,7 +17048,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17048,7 +17079,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17079,7 +17110,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17110,7 +17141,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17141,7 +17172,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17172,7 +17203,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17203,7 +17234,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17234,7 +17265,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17265,7 +17296,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17296,7 +17327,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17327,7 +17358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17358,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 117,
+        "line": 118,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 135,
+        "line": 136,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 135,
+        "line": 136,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 135,
+        "line": 136,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 140,
+        "line": 141,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 140,
+        "line": 141,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 140,
+        "line": 141,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 140,
+        "line": 141,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 140,
+        "line": 141,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 147,
+        "line": 148,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 168,
+        "line": 169,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 168,
+        "line": 169,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 168,
+        "line": 169,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 168,
+        "line": 169,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 168,
+        "line": 169,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 168,
+        "line": 169,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 168,
+        "line": 169,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 186,
+        "line": 187,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 222,
+        "line": 223,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 250,
+        "line": 251,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 250,
+        "line": 251,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 250,
+        "line": 251,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 250,
+        "line": 251,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 250,
+        "line": 251,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 250,
+        "line": 251,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 250,
+        "line": 251,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 250,
+        "line": 251,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 250,
+        "line": 251,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 266,
+        "line": 267,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 363,
+        "line": 364,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 363,
+        "line": 364,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 363,
+        "line": 364,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 363,
+        "line": 364,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 363,
+        "line": 364,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 363,
+        "line": 364,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 363,
+        "line": 364,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 372,
+        "line": 373,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 372,
+        "line": 373,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 372,
+        "line": 373,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 383,
+        "line": 384,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 396,
+        "line": 397,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 396,
+        "line": 397,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 404,
+        "line": 405,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 404,
+        "line": 405,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 404,
+        "line": 405,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 404,
+        "line": 405,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 404,
+        "line": 405,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 404,
+        "line": 405,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 404,
+        "line": 405,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 404,
+        "line": 405,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 415,
+        "line": 416,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 415,
+        "line": 416,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 415,
+        "line": 416,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 415,
+        "line": 416,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 429,
+        "line": 430,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 429,
+        "line": 430,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 433,
+        "line": 434,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 442,
+        "line": 443,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 442,
+        "line": 443,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 442,
+        "line": 443,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 442,
+        "line": 443,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 442,
+        "line": 443,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 449,
+        "line": 450,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 449,
+        "line": 450,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 449,
+        "line": 450,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 454,
+        "line": 455,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 454,
+        "line": 455,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 454,
+        "line": 455,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 472,
+        "line": 473,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 495,
+        "line": 496,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 495,
+        "line": 496,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 521,
+        "line": 522,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 521,
+        "line": 522,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 521,
+        "line": 522,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 521,
+        "line": 522,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 521,
+        "line": 522,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 521,
+        "line": 522,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 521,
+        "line": 522,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 521,
+        "line": 522,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 535,
+        "line": 536,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 535,
+        "line": 536,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 536,
+        "line": 537,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24116,7 +24147,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24147,7 +24178,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24178,7 +24209,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24209,7 +24240,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24240,7 +24271,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24271,7 +24302,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24290,7 +24321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24305,7 +24336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24324,7 +24355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24339,7 +24370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24358,7 +24389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24373,7 +24404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24392,7 +24423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24407,7 +24438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24426,7 +24457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24441,7 +24472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24460,7 +24491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24475,7 +24506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24494,7 +24525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24509,7 +24540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24528,7 +24559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24543,7 +24574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24562,7 +24593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24577,8 +24608,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_bind_aio_legacy_generation_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": "_run_aio_highres_stage",
+        "bound_name": "_run_aio_highres_stage",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 565,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_highres_stage",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
+        "kind": "static_from",
+        "line": 577,
+        "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
         "role": "compatibility_fallback",
@@ -24596,7 +24661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24611,7 +24676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24630,7 +24695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24645,7 +24710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24664,7 +24729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24679,7 +24744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24698,7 +24763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24713,7 +24778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24732,7 +24797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24747,7 +24812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24766,7 +24831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24781,7 +24846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24800,7 +24865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24815,7 +24880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24834,7 +24899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24849,7 +24914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24868,7 +24933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24883,7 +24948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24902,7 +24967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24917,7 +24982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24936,7 +25001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24951,7 +25016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24970,7 +25035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -24985,7 +25050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25004,7 +25069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25019,7 +25084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25038,7 +25103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25053,7 +25118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25072,7 +25137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25087,7 +25152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25106,7 +25171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25121,7 +25186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25140,7 +25205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25155,7 +25220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25174,7 +25239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25189,7 +25254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 598,
+        "line": 600,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25208,7 +25273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25223,7 +25288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25242,7 +25307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25257,7 +25322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25276,7 +25341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25291,7 +25356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25310,7 +25375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25325,7 +25390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25344,7 +25409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25359,7 +25424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25378,7 +25443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25393,7 +25458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25412,7 +25477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25427,7 +25492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25446,7 +25511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25461,7 +25526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25480,7 +25545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25495,7 +25560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25514,7 +25579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25529,7 +25594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25548,7 +25613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25563,7 +25628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25582,7 +25647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25597,7 +25662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25616,7 +25681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25631,7 +25696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25650,7 +25715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25665,7 +25730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25684,7 +25749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25699,7 +25764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25718,7 +25783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25733,7 +25798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25752,7 +25817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25767,7 +25832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25786,7 +25851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25801,7 +25866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25820,7 +25885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25835,7 +25900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25854,7 +25919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25869,7 +25934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25888,7 +25953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25903,7 +25968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25922,7 +25987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25937,7 +26002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25956,7 +26021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -25971,7 +26036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25990,7 +26055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26005,7 +26070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26024,7 +26089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26039,7 +26104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26058,7 +26123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26073,7 +26138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26092,7 +26157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26107,7 +26172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26126,7 +26191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26141,7 +26206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26160,7 +26225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26175,7 +26240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26194,7 +26259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26209,7 +26274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26228,7 +26293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26243,7 +26308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26262,7 +26327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26277,7 +26342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26296,7 +26361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26311,7 +26376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26330,7 +26395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26345,7 +26410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26364,7 +26429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26379,7 +26444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26398,7 +26463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26413,7 +26478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26432,7 +26497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26447,7 +26512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26466,7 +26531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26481,7 +26546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26500,7 +26565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26515,7 +26580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26534,7 +26599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26549,7 +26614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26568,7 +26633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26583,7 +26648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26602,7 +26667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26617,7 +26682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26636,7 +26701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26651,7 +26716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26670,7 +26735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26685,7 +26750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26704,7 +26769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26719,7 +26784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26738,7 +26803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26753,7 +26818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26772,7 +26837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26787,7 +26852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26806,7 +26871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26821,7 +26886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26840,7 +26905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26855,7 +26920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26874,7 +26939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26889,7 +26954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26908,7 +26973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26923,7 +26988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26942,7 +27007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26957,7 +27022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26976,7 +27041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -26991,7 +27056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27010,7 +27075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27025,7 +27090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27044,7 +27109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27059,7 +27124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27078,7 +27143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27093,7 +27158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27112,7 +27177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27127,7 +27192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27146,7 +27211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27161,7 +27226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27180,7 +27245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27195,7 +27260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27214,7 +27279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27229,7 +27294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27248,7 +27313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27263,7 +27328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27282,7 +27347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27297,7 +27362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27316,7 +27381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27331,7 +27396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27350,7 +27415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27365,7 +27430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27384,7 +27449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27399,7 +27464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27418,7 +27483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27433,7 +27498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27452,7 +27517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27467,7 +27532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27486,7 +27551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27501,7 +27566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27520,7 +27585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27535,7 +27600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27554,7 +27619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27569,7 +27634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27588,7 +27653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27603,7 +27668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27622,7 +27687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27637,7 +27702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27656,7 +27721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27671,7 +27736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 689,
+        "line": 691,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27690,7 +27755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27705,7 +27770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 689,
+        "line": 691,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27724,7 +27789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27739,7 +27804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 689,
+        "line": 691,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27758,7 +27823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27773,7 +27838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27792,7 +27857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27807,7 +27872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27826,7 +27891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27841,7 +27906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27860,7 +27925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27875,7 +27940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27894,7 +27959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27909,7 +27974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27928,7 +27993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27943,7 +28008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 701,
+        "line": 703,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -27962,7 +28027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -27977,7 +28042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -27996,7 +28061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28011,7 +28076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28030,7 +28095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28045,7 +28110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28064,7 +28129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28079,7 +28144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28098,7 +28163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28113,7 +28178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28132,7 +28197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28147,7 +28212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28166,7 +28231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28181,7 +28246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28200,7 +28265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28215,7 +28280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28234,7 +28299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28249,7 +28314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28268,7 +28333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28283,7 +28348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28302,7 +28367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28317,7 +28382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28336,7 +28401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28351,7 +28416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28370,7 +28435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28385,7 +28450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28404,7 +28469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28419,7 +28484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28438,7 +28503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28453,7 +28518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28472,7 +28537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28487,7 +28552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28506,7 +28571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28521,7 +28586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28540,7 +28605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28555,7 +28620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28574,7 +28639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28589,7 +28654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28608,7 +28673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28623,7 +28688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28642,7 +28707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28657,7 +28722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28676,7 +28741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28691,7 +28756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28710,7 +28775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28725,7 +28790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28744,7 +28809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28759,7 +28824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28778,7 +28843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28793,7 +28858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28812,7 +28877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28827,7 +28892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28846,7 +28911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28861,7 +28926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28880,7 +28945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28895,7 +28960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28914,7 +28979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28929,7 +28994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28948,7 +29013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28963,7 +29028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28982,7 +29047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -28997,7 +29062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29016,7 +29081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29031,7 +29096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29050,7 +29115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29065,7 +29130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29084,7 +29149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29099,7 +29164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29118,7 +29183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29133,7 +29198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29152,7 +29217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29167,7 +29232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29186,7 +29251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29201,7 +29266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29220,7 +29285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29235,7 +29300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29254,7 +29319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29269,7 +29334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29288,7 +29353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29303,7 +29368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29322,7 +29387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29337,7 +29402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29356,7 +29421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29371,7 +29436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29390,7 +29455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29405,7 +29470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29424,7 +29489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29439,7 +29504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29458,7 +29523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29473,7 +29538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29492,7 +29557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29507,7 +29572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29526,7 +29591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29541,7 +29606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29560,7 +29625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29575,7 +29640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29594,7 +29659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29609,7 +29674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29628,7 +29693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29643,7 +29708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29662,7 +29727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29677,7 +29742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29696,7 +29761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29711,7 +29776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29730,7 +29795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29745,7 +29810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29764,7 +29829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29779,7 +29844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29798,7 +29863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29813,7 +29878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29832,7 +29897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29847,7 +29912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29866,7 +29931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29881,7 +29946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29900,7 +29965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29915,7 +29980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29934,7 +29999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29949,7 +30014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29968,7 +30033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -29983,7 +30048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30002,7 +30067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30017,7 +30082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30036,7 +30101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30051,7 +30116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30070,7 +30135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30085,7 +30150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30104,7 +30169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30119,7 +30184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30138,7 +30203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30153,7 +30218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30172,7 +30237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30187,7 +30252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30206,7 +30271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30221,7 +30286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30240,7 +30305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30255,7 +30320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30274,7 +30339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30289,7 +30354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30308,7 +30373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30323,7 +30388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30342,7 +30407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30357,7 +30422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30376,7 +30441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30391,7 +30456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30410,7 +30475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30425,7 +30490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30444,7 +30509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30459,7 +30524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30478,7 +30543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30493,7 +30558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30512,7 +30577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30527,7 +30592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30546,7 +30611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30561,7 +30626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30580,7 +30645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30595,7 +30660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30614,7 +30679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30629,7 +30694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30648,7 +30713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30663,7 +30728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30682,7 +30747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30697,7 +30762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30716,7 +30781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30731,7 +30796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30750,7 +30815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30765,7 +30830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30784,7 +30849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30799,7 +30864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30818,7 +30883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30833,7 +30898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30852,7 +30917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30867,7 +30932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30886,7 +30951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30901,7 +30966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30920,7 +30985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30935,7 +31000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30954,7 +31019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -30969,7 +31034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30988,7 +31053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31003,7 +31068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31022,7 +31087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31037,7 +31102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31056,7 +31121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31071,7 +31136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31090,7 +31155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31105,7 +31170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31124,7 +31189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31139,7 +31204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31158,7 +31223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31173,7 +31238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31192,7 +31257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31207,7 +31272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31226,7 +31291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31241,7 +31306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31260,7 +31325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31275,7 +31340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31294,7 +31359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31309,7 +31374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31328,7 +31393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31343,7 +31408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31362,7 +31427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31377,7 +31442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31396,7 +31461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31411,7 +31476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31430,7 +31495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31445,7 +31510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31464,7 +31529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31479,7 +31544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31498,7 +31563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31513,7 +31578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31532,7 +31597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31547,7 +31612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31566,7 +31631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31581,7 +31646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31600,7 +31665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31615,7 +31680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31634,7 +31699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31649,7 +31714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31668,7 +31733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31683,7 +31748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31702,7 +31767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31717,7 +31782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31736,7 +31801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31751,7 +31816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31770,7 +31835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31785,7 +31850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31804,7 +31869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31819,7 +31884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31838,7 +31903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31853,7 +31918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31872,7 +31937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31887,7 +31952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31906,7 +31971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31921,7 +31986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31940,7 +32005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31955,7 +32020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -31974,7 +32039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -31989,7 +32054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32008,7 +32073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32023,7 +32088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32042,7 +32107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32057,7 +32122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32076,7 +32141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32091,7 +32156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32110,7 +32175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32125,7 +32190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32144,7 +32209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32159,7 +32224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32178,7 +32243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32193,7 +32258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32212,7 +32277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32227,7 +32292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32246,7 +32311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32261,7 +32326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32280,7 +32345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32295,7 +32360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32314,7 +32379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32329,7 +32394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32348,7 +32413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32363,7 +32428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32382,7 +32447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32397,7 +32462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32416,7 +32481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32431,7 +32496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32450,7 +32515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32465,7 +32530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32484,7 +32549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32499,7 +32564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32518,7 +32583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32533,7 +32598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32552,7 +32617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32567,7 +32632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32586,7 +32651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32601,7 +32666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32620,7 +32685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32635,7 +32700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32654,7 +32719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32669,7 +32734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32688,7 +32753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32703,7 +32768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32722,7 +32787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32737,7 +32802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32756,7 +32821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32771,7 +32836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32790,7 +32855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32805,7 +32870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32824,7 +32889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32839,7 +32904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32858,7 +32923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32873,7 +32938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32892,7 +32957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32907,7 +32972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1005,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32926,7 +32991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32941,7 +33006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1005,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32960,7 +33025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -32975,7 +33040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1005,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32994,7 +33059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33009,7 +33074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33028,7 +33093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33043,7 +33108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33062,7 +33127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33077,7 +33142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33096,7 +33161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33111,7 +33176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33130,7 +33195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33145,7 +33210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33164,7 +33229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33179,7 +33244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33198,7 +33263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33213,7 +33278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33232,7 +33297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33247,7 +33312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33266,7 +33331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33281,7 +33346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1049,
+        "line": 1051,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33300,7 +33365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33315,7 +33380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1049,
+        "line": 1051,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33334,7 +33399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33349,7 +33414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1055,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33368,7 +33433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33383,7 +33448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1055,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33402,7 +33467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33417,7 +33482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33436,7 +33501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33451,7 +33516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33470,7 +33535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33485,7 +33550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33504,7 +33569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33519,7 +33584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33538,7 +33603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33553,7 +33618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33572,7 +33637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33587,7 +33652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33606,7 +33671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33621,7 +33686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33640,7 +33705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33655,7 +33720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33674,7 +33739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33689,7 +33754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33708,7 +33773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33723,7 +33788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33742,7 +33807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33757,7 +33822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33776,7 +33841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33791,7 +33856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33810,7 +33875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33825,7 +33890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33844,7 +33909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33859,7 +33924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33878,7 +33943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33893,7 +33958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33912,7 +33977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33927,7 +33992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33946,7 +34011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33961,7 +34026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -33980,7 +34045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -33995,7 +34060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34014,7 +34079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34029,7 +34094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34048,7 +34113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34063,7 +34128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34082,7 +34147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34097,7 +34162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34116,7 +34181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34131,7 +34196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34150,7 +34215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34165,7 +34230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34184,7 +34249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34199,7 +34264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34218,7 +34283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34233,7 +34298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34252,7 +34317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34267,7 +34332,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34286,7 +34351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34301,7 +34366,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34320,7 +34385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34335,7 +34400,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1092,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34354,7 +34419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34369,7 +34434,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34388,7 +34453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34403,7 +34468,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34422,7 +34487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34437,7 +34502,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34456,7 +34521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34471,7 +34536,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1098,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34490,7 +34555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34505,7 +34570,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1098,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34524,7 +34589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34539,7 +34604,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34558,7 +34623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34573,7 +34638,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34592,7 +34657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34607,7 +34672,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34626,7 +34691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34641,7 +34706,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34660,7 +34725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34675,7 +34740,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34694,7 +34759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34709,7 +34774,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34728,7 +34793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34743,7 +34808,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34762,7 +34827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34777,7 +34842,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34796,7 +34861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34811,7 +34876,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34830,7 +34895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34845,7 +34910,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34864,7 +34929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34879,7 +34944,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34898,7 +34963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34913,7 +34978,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34932,7 +34997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34947,7 +35012,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34966,7 +35031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -34981,7 +35046,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35000,7 +35065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -35015,7 +35080,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35034,7 +35099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -35049,7 +35114,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35068,7 +35133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -35083,7 +35148,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35102,7 +35167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -35117,7 +35182,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35136,7 +35201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -35151,7 +35216,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35169,7 +35234,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1614
+            "line": 1616
           }
         ],
         "classification": "external",
@@ -35177,7 +35242,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1615,
+        "line": 1617,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35194,7 +35259,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1622
+            "line": 1624
           }
         ],
         "classification": "external",
@@ -35202,7 +35267,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1623,
+        "line": 1625,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35219,7 +35284,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1630
+            "line": 1632
           }
         ],
         "classification": "external",
@@ -35227,7 +35292,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1631,
+        "line": 1633,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -38211,13 +38276,13 @@
       },
       {
         "is_package": false,
-        "loc": 423,
+        "loc": 506,
         "module": "easyuse_anima.aio.legacy_generation",
-        "normalized_git_blob_sha1": "1776c827207c07e9b6ab3239b287abc4e96fcbe0",
+        "normalized_git_blob_sha1": "1fb24486e282b1cc2752365c643338871818dc6e",
         "path": "easyuse_anima/aio/legacy_generation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 3,
+          "function_count": 4,
           "global_count": 3
         }
       },
@@ -38859,13 +38924,13 @@
       },
       {
         "is_package": false,
-        "loc": 2319,
+        "loc": 2246,
         "module": "nodes",
-        "normalized_git_blob_sha1": "c0f1454971e614e93b1357313b29371794587041",
+        "normalized_git_blob_sha1": "f15e16b263a29953f593b289bf793871fb2c0c08",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 15,
+          "function_count": 14,
           "global_count": 26
         }
       },
@@ -40225,7 +40290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40234,7 +40299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40248,7 +40313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40257,7 +40322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40271,7 +40336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40280,7 +40345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40294,7 +40359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40303,7 +40368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40317,7 +40382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40326,7 +40391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40340,7 +40405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40349,7 +40414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40363,7 +40428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40372,7 +40437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40386,7 +40451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40395,7 +40460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 565,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40409,7 +40474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40418,7 +40483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40432,7 +40497,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
+        "kind": "static_from",
+        "line": 577,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40441,7 +40529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40455,7 +40543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40464,7 +40552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40478,7 +40566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40487,7 +40575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40501,7 +40589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40510,7 +40598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40524,7 +40612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40533,7 +40621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40547,7 +40635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40556,7 +40644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40570,7 +40658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40579,7 +40667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40593,7 +40681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40602,7 +40690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40616,7 +40704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40625,7 +40713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40639,7 +40727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40648,7 +40736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40662,7 +40750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40671,7 +40759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40685,7 +40773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40694,7 +40782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40708,7 +40796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40717,7 +40805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40731,7 +40819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40740,7 +40828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40754,7 +40842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40763,7 +40851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40777,7 +40865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40786,7 +40874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40800,7 +40888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40809,7 +40897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40823,7 +40911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40832,7 +40920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 598,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40846,7 +40934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40855,7 +40943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40869,7 +40957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40878,7 +40966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40892,7 +40980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40901,7 +40989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 601,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40915,7 +41003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40924,7 +41012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40938,7 +41026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40947,7 +41035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40961,7 +41049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40970,7 +41058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40984,7 +41072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -40993,7 +41081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41007,7 +41095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41016,7 +41104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41030,7 +41118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41039,7 +41127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41053,7 +41141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41062,7 +41150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41076,7 +41164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41085,7 +41173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41099,7 +41187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41108,7 +41196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41122,7 +41210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41131,7 +41219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41145,7 +41233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41154,7 +41242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41168,7 +41256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41177,7 +41265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41191,7 +41279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41200,7 +41288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41214,7 +41302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41223,7 +41311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41237,7 +41325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41246,7 +41334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41260,7 +41348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41269,7 +41357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41283,7 +41371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41292,7 +41380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41306,7 +41394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41315,7 +41403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41329,7 +41417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41338,7 +41426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41352,7 +41440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41361,7 +41449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41375,7 +41463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41384,7 +41472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41398,7 +41486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41407,7 +41495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41421,7 +41509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41430,7 +41518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41444,7 +41532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41453,7 +41541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41467,7 +41555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41476,7 +41564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41490,7 +41578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41499,7 +41587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41513,7 +41601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41522,7 +41610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41536,7 +41624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41545,7 +41633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41559,7 +41647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41568,7 +41656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41582,7 +41670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41591,7 +41679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41605,7 +41693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41614,7 +41702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41628,7 +41716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41637,7 +41725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41651,7 +41739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41660,7 +41748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 633,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41674,7 +41762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41683,7 +41771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41697,7 +41785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41706,7 +41794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41720,7 +41808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41729,7 +41817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41743,7 +41831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41752,7 +41840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41766,7 +41854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41775,7 +41863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41789,7 +41877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41798,7 +41886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41812,7 +41900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41821,7 +41909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41835,7 +41923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41844,7 +41932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41858,7 +41946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41867,7 +41955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41881,7 +41969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41890,7 +41978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 647,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41904,7 +41992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41913,7 +42001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41927,7 +42015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41936,7 +42024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41950,7 +42038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41959,7 +42047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41973,7 +42061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -41982,7 +42070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41996,7 +42084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42005,7 +42093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42019,7 +42107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42028,7 +42116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42042,7 +42130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42051,7 +42139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42065,7 +42153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42074,7 +42162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42088,7 +42176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42097,7 +42185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42111,7 +42199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42120,7 +42208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42134,7 +42222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42143,7 +42231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42157,7 +42245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42166,7 +42254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42180,7 +42268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42189,7 +42277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42203,7 +42291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42212,7 +42300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42226,7 +42314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42235,7 +42323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42249,7 +42337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42258,7 +42346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42272,7 +42360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42281,7 +42369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42295,7 +42383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42304,7 +42392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42318,7 +42406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42327,7 +42415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42341,7 +42429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42350,7 +42438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42364,7 +42452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42373,7 +42461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42387,7 +42475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42396,7 +42484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42410,7 +42498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42419,7 +42507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42433,7 +42521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42442,7 +42530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42456,7 +42544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42465,7 +42553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42479,7 +42567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42488,7 +42576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42502,7 +42590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42511,7 +42599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 689,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42525,7 +42613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42534,7 +42622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 689,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42548,7 +42636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42557,7 +42645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 689,
+        "line": 691,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42571,7 +42659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42580,7 +42668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42594,7 +42682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42603,7 +42691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42617,7 +42705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42626,7 +42714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42640,7 +42728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42649,7 +42737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42663,7 +42751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42672,7 +42760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 694,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42686,7 +42774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42695,7 +42783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 701,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42709,7 +42797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42718,7 +42806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42732,7 +42820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42741,7 +42829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42755,7 +42843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42764,7 +42852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42778,7 +42866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42787,7 +42875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42801,7 +42889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42810,7 +42898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42824,7 +42912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42833,7 +42921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42847,7 +42935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42856,7 +42944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42870,7 +42958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42879,7 +42967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42893,7 +42981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42902,7 +42990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42916,7 +43004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42925,7 +43013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42939,7 +43027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42948,7 +43036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42962,7 +43050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42971,7 +43059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42985,7 +43073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -42994,7 +43082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43008,7 +43096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43017,7 +43105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43031,7 +43119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43040,7 +43128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43054,7 +43142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43063,7 +43151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43077,7 +43165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43086,7 +43174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43100,7 +43188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43109,7 +43197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43123,7 +43211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43132,7 +43220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43146,7 +43234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43155,7 +43243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43169,7 +43257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43178,7 +43266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 722,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43192,7 +43280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43201,7 +43289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43215,7 +43303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43224,7 +43312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43238,7 +43326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43247,7 +43335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43261,7 +43349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43270,7 +43358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43284,7 +43372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43293,7 +43381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43307,7 +43395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43316,7 +43404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43330,7 +43418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43339,7 +43427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43353,7 +43441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43362,7 +43450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43376,7 +43464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43385,7 +43473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43399,7 +43487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43408,7 +43496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43422,7 +43510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43431,7 +43519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43445,7 +43533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43454,7 +43542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43468,7 +43556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43477,7 +43565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43491,7 +43579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43500,7 +43588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43514,7 +43602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43523,7 +43611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43537,7 +43625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43546,7 +43634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43560,7 +43648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43569,7 +43657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43583,7 +43671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43592,7 +43680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43606,7 +43694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43615,7 +43703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43629,7 +43717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43638,7 +43726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43652,7 +43740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43661,7 +43749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43675,7 +43763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43684,7 +43772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 740,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43698,7 +43786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43707,7 +43795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43721,7 +43809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43730,7 +43818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43744,7 +43832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43753,7 +43841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43767,7 +43855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43776,7 +43864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43790,7 +43878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43799,7 +43887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43813,7 +43901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43822,7 +43910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43836,7 +43924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43845,7 +43933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43859,7 +43947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43868,7 +43956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43882,7 +43970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43891,7 +43979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43905,7 +43993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43914,7 +44002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43928,7 +44016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43937,7 +44025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43951,7 +44039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43960,7 +44048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43974,7 +44062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -43983,7 +44071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43997,7 +44085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44006,7 +44094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 776,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44020,7 +44108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44029,7 +44117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44043,7 +44131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44052,7 +44140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44066,7 +44154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44075,7 +44163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44089,7 +44177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44098,7 +44186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44112,7 +44200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44121,7 +44209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44135,7 +44223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44144,7 +44232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44158,7 +44246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44167,7 +44255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44181,7 +44269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44190,7 +44278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44204,7 +44292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44213,7 +44301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 804,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44227,7 +44315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44236,7 +44324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44250,7 +44338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44259,7 +44347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44273,7 +44361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44282,7 +44370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44296,7 +44384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44305,7 +44393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44319,7 +44407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44328,7 +44416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44342,7 +44430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44351,7 +44439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44365,7 +44453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44374,7 +44462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44388,7 +44476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44397,7 +44485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44411,7 +44499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44420,7 +44508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44434,7 +44522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44443,7 +44531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44457,7 +44545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44466,7 +44554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44480,7 +44568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44489,7 +44577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44503,7 +44591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44512,7 +44600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44526,7 +44614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44535,7 +44623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44549,7 +44637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44558,7 +44646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44572,7 +44660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44581,7 +44669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44595,7 +44683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44604,7 +44692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44618,7 +44706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44627,7 +44715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44641,7 +44729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44650,7 +44738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44664,7 +44752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44673,7 +44761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44687,7 +44775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44696,7 +44784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44710,7 +44798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44719,7 +44807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44733,7 +44821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44742,7 +44830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44756,7 +44844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44765,7 +44853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44779,7 +44867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44788,7 +44876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 820,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44802,7 +44890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44811,7 +44899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44825,7 +44913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44834,7 +44922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44848,7 +44936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44857,7 +44945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44871,7 +44959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44880,7 +44968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 900,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44894,7 +44982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44903,7 +44991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44917,7 +45005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44926,7 +45014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44940,7 +45028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44949,7 +45037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44963,7 +45051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44972,7 +45060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44986,7 +45074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -44995,7 +45083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45009,7 +45097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45018,7 +45106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 911,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45032,7 +45120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45041,7 +45129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45055,7 +45143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45064,7 +45152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45078,7 +45166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45087,7 +45175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45101,7 +45189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45110,7 +45198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45124,7 +45212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45133,7 +45221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45147,7 +45235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45156,7 +45244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45170,7 +45258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45179,7 +45267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45193,7 +45281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45202,7 +45290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45216,7 +45304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45225,7 +45313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45239,7 +45327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45248,7 +45336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 926,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45262,7 +45350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45271,7 +45359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45285,7 +45373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45294,7 +45382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45308,7 +45396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45317,7 +45405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45331,7 +45419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45340,7 +45428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 937,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45354,7 +45442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45363,7 +45451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45377,7 +45465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45386,7 +45474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 950,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45400,7 +45488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45409,7 +45497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45423,7 +45511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45432,7 +45520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45446,7 +45534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45455,7 +45543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45469,7 +45557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45478,7 +45566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45492,7 +45580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45501,7 +45589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45515,7 +45603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45524,7 +45612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45538,7 +45626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45547,7 +45635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45561,7 +45649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45570,7 +45658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45584,7 +45672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45593,7 +45681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45607,7 +45695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45616,7 +45704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45630,7 +45718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45639,7 +45727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45653,7 +45741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45662,7 +45750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 969,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45676,7 +45764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45685,7 +45773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45699,7 +45787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45708,7 +45796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45722,7 +45810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45731,7 +45819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45745,7 +45833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45754,7 +45842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45768,7 +45856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45777,7 +45865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45791,7 +45879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45800,7 +45888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45814,7 +45902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45823,7 +45911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45837,7 +45925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45846,7 +45934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45860,7 +45948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45869,7 +45957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45883,7 +45971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45892,7 +45980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45906,7 +45994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45915,7 +46003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45929,7 +46017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45938,7 +46026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45952,7 +46040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45961,7 +46049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45975,7 +46063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -45984,7 +46072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45998,7 +46086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46007,7 +46095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46021,7 +46109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46030,7 +46118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 996,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46044,7 +46132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46053,7 +46141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46067,7 +46155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46076,7 +46164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46090,7 +46178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46099,7 +46187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46113,7 +46201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46122,7 +46210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46136,7 +46224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46145,7 +46233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46159,7 +46247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46168,7 +46256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46182,7 +46270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46191,7 +46279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46205,7 +46293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46214,7 +46302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46228,7 +46316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46237,7 +46325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46251,7 +46339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46260,7 +46348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46274,7 +46362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46283,7 +46371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1026,
+        "line": 1028,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46297,7 +46385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46306,7 +46394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1049,
+        "line": 1051,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46320,7 +46408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46329,7 +46417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1049,
+        "line": 1051,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46343,7 +46431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46352,7 +46440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1055,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46366,7 +46454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46375,7 +46463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1055,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46389,7 +46477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46398,7 +46486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46412,7 +46500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46421,7 +46509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46435,7 +46523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46444,7 +46532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46458,7 +46546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46467,7 +46555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46481,7 +46569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46490,7 +46578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46504,7 +46592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46513,7 +46601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46527,7 +46615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46536,7 +46624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46550,7 +46638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46559,7 +46647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46573,7 +46661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46582,7 +46670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46596,7 +46684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46605,7 +46693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46619,7 +46707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46628,7 +46716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46642,7 +46730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46651,7 +46739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46665,7 +46753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46674,7 +46762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46688,7 +46776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46697,7 +46785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46711,7 +46799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46720,7 +46808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46734,7 +46822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46743,7 +46831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46757,7 +46845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46766,7 +46854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46780,7 +46868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46789,7 +46877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46803,7 +46891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46812,7 +46900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46826,7 +46914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46835,7 +46923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46849,7 +46937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46858,7 +46946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46872,7 +46960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46881,7 +46969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46895,7 +46983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46904,7 +46992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46918,7 +47006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46927,7 +47015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46941,7 +47029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46950,7 +47038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46964,7 +47052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46973,7 +47061,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46987,7 +47075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -46996,7 +47084,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47010,7 +47098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47019,7 +47107,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47033,7 +47121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47042,7 +47130,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47056,7 +47144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47065,7 +47153,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47079,7 +47167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47088,7 +47176,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47102,7 +47190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47111,7 +47199,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47125,7 +47213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47134,7 +47222,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47148,7 +47236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47157,7 +47245,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47171,7 +47259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47180,7 +47268,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47194,7 +47282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47203,7 +47291,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47217,7 +47305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47226,7 +47314,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47240,7 +47328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47249,7 +47337,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47263,7 +47351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47272,7 +47360,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47286,7 +47374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47295,7 +47383,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47309,7 +47397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47318,7 +47406,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47332,7 +47420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47341,7 +47429,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47355,7 +47443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47364,7 +47452,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47378,7 +47466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47387,7 +47475,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47401,7 +47489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47410,7 +47498,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47424,7 +47512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47433,7 +47521,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47447,7 +47535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47456,7 +47544,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47470,7 +47558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47479,7 +47567,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47493,7 +47581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47502,7 +47590,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47516,7 +47604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47525,7 +47613,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47539,7 +47627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47548,7 +47636,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47562,7 +47650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 565,
             "kind": "try",
             "line": 10
           }
@@ -47571,7 +47659,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51398,14 +51486,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1614
+            "line": 1616
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1615,
+        "line": 1617,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51417,14 +51505,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1622
+            "line": 1624
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1623,
+        "line": 1625,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51436,14 +51524,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1630
+            "line": 1632
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1631,
+        "line": 1633,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52818,14 +52906,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1614
+            "line": 1616
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1615,
+        "line": 1617,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52837,14 +52925,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1622
+            "line": 1624
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1623,
+        "line": 1625,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52856,14 +52944,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1630
+            "line": 1632
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1631,
+        "line": 1633,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54324,7 +54412,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1119,
+        "line": 1121,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54333,7 +54421,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2215,
+        "line": 2142,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54342,7 +54430,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2218,
+        "line": 2145,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54351,7 +54439,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2221,
+        "line": 2148,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54360,7 +54448,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2224,
+        "line": 2151,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54369,7 +54457,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2227,
+        "line": 2154,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54378,7 +54466,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2230,
+        "line": 2157,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54387,7 +54475,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2233,
+        "line": 2160,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54396,7 +54484,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2236,
+        "line": 2163,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54405,7 +54493,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2239,
+        "line": 2166,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54414,7 +54502,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2242,
+        "line": 2169,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54423,7 +54511,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2245,
+        "line": 2172,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54432,7 +54520,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2248,
+        "line": 2175,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54441,7 +54529,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2251,
+        "line": 2178,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54450,7 +54538,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2254,
+        "line": 2181,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54459,7 +54547,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2257,
+        "line": 2184,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54468,7 +54556,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2260,
+        "line": 2187,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54477,7 +54565,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2264,
+        "line": 2191,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54486,7 +54574,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2267,
+        "line": 2194,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54495,7 +54583,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2271,
+        "line": 2198,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54504,7 +54592,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2274,
+        "line": 2201,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54513,7 +54601,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2278,
+        "line": 2205,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54522,7 +54610,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2281,
+        "line": 2208,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54531,7 +54619,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2284,
+        "line": 2211,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54540,7 +54628,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2287,
+        "line": 2214,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54549,7 +54637,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2290,
+        "line": 2217,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54558,7 +54646,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2293,
+        "line": 2220,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54567,7 +54655,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2300,
+        "line": 2227,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54576,7 +54664,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2306,
+        "line": 2233,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54585,7 +54673,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2311,
+        "line": 2238,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54594,7 +54682,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2315,
+        "line": 2242,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55108,13 +55196,13 @@
       },
       {
         "kind": "dict",
-        "line": 1181,
+        "line": 1183,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1170,
+        "line": 1172,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "43c30568731e95f2a5d4bf2603678d72ae3a3fda",
+    "base_commit": "8b3ba38988407225aa53b9cd23e151db3a7d6ac8",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -51,7 +51,8 @@
       "B-11c18",
       "B-11c19",
       "B-11c20",
-      "B-11c21"
+      "B-11c21",
+      "B-11c22"
     ]
   },
   "enums": {
@@ -86,11 +87,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 293,
+    "nodes_canonical_bindings": 294,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 15,
+    "root_residual_functions": 14,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -302,6 +303,9 @@
     "EASY_USE_ANIMA_INPUT_TYPE": [
       "easyuse_anima.nodes.aio_nodes"
     ],
+    "EasyUseAnimaImageScaleByMultiple": [
+      "easyuse_anima.aio.legacy_generation"
+    ],
     "EasyUseAnimaNAIARandomPrompt": [
       "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
@@ -455,6 +459,9 @@
       "easyuse_anima.aio.output"
     ],
     "_aio_save_filename_prefix": [
+      "easyuse_anima.aio.legacy_generation"
+    ],
+    "_aio_stage_sampler_settings": [
       "easyuse_anima.aio.legacy_generation"
     ],
     "_aio_usdu_auto_tile_dimension": [
@@ -2090,6 +2097,7 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_bind_aio_legacy_generation_runtime": "_bind_aio_legacy_generation_runtime",
+        "_run_aio_highres_stage": "_run_aio_highres_stage",
         "_run_aio_legacy_generation": "_run_aio_legacy_generation"
       },
       "classification": "transitional_private_seam",
@@ -2103,10 +2111,12 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -4168,7 +4178,6 @@
         "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed",
         "_run_aio_detailer_stage": "_run_aio_detailer_stage",
         "_run_aio_detailer_target": "_run_aio_detailer_target",
-        "_run_aio_highres_stage": "_run_aio_highres_stage",
         "_run_aio_resshift_upscale_stage": "_run_aio_resshift_upscale_stage",
         "_run_aio_upscale_stage": "_run_aio_upscale_stage",
         "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage"

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -32,6 +32,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             nodes._run_aio_legacy_generation,
             legacy_generation._run_aio_legacy_generation,
         )
+        self.assertIs(
+            nodes._run_aio_highres_stage,
+            legacy_generation._run_aio_highres_stage,
+        )
 
         with _loaded_package_entrypoint() as (package_entrypoint, package_nodes):
             canonical_module = sys.modules[
@@ -45,6 +49,302 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 package_nodes._run_aio_legacy_generation,
                 canonical_module._run_aio_legacy_generation,
             )
+            self.assertIs(
+                package_nodes._run_aio_highres_stage,
+                canonical_module._run_aio_highres_stage,
+            )
+
+    def test_highres_stage_disabled_short_circuits_after_as_bool(self):
+        trace: list[str] = []
+        image = object()
+        base_latent = object()
+
+        def resolve(name):
+            trace.append(f"resolve:{name}")
+            if name == "_as_bool":
+                return lambda value, default: trace.append("as_bool") or False
+            self.fail(f"disabled highres stage resolved unexpected helper: {name}")
+
+        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
+        try:
+            result = nodes._run_aio_highres_stage(
+                object(),
+                object(),
+                object(),
+                object(),
+                object(),
+                image,
+                base_latent,
+                "64",
+                "96",
+                {},
+                {"enabled": False},
+            )
+        finally:
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=lambda name: getattr(nodes, name)
+            )
+
+        self.assertIs(result[0], base_latent)
+        self.assertIs(result[1], image)
+        self.assertEqual(result[2:], (64, 96, {"enabled": False}))
+        self.assertEqual(trace, ["resolve:_as_bool", "as_bool"])
+
+    def test_highres_stage_preserves_dependency_and_metadata_order(self):
+        trace: list[str] = []
+        model = _Token("model")
+        stage_model = _Token("stage_model")
+        clip = _Token("clip")
+        vae = _Token("vae")
+        positive = _Token("positive")
+        negative = _Token("negative")
+        image = _Token("image")
+        scaled_image = _Token("scaled_image")
+        initial_latent = _Token("initial_latent")
+        sampled_latent = _Token("sampled_latent")
+        decoded_image = _Token("decoded_image")
+        resized_image = _Token("resized_image")
+        resized_latent = _Token("resized_latent")
+        stage_sampler = {"backend": "comfy_ksampler", "steps": 9}
+        test_case = self
+
+        def as_bool(value, default):
+            trace.append("call:_as_bool")
+            self.assertEqual((value, default), (True, False))
+            return True
+
+        def stage_sampler_settings(base, highres, **kwargs):
+            trace.append("call:_aio_stage_sampler_settings")
+            self.assertEqual(base, {"steps": 20})
+            self.assertEqual(highres["enabled"], True)
+            self.assertEqual(
+                kwargs,
+                {"scheduler_default": "simple", "inherit_backend": True},
+            )
+            return stage_sampler
+
+        class ScaleByMultiple:
+            def __init__(self):
+                trace.append("construct:scaler")
+
+            def upscale(self, *args):
+                trace.append("call:upscale")
+                test_case.assertEqual(args, (image, 1.5, "lanczos", "64", 2048))
+                return scaled_image, 128, 192, 1.5
+
+        def encode(source_vae, source_image):
+            trace.append(f"call:encode:{source_image.name}")
+            self.assertIs(source_vae, vae)
+            if source_image is scaled_image:
+                return initial_latent
+            self.assertIs(source_image, resized_image)
+            return resized_latent
+
+        def apply_patch(source_model, source_clip, conditioning, sampler):
+            trace.append("call:patch")
+            self.assertEqual(
+                (source_model, source_clip, conditioning, sampler),
+                (model, clip, positive, stage_sampler),
+            )
+            return stage_model
+
+        def sample(*args):
+            trace.append("call:sample")
+            self.assertEqual(
+                args,
+                (
+                    stage_model,
+                    clip,
+                    positive,
+                    negative,
+                    initial_latent,
+                    stage_sampler,
+                    {"scale": 3.0},
+                    True,
+                    "quality",
+                    "quality-neg",
+                ),
+            )
+            return sampled_latent
+
+        def cleanup(current_model, original_model):
+            trace.append("call:cleanup")
+            self.assertEqual((current_model, original_model), (stage_model, model))
+
+        def decode(source_vae, latent):
+            trace.append("call:decode")
+            self.assertEqual((source_vae, latent), (vae, sampled_latent))
+            return decoded_image
+
+        def resize(source_image, width, height, method):
+            trace.append("call:resize")
+            self.assertEqual(
+                (source_image, width, height, method),
+                (decoded_image, 128, 192, "lanczos"),
+            )
+            return resized_image, True
+
+        def json_safe(value):
+            trace.append("call:json_safe")
+            self.assertIs(value, stage_sampler)
+            return {"backend": value["backend"], "steps": value["steps"]}
+
+        helpers = {
+            "_as_bool": as_bool,
+            "_aio_stage_sampler_settings": stage_sampler_settings,
+            "EasyUseAnimaImageScaleByMultiple": ScaleByMultiple,
+            "_encode_image_with_comfy_vae": encode,
+            "_apply_aio_spectrum_model_patches_for_comfy_sampler": apply_patch,
+            "_sample_latent_with_aio_backend": sample,
+            "_cleanup_aio_ephemeral_model": cleanup,
+            "_decode_latent_with_comfy": decode,
+            "_resize_image_to_size_if_needed": resize,
+            "_prompt_data_json_safe": json_safe,
+        }
+
+        def resolve(name):
+            trace.append(f"resolve:{name}")
+            return helpers[name]
+
+        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
+        try:
+            result = nodes._run_aio_highres_stage(
+                model,
+                clip,
+                vae,
+                positive,
+                negative,
+                image,
+                object(),
+                64,
+                96,
+                {"steps": 20},
+                {
+                    "enabled": True,
+                    "scale_by": 1.5,
+                    "upscale_method": "lanczos",
+                    "multiple": "64",
+                    "max_long_edge": 2048,
+                },
+                {"scale": 3.0},
+                True,
+                "quality",
+                "quality-neg",
+            )
+        finally:
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=lambda name: getattr(nodes, name)
+            )
+
+        self.assertEqual(
+            result,
+            (
+                resized_latent,
+                resized_image,
+                128,
+                192,
+                {
+                    "enabled": True,
+                    "width": 128,
+                    "height": 192,
+                    "applied_scale": 1.5,
+                    "sampler": {"backend": "comfy_ksampler", "steps": 9},
+                },
+            ),
+        )
+        self.assertEqual(
+            trace,
+            [
+                "resolve:_as_bool",
+                "call:_as_bool",
+                "resolve:_aio_stage_sampler_settings",
+                "call:_aio_stage_sampler_settings",
+                "resolve:EasyUseAnimaImageScaleByMultiple",
+                "construct:scaler",
+                "call:upscale",
+                "resolve:_encode_image_with_comfy_vae",
+                "call:encode:scaled_image",
+                "resolve:_apply_aio_spectrum_model_patches_for_comfy_sampler",
+                "call:patch",
+                "resolve:_sample_latent_with_aio_backend",
+                "call:sample",
+                "resolve:_cleanup_aio_ephemeral_model",
+                "call:cleanup",
+                "resolve:_decode_latent_with_comfy",
+                "call:decode",
+                "resolve:_resize_image_to_size_if_needed",
+                "call:resize",
+                "resolve:_encode_image_with_comfy_vae",
+                "call:encode:resized_image",
+                "resolve:_prompt_data_json_safe",
+                "call:json_safe",
+            ],
+        )
+
+    def test_highres_stage_sampling_failure_cleans_original_model_boundary(self):
+        trace: list[str] = []
+        model = _Token("model")
+        stage_sampler = {"backend": "spectrum_mod_guidance_advanced"}
+
+        class ScaleByMultiple:
+            def upscale(self, *args):
+                trace.append("upscale")
+                return _Token("scaled"), 64, 96, 1.0
+
+        def sample(*args):
+            trace.append("sample")
+            raise RuntimeError("sample failed")
+
+        def cleanup(current_model, original_model):
+            trace.append("cleanup")
+            self.assertIs(current_model, model)
+            self.assertIs(original_model, model)
+
+        helpers = {
+            "_as_bool": lambda value, default: True,
+            "_aio_stage_sampler_settings": lambda *args, **kwargs: stage_sampler,
+            "EasyUseAnimaImageScaleByMultiple": ScaleByMultiple,
+            "_encode_image_with_comfy_vae": lambda vae, image: _Token("latent"),
+            "_sample_latent_with_aio_backend": sample,
+            "_cleanup_aio_ephemeral_model": cleanup,
+        }
+
+        def resolve(name):
+            trace.append(f"resolve:{name}")
+            if name not in helpers:
+                self.fail(f"sampling failure resolved unexpected helper: {name}")
+            return helpers[name]
+
+        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
+        try:
+            with self.assertRaisesRegex(RuntimeError, "sample failed"):
+                nodes._run_aio_highres_stage(
+                    model,
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    64,
+                    96,
+                    {},
+                    {"enabled": True},
+                )
+        finally:
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=lambda name: getattr(nodes, name)
+            )
+
+        self.assertEqual(
+            trace[-4:],
+            [
+                "resolve:_sample_latent_with_aio_backend",
+                "sample",
+                "resolve:_cleanup_aio_ephemeral_model",
+                "cleanup",
+            ],
+        )
 
     def test_root_generate_keeps_signature_and_forwards_without_adaptation(self):
         signature = inspect.signature(nodes.EasyUseAnimaAIOGenerator.generate)

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "c0f1454971e614e93b1357313b29371794587041")
-        # Issue #184 B-11c21 moves only the AiO postprocess stage to its
-        # canonical postprocess owner.
-        self.assertEqual(report["top_level"]["function_count"], 15)
+        self.assertEqual(report["git_blob_sha1"], "f15e16b263a29953f593b289bf793871fb2c0c08")
+        # Issue #184 B-11c22 moves only the AiO highres stage to its canonical
+        # legacy-generation owner.
+        self.assertEqual(report["top_level"]["function_count"], 14)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_319)
+        self.assertEqual(report["line_count"], 2_246)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "43c30568731e95f2a5d4bf2603678d72ae3a3fda"
+BASE_COMMIT = "8b3ba38988407225aa53b9cd23e151db3a7d6ac8"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1324,6 +1324,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c19",
                 "B-11c20",
                 "B-11c21",
+                "B-11c22",
             ],
         },
         "enums": {
@@ -1336,11 +1337,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 293,
+            "nodes_canonical_bindings": 294,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 15,
+            "root_residual_functions": 14,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c22 단일 Move로 root `_run_aio_highres_stage` body만 roadmap의 temporary current-order orchestration owner `easyuse_anima.aio.legacy_generation`으로 이동합니다.
- root `nodes.py`에는 relative/flat direct identity alias를 유지하고 기존 legacy-generation binder로 모든 dependency를 사용 시점에 resolve합니다.

## 작업 전 inventory

### Symbol / caller

- `_run_aio_highres_stage`
  - 현재 surface: `nodes.py` private root definition
  - production consumer: `easyuse_anima.aio.legacy_generation._run_aio_legacy_generation`이 `_runtime_helper("_run_aio_highres_stage")`로 root seam 조회
  - highres behavior tests와 legacy orchestration contract가 직접 소비
  - public mapping/export 없음
- canonical owner는 B-09b가 지정한 `easyuse_anima.aio.legacy_generation`입니다. `aio.sampling`은 backend dispatch/VAE/sampler helper owner이므로 stage orchestration 전체를 넣지 않습니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical stage identity를 유지합니다.
- 기존 `_bind_aio_legacy_generation_runtime`을 재사용합니다. 새 binder/global/module은 추가하지 않습니다.
- production caller는 같은 모듈 안에서도 기존 root string lookup을 유지해 monkeypatch seam을 보존합니다.
- cache/provider import/mutable module state는 추가하지 않습니다.

### Call-time dependency inventory

- `_as_bool`
- `_aio_stage_sampler_settings`
- `EasyUseAnimaImageScaleByMultiple`
- `_encode_image_with_comfy_vae`
- `_apply_aio_spectrum_model_patches_for_comfy_sampler`
- `_sample_latent_with_aio_backend`
- `_cleanup_aio_ephemeral_model`
- `_decode_latent_with_comfy`
- `_resize_image_to_size_if_needed`
- `_prompt_data_json_safe`

### 보존할 평가·정리 순서

- disabled: `_as_bool` 뒤 base latent/image/width/height와 `{"enabled": False}`를 그대로 반환하며 다른 dependency를 resolve하지 않습니다.
- enabled: stage sampler → scaler class instantiate/upscale → VAE encode → comfy backend일 때만 model patch 순서를 유지합니다.
- `try/finally`는 `_sample_latent_with_aio_backend` 호출만 감싸며 cleanup은 항상 `_cleanup_aio_ephemeral_model(stage_model, model)`로 수행합니다. patch-before-try 경계는 바꾸지 않습니다.
- 이후 decode → resize → resized일 때만 re-encode 순서를 유지합니다.
- `mod_guidance_settings or {}`, sampler 인자 순서, quality 인자, metadata 순서 `enabled,width,height,applied_scale,sampler`, 마지막 `_prompt_data_json_safe(stage_sampler)` 평가를 보존합니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/legacy_generation.py`, `nodes.py`
- contract/analyzer: `tests/test_aio_legacy_generation.py`, `tests/test_python_compatibility_surface.py`, `tests/test_nodes_module_analyzer.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 예상 계약 delta

- base: `dev` / `8b3ba38988407225aa53b9cd23e151db3a7d6ac8`
- canonical bindings: `293 → 294`
- root/top-level residual functions: `15 → 14`
- runtime binders: `30` 유지
- runtime resolver names: `278 → 280` (`_aio_stage_sampler_settings`, `EasyUseAnimaImageScaleByMultiple` 신규)
- shipped/runtime-closure modules: `83` 유지
- globals 26, preamble imports 6: 변화 없음
- `nodes.py` line count: `2319 → 2246`

## 금지 경계

- `sampling.py` helper/backend 책임, stage protocol, #169 Behavior/Contract 동시 변경 금지
- legacy caller의 root string lookup을 sibling direct call로 바꾸지 않음
- dependency 정적 import, settings/schema/default/workflow 변경 금지
- patch-before-try 또는 sampling-only try/finally 경계 변경 금지
- sampler/quality 인자, cleanup, resize/re-encode, metadata 순서 변경 금지
- 다른 stage/residual, 새 binder/module 결합 금지

## 검증

- exact head: `25ae61b0c7763ad0b6f49cb4016f56eeada09658`
- focused: 전용 legacy/highres 계약, package alias, analyzer/backend fixture, compatibility surface, import boundary 39 tests 통과
- canonical Ruff: `easyuse_anima/aio/legacy_generation.py` clean
- 독립 read-only diff review: 차단점 없음
- `tools/check_project.ps1 -Profile full`: Python 921 tests, frontend 114 files, Pyright baseline, import boundary, diff check 통과
- Ruff 전체 113건은 G-01 report-only 기존 기준이며 이 Move의 차단점이 아님
- Live ComfyUI/browser smoke: private orchestration Move 범위에서는 수행하지 않음

## 상태

- Ready
- focused, 독립 diff review, exact-head full 검증 완료
